### PR TITLE
Fix the output paths for the cleaning tool

### DIFF
--- a/src/services/building/targets.js
+++ b/src/services/building/targets.js
@@ -122,6 +122,11 @@ class Targets {
         } else {
           newTarget.output = this._normalizeBrowserTargetOutput(newTarget.output);
         }
+        /**
+         * Keep the original output settings without the placeholders so internal services or
+         * plugins can use them.
+         */
+        newTarget.originalOutput = extend(true, {}, newTarget.output);
         // Replace placeholders on the output settings
         newTarget.output = this._replaceTargetOutputPlaceholders(newTarget);
 

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -379,6 +379,8 @@
  * The target entry files for each specific build type.
  * @property {ProjectConfigurationNodeTargetTemplateOutput} output
  * The target file paths for each specific build type.
+ * @property {ProjectConfigurationNodeTargetTemplateOutput} originalOutput
+ * The target file paths for each specific build type, without the placeholders replaced.
  * @property {boolean} runOnDevelopment
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
@@ -479,6 +481,8 @@
  * The target entry files for each specific build type.
  * @property {ProjectConfigurationBrowserTargetTemplateOutput} output
  * The target output settings for each specific build type.
+ * @property {ProjectConfigurationBrowserTargetTemplateOutput} originalOutput
+ * The target output settings for each specific build type, without the placeholders replaced.
  * @property {ProjectConfigurationBrowserTargetTemplateSourceMapSettings} sourceMap
  * The target source map settings for each specific environment build.
  * @property {ProjectConfigurationBrowserTargetTemplateHTMLSettings} html

--- a/tests/services/building/targets.test.js
+++ b/tests/services/building/targets.test.js
@@ -109,6 +109,7 @@ describe('services/building:targets', () => {
         name: 'targetOne',
         entry: {},
         output: {},
+        originalOutput: {},
         paths: {
           source: `${source}/targetOne`,
           build,
@@ -132,6 +133,7 @@ describe('services/building:targets', () => {
         name: 'targetTwo',
         entry: {},
         output: {},
+        originalOutput: {},
         type: 'node',
         paths: {
           source: `${source}/target-two`,
@@ -156,6 +158,7 @@ describe('services/building:targets', () => {
         name: 'targetThree',
         entry: {},
         output: {},
+        originalOutput: {},
         type: 'node',
         paths: {
           source: `${source}/target-three`,
@@ -177,6 +180,7 @@ describe('services/building:targets', () => {
         name: 'targetFour',
         entry: {},
         output: {},
+        originalOutput: {},
         paths: { source, build },
         folders: { source, build },
         is: {
@@ -349,6 +353,10 @@ describe('services/building:targets', () => {
           development: 'targetOne.js',
           production: 'targetOne.js',
         },
+        originalOutput: {
+          development: '[target-name].js',
+          production: '[target-name].js',
+        },
         paths: { source, build },
         folders: { source, build },
         hasFolder: false,
@@ -375,6 +383,20 @@ describe('services/building:targets', () => {
             js: 'statics/js/targetTwo.js',
             fonts: 'statics/fonts/[name].[ext]',
             css: 'statics/styles/targetTwo.css',
+            images: 'statics/images/[name].[ext]',
+          },
+        },
+        originalOutput: {
+          development: {
+            js: 'statics/js/[target-name].js',
+            fonts: 'statics/fonts/[name].[ext]',
+            css: 'statics/styles/[target-name].css',
+            images: 'statics/images/[name].[ext]',
+          },
+          production: {
+            js: 'statics/js/[target-name].js',
+            fonts: 'statics/fonts/[name].[ext]',
+            css: 'statics/styles/[target-name].css',
             images: 'statics/images/[name].[ext]',
           },
         },
@@ -408,6 +430,20 @@ describe('services/building:targets', () => {
             js: 'statics/js/targetThree.production.js',
           },
         },
+        originalOutput: {
+          development: {
+            fonts: 'statics/fonts/[name].[ext]',
+            css: 'statics/styles/[target-name].css',
+            images: 'statics/images/[name].[ext]',
+            js: 'statics/js/[target-name].development.js',
+          },
+          production: {
+            fonts: 'statics/fonts/[name].[ext]',
+            css: 'statics/styles/[target-name].css',
+            images: 'statics/images/[name].[ext]',
+            js: 'statics/js/[target-name].production.js',
+          },
+        },
         type: 'browser',
         paths: { source, build },
         folders: { source, build },
@@ -439,6 +475,20 @@ describe('services/building:targets', () => {
             images: `statics/images/[name].${hash}.[ext]`,
           },
         },
+        originalOutput: {
+          development: {
+            js: 'statics/js/[target-name].js',
+            fonts: 'statics/fonts/[name].[ext]',
+            css: 'statics/styles/[target-name].css',
+            images: 'statics/images/[name].[ext]',
+          },
+          production: {
+            js: 'statics/js/[target-name].[hash].js',
+            fonts: 'statics/fonts/[name].[hash].[ext]',
+            css: 'statics/styles/[target-name].[hash].css',
+            images: 'statics/images/[name].[hash].[ext]',
+          },
+        },
         paths: { source, build },
         folders: { source, build },
         hasFolder: false,
@@ -456,6 +506,10 @@ describe('services/building:targets', () => {
           production: 'index.js',
         },
         output: {
+          development: 'start.js',
+          production: 'start.js',
+        },
+        originalOutput: {
           development: 'start.js',
           production: 'start.js',
         },
@@ -479,6 +533,10 @@ describe('services/building:targets', () => {
           development: 'start.development.js',
           production: 'targetSix.js',
         },
+        originalOutput: {
+          development: 'start.development.js',
+          production: '[target-name].js',
+        },
         paths: { source, build },
         folders: { source, build },
         hasFolder: false,
@@ -496,6 +554,10 @@ describe('services/building:targets', () => {
           production: 'index.js',
         },
         output: {
+          development: null,
+          production: 'start.production.js',
+        },
+        originalOutput: {
           development: null,
           production: 'start.production.js',
         },
@@ -590,6 +652,7 @@ describe('services/building:targets', () => {
         defaultTargetName: 'browser',
         entry: {},
         output: {},
+        originalOutput: {},
         html: {
           template: 'index.html',
           filename: 'index.html',
@@ -608,6 +671,7 @@ describe('services/building:targets', () => {
         defaultTargetName: 'browser',
         entry: {},
         output: {},
+        originalOutput: {},
         html: {
           template: 'done.html',
           filename: 'index.html',
@@ -626,6 +690,7 @@ describe('services/building:targets', () => {
         defaultTargetName: 'browser',
         entry: {},
         output: {},
+        originalOutput: {},
         html: {
           template: 'index.html',
           filename: 'done.html',
@@ -644,6 +709,7 @@ describe('services/building:targets', () => {
         defaultTargetName: 'browser',
         entry: {},
         output: {},
+        originalOutput: {},
         html: {
           template: 'template.html',
           filename: 'filename.html',
@@ -717,6 +783,7 @@ describe('services/building:targets', () => {
       name: targetName,
       entry: {},
       output: {},
+      originalOutput: {},
       paths: {
         source: `${source}/targetOne`,
         build,


### PR DESCRIPTION
### What does this PR do?

On #1, I forgot about the `buildCleaner` service, and it was still using the old settings with some assumed names for the bundled file.

In order to fix it I needed to keep somewhere the original `output` setting, before replacing the placeholders, so the service could change those placeholders into `*` and make patterns for files to remove. Since this can be useful for other plugins/services, I decided to keep those original settings on a `originalOutput` setting.

I also deprecated `BuildCleaner#getTargetNamesVariation` and I'll remove it on the next major release.

### How should it be tested manually?

1. Try to clean a target, it should work fine now.
2. `npm/yarn test`.

### To-DOs

I need to add as global schema for the tests because each case has its own mocked data, and if I changed the project configuration schema, it doesn't affect other services tests.