### PR TITLE
Update the Node targets output settings to support static files.

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -146,13 +146,29 @@ This object is the one that tells projext which is the main file (executable) of
 >
 > ```js
 > {
->   default: '[target-name].js',
->   development: null,
+>   default: {
+>     js: '[target-name].js',
+>     fonts: 'statics/fonts/[name].[hash].[ext]',
+>     css: 'statics/styles/[target-name].[hash].css',
+>     images: 'statics/images/[name].[hash].[ext]',
+>   },
+>   development: {
+>     fonts: 'statics/fonts/[name].[ext]',
+>     css: 'statics/styles/[target-name].css',
+>     images: 'statics/images/[name].[ext]',
+>   },
 >   production: null,
 > }
 > ```
 
-This tells projext where to place the generated bundle on each environment. You can also use the `[target-name]` placeholder on the paths.
+This tells projext where to place the files generated while bundling on each environment, depending on the file type.
+
+You can use the following placeholders:
+
+- `[target-name]`: The name of the target.
+- `[hash]`: A random hash generated for cache busting.
+- `[name]`: The file original name (Not available for `css` and `js`).
+- `[ext]`: The file original extension (Not available for `css` and `js`).
 
 #### `runOnDevelopment`
 > Default value: `false`

--- a/src/services/building/buildCleaner.js
+++ b/src/services/building/buildCleaner.js
@@ -126,23 +126,6 @@ class BuildCleaner {
     });
   }
   /**
-   * Get all the names variations for a target bundled file based on the target name.
-   * @param {string} name The target name.
-   * @return {Array} A list of all the possible names of files related to that target.
-   * @deprecated
-   */
-  getTargetNamesVariation(name) {
-    const names = [
-      name,
-      `${name}.js`,
-      `${name}.js.map`,
-      `${name}.*.js`,
-      `${name}.*.js.map`,
-    ];
-    names.push(...names.map((file) => `${file}.gz`));
-    return names;
-  }
-  /**
    * Replace a dictionary of given placeholders on a string.
    * @param {string} string       The target string where the placeholders will be replaced.
    * @param {Object} placeholders A dictionary of placeholders and their values.

--- a/src/services/building/targets.js
+++ b/src/services/building/targets.js
@@ -117,11 +117,7 @@ class Targets {
         // Check if there are missing entries and fill them with the default value.
         newTarget.entry = this._normalizeTargetEntry(newTarget.entry);
         // Check if there are missing entries and merge them with the default value.
-        if (newTarget.is.node) {
-          newTarget.output = this._normalizeNodeTargetOutput(newTarget.output);
-        } else {
-          newTarget.output = this._normalizeBrowserTargetOutput(newTarget.output);
-        }
+        newTarget.output = this._normalizeTargetOutput(newTarget.output);
         /**
          * Keep the original output settings without the placeholders so internal services or
          * plugins can use them.
@@ -284,13 +280,13 @@ class Targets {
    * Checks if there are missing output settings that need to be merged with the ones on the
    * default fallback, and in case there are, a new set of output settings will be generated and
    * returned.
-   * @param {ProjectConfigurationBrowserTargetTemplateOutput} currentOutput
+   * @param {ProjectConfigurationTargetTemplateOutput} currentOutput
    * The output settings defined on the target after merging it with its type template.
-   * @return {ProjectConfigurationBrowserTargetTemplateOutput}
+   * @return {ProjectConfigurationTargetTemplateOutput}
    * @ignore
    * @protected
    */
-  _normalizeBrowserTargetOutput(currentOutput) {
+  _normalizeTargetOutput(currentOutput) {
     const newOutput = Object.assign({}, currentOutput);
     const { default: defaultOutput } = newOutput;
     delete newOutput.default;
@@ -311,18 +307,6 @@ class Targets {
     }
 
     return newOutput;
-  }
-  /**
-   * Checks if there are missing output paths that need to be replaced with the  default fallback,
-   * and in case there are, a new set of settings will be generated and returned.
-   * @param {ProjectConfigurationNodeTargetTemplateOutput} currentOutput
-   * The output settings defined on the target after merging it with its type template.
-   * @return {ProjectConfigurationNodeTargetTemplateOutput}
-   * @ignore
-   * @protected
-   */
-  _normalizeNodeTargetOutput(currentOutput) {
-    return this._normalizeSettingsWithDefault(currentOutput);
   }
   /**
    * Replace the common placeholders from a target output paths.

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -42,8 +42,17 @@ class ProjectConfiguration extends ConfigurationFile {
             production: null,
           },
           output: {
-            default: '[target-name].js',
-            development: null,
+            default: {
+              js: '[target-name].js',
+              fonts: 'statics/fonts/[name].[hash].[ext]',
+              css: 'statics/styles/[target-name].[hash].css',
+              images: 'statics/images/[name].[hash].[ext]',
+            },
+            development: {
+              fonts: 'statics/fonts/[name].[ext]',
+              css: 'statics/styles/[target-name].css',
+              images: 'statics/images/[name].[ext]',
+            },
             production: null,
           },
           runOnDevelopment: false,

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -110,28 +110,80 @@
  */
 
 /**
+ * @typedef {Object} ProjectConfigurationTargetTemplateOutputPaths
+ * @property {string} [js]
+ * The path to generated Javascript files on the distribution directory.
+ *
+ * The available placeholders are:
+ * - `[target-name]`: The name of the target.
+ * - `[hash]`: A random hash generated for cache busting.
+ *
+ * The default value is:
+ * - For `node` targets, on all build types: `[taret-name].js`.
+ * - For `browser` targets:
+ *   - `development`: `'statics/js/[target-name].js'`.
+ *   - `production`: `'statics/js/[target-name].[hash].js'`.
+ * @property {string} [css]
+ * The path to generated stylesheets on the distribution directory.
+ *
+ * The available placeholders are:
+ * - `[target-name]`: The name of the target.
+ * - `[hash]`: A random hash generated for cache busting.
+ *
+ * The default value is, for both `node` and `browser` targets:
+ * - `development`: `'statics/styles/[target-name].css'`.
+ * - `production`: `'statics/styles/[target-name].[hash].css'`.
+ * @property {string} [fonts]
+ * The path to font files once they are copied to the distribution directory.
+ *
+ * The available placeholders are:
+ * - `[target-name]`: The name of the target.
+ * - `[name]`: The file original name.
+ * - `[ext]`: The file original extension.
+ * - `[hash]`: A random hash generated for cache busting.
+ *
+ * The default value is, for both `node` and `browser` targets:
+ * - `development`: `'statics/fonts/[name][ext]'`.
+ * - `production`: `'statics/fonts/[name].[hash].[ext]'`.
+ * @property {string} [fonts]
+ * The path to image files once they are copied to the distribution directory.
+ *
+ * The available placeholders are:
+ * - `[target-name]`: The name of the target.
+ * - `[name]`: The file original name.
+ * - `[ext]`: The file original extension.
+ * - `[hash]`: A random hash generated for cache busting.
+ *
+ * The default value is, for both `node` and `browser` targets:
+ * - `development`: `'statics/images/[name][ext]'`.
+ * - `production`: `'statics/images/[name].[hash].[ext]'`.
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationTargetTemplateOutput
+ * @property {ProjectConfigurationTargetTemplateOutputPaths} [default]
+ * The target output settings for all types of build that don't have specified settings.
+ * @property {ProjectConfigurationTargetTemplateOutputPaths} [development]
+ * The target output settings on a development build. If `null`, it will fallback to the ones
+ * specified on `default`.
+ * @property {ProjectConfigurationTargetTemplateOutputPaths} [production]
+ * The target output settings on a production build. If `null`, it will fallback to the ones
+ * specified on `default`.
+ */
+
+/**
  * @typedef {Object} ProjectConfigurationTargetTemplateLibraryOptions
  * @property {string} [libraryTarget='commonjs2']
- * How the library will be exposed: `commonjs2`, `umd` and `window`
+ * How the library will be exposed: `commonjs2`, `umd` and `window`.
+ * The default value is:
+ * - `browser`: `'umd'`.
+ * - `node`: `'commonjs2'`.
  */
 
 /**
  * ================================================================================================
  * Project configuration > Targets templates > Sub properties > Node
  * ================================================================================================
- */
-
-/**
- * @typedef {Object} ProjectConfigurationNodeTargetTemplateOutput
- * @property {string} [default='[target-name].js']
- * The target output file path for all types of build that are not specified. The only available
- * placeholder is `[target-name]`.
- * @property {string} [development=null]
- * The target output file path on a development build. If `null`, it will fallback to the
- * `default`. The only available placeholder is `[target-name]`.
- * @property {string} [production=null]
- * The target output file path on a production build. If `null`, it will fallback to the `default`.
- * The only available placeholder is `[target-name]`.
  */
 
 /**
@@ -153,72 +205,6 @@
  * ================================================================================================
  * Project configuration > Targets templates > Sub properties > Browser
  * ================================================================================================
- */
-
-/**
- * @typedef {Object} ProjectConfigurationBrowserTargetTemplateDevelopmentOutputPaths
- * @property {string} [js='statics/js/[target-name].js']
- * The path to generated Javascript files on the distribution directory. The available placeholders
- * are:
- * - `[target-name]`: The name of the target.
- * - `[hash]`: A random hash generated for cache busting.
- * @property {string} [fonts='statics/fonts/[name].[ext]']
- * The path to font files once they are copied to the distribution directory. The available
- * placeholders are:
- * - `[target-name]`: The name of the target.
- * - `[name]`: The file original name.
- * - `[ext]`: The file original extension.
- * - `[hash]`: A random hash generated for cache busting.
- * @property {string} [css='statics/styles/[name].css']
- * The path to generated stylesheets on the distribution directory. The available placeholders are:
- * - `[target-name]`: The name of the target.
- * - `[hash]`: A random hash generated for cache busting.
- * @property {string} [fonts='statics/images/[name].[ext]']
- * The path to image files once they are copied to the distribution directory. The available
- * placeholders are:
- * - `[target-name]`: The name of the target.
- * - `[name]`: The file original name.
- * - `[ext]`: The file original extension.
- * - `[hash]`: A random hash generated for cache busting.
- */
-
-/**
- * @typedef {Object} ProjectConfigurationBrowserTargetTemplateProductionOutputPaths
- * @property {string} [js='statics/js/[target-name].[hash].js']
- * The path to generated Javascript files on the distribution directory. The available placeholders
- * are:
- * - `[target-name]`: The name of the target.
- * - `[hash]`: A random hash generated for cache busting.
- * @property {string} [fonts='statics/fonts/[name].[hash].[ext]']
- * The path to font files once they are copied to the distribution directory. The available
- * placeholders are:
- * - `[target-name]`: The name of the target.
- * - `[name]`: The file original name.
- * - `[ext]`: The file original extension.
- * - `[hash]`: A random hash generated for cache busting.
- * @property {string} [css='statics/styles/[target-name].[hash].css']
- * The path to generated stylesheets on the distribution directory. The available placeholders are:
- * - `[target-name]`: The name of the target.
- * - `[hash]`: A random hash generated for cache busting.
- * @property {string} [fonts='statics/images/[name].[hash].[ext]']
- * The path to image files once they are copied to the distribution directory. The available
- * placeholders are:
- * - `[target-name]`: The name of the target.
- * - `[name]`: The file original name.
- * - `[ext]`: The file original extension.
- * - `[hash]`: A random hash generated for cache busting.
- */
-
-/**
- * @typedef {Object} ProjectConfigurationBrowserTargetTemplateOutput
- * @property {ProjectConfigurationBrowserTargetTemplateProductionOutputPaths} [default]
- * The target output settings for all types of build that don't have specified settings.
- * @property {ProjectConfigurationBrowserTargetTemplateDevelopmentOutputPaths} [development]
- * The target output settings on a development build. If `null`, it will fallback to the ones
- * specified on `default`.
- * @property {ProjectConfigurationBrowserTargetTemplateProductionOutputPaths} [production=null]
- * The target output settings on a production build. If `null`, it will fallback to the ones
- * specified on `default`.
  */
 
 /**
@@ -331,8 +317,8 @@
  * folder name than the target's name.
  * @property {ProjectConfigurationTargetTemplateEntry} [entry]
  * The target entry files for each specific build type.
- * @property {ProjectConfigurationNodeTargetTemplateOutput} [output]
- * The target file paths for each specific build type.
+ * @property {ProjectConfigurationTargetTemplateOutput} [output]
+ * The target output settings for each specific build type.
  * @property {boolean} [runOnDevelopment=false]
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
@@ -377,10 +363,10 @@
  * folder name than the target's name.
  * @property {ProjectConfigurationTargetTemplateEntry} entry
  * The target entry files for each specific build type.
- * @property {ProjectConfigurationNodeTargetTemplateOutput} output
- * The target file paths for each specific build type.
- * @property {ProjectConfigurationNodeTargetTemplateOutput} originalOutput
- * The target file paths for each specific build type, without the placeholders replaced.
+ * @property {ProjectConfigurationTargetTemplateOutput} output
+ * The target output settings for each specific build type.
+ * @property {ProjectConfigurationTargetTemplateOutput} originalOutput
+ * The target output settings for each specific build type, without the placeholders replaced.
  * @property {boolean} runOnDevelopment
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
@@ -430,7 +416,7 @@
  * folder name than the target's name.
  * @property {ProjectConfigurationTargetTemplateEntry} [entry]
  * The target entry files for each specific build type.
- * @property {ProjectConfigurationBrowserTargetTemplateOutput} [output]
+ * @property {ProjectConfigurationTargetTemplateOutput} [output]
  * The target output settings for each specific build type.
  * @property {ProjectConfigurationBrowserTargetTemplateSourceMapSettings} [sourceMap]
  * The target source map settings for each specific environment build.
@@ -479,9 +465,9 @@
  * folder name than the target's name.
  * @property {ProjectConfigurationTargetTemplateEntry} entry
  * The target entry files for each specific build type.
- * @property {ProjectConfigurationBrowserTargetTemplateOutput} output
+ * @property {ProjectConfigurationTargetTemplateOutput} output
  * The target output settings for each specific build type.
- * @property {ProjectConfigurationBrowserTargetTemplateOutput} originalOutput
+ * @property {ProjectConfigurationTargetTemplateOutput} originalOutput
  * The target output settings for each specific build type, without the placeholders replaced.
  * @property {ProjectConfigurationBrowserTargetTemplateSourceMapSettings} sourceMap
  * The target source map settings for each specific environment build.

--- a/tests/services/building/buildCleaner.test.js
+++ b/tests/services/building/buildCleaner.test.js
@@ -155,8 +155,18 @@ describe('services/building:buildCleaner', () => {
       bundle: true,
       name: 'someTarget',
       originalOutput: {
-        development: '[target-name].js',
-        production: '[target-name].js',
+        development: {
+          js: '[target-name].js',
+          fonts: 'statics/fonts/[name].[ext]',
+          css: 'statics/styles/[target-name].css',
+          images: 'statics/images/[name].[ext]',
+        },
+        production: {
+          js: '[target-name].[hash].js',
+          fonts: 'statics/fonts/[name].[hash].[ext]',
+          css: 'statics/styles/[target-name].[hash].css',
+          images: 'statics/images/[name].[hash].[ext]',
+        },
       },
       paths: {
         source: 'some-target-source',
@@ -179,7 +189,21 @@ describe('services/building:buildCleaner', () => {
     let sut = null;
     const expectedItems = [
       `${target.name}.js`,
-      `${target.name}.js`,
+      `statics/styles/${target.name}.css`,
+      'statics/fonts/*.*',
+      'statics/images/*.*',
+      `${target.name}.*.js`,
+      `statics/styles/${target.name}.*.css`,
+      'statics/fonts/*.*.*',
+      'statics/images/*.*.*',
+      `${target.name}.js.gz`,
+      `statics/styles/${target.name}.css.gz`,
+      'statics/fonts/*.*.gz',
+      'statics/images/*.*.gz',
+      `${target.name}.*.js.gz`,
+      `statics/styles/${target.name}.*.css.gz`,
+      'statics/fonts/*.*.*.gz',
+      'statics/images/*.*.*.gz',
     ];
     // When
     sut = new BuildCleaner(appLogger, cleaner, pathUtils, projectConfiguration);
@@ -205,6 +229,7 @@ describe('services/building:buildCleaner', () => {
     const target = {
       is: {
         node: false,
+        browser: true,
       },
       name: 'someTarget',
       originalOutput: {
@@ -232,16 +257,9 @@ describe('services/building:buildCleaner', () => {
       success: jest.fn(),
     };
     const cleaner = jest.fn(() => Promise.resolve());
-    const output = {
-      js: 'statics/js',
-      fonts: 'statics/fonts',
-      css: 'statics/css',
-      images: 'statics/img',
-    };
     const projectConfiguration = {
       paths: {
         build: buildPath,
-        output,
       },
     };
     const pathUtils = {
@@ -297,8 +315,18 @@ describe('services/building:buildCleaner', () => {
       bundle: true,
       name: 'someTarget',
       originalOutput: {
-        development: '[target-name].js',
-        production: '[target-name].js',
+        development: {
+          js: '[target-name].js',
+          fonts: 'statics/fonts/[name].[ext]',
+          css: 'statics/styles/[target-name].css',
+          images: 'statics/images/[name].[ext]',
+        },
+        production: {
+          js: '[target-name].[hash].js',
+          fonts: 'statics/fonts/[name].[hash].[ext]',
+          css: 'statics/styles/[target-name].[hash].css',
+          images: 'statics/images/[name].[hash].[ext]',
+        },
       },
       paths: {
         source: 'some-target-source',
@@ -322,7 +350,21 @@ describe('services/building:buildCleaner', () => {
     let sut = null;
     const expectedItems = [
       `${target.name}.js`,
-      `${target.name}.js`,
+      `statics/styles/${target.name}.css`,
+      'statics/fonts/*.*',
+      'statics/images/*.*',
+      `${target.name}.*.js`,
+      `statics/styles/${target.name}.*.css`,
+      'statics/fonts/*.*.*',
+      'statics/images/*.*.*',
+      `${target.name}.js.gz`,
+      `statics/styles/${target.name}.css.gz`,
+      'statics/fonts/*.*.gz',
+      'statics/images/*.*.gz',
+      `${target.name}.*.js.gz`,
+      `statics/styles/${target.name}.*.css.gz`,
+      'statics/fonts/*.*.*.gz',
+      'statics/images/*.*.*.gz',
     ];
     // When
     sut = new BuildCleaner(appLogger, cleaner, pathUtils, projectConfiguration);

--- a/tests/services/building/buildCleaner.test.js
+++ b/tests/services/building/buildCleaner.test.js
@@ -382,35 +382,6 @@ describe('services/building:buildCleaner', () => {
       expect(errorResult).toBe(error);
     });
   });
-  /**
-   * @deprecated
-   */
-  it('should generate variations of a target bundled name', () => {
-    // Given
-    const appLogger = 'appLogger';
-    const cleaner = 'cleaner';
-    const pathUtils = 'pathUtils';
-    const projectConfiguration = 'projectConfiguration';
-    const name = 'some-target';
-    let sut = null;
-    let result = null;
-    // When
-    sut = new BuildCleaner(appLogger, cleaner, pathUtils, projectConfiguration);
-    result = sut.getTargetNamesVariation(name);
-    // Then
-    expect(result).toEqual([
-      `${name}`,
-      `${name}.js`,
-      `${name}.js.map`,
-      `${name}.*.js`,
-      `${name}.*.js.map`,
-      `${name}.gz`,
-      `${name}.js.gz`,
-      `${name}.js.map.gz`,
-      `${name}.*.js.gz`,
-      `${name}.*.js.map.gz`,
-    ]);
-  });
 
   it('should include a provider for the DIC', () => {
     // Given

--- a/tests/services/building/targets.test.js
+++ b/tests/services/building/targets.test.js
@@ -590,37 +590,154 @@ describe('services/building:targets', () => {
     };
     const source = 'source-path';
     const build = 'build-path';
-    const projectConfiguration = {
-      targets: {
-        targetOne: {
+    const targetsData = [
+      {
+        config: {
+          name: 'targetOne',
           type: 'browser',
         },
-        targetTwo: {
+        expected: {
+          name: 'targetOne',
+          defaultTargetName: 'browser',
+          entry: {},
+          output: {},
+          originalOutput: {},
+          html: {
+            template: 'index.html',
+            filename: 'index.html',
+          },
+          type: 'browser',
+          paths: { source, build },
+          folders: { source, build },
+          hasFolder: false,
+          is: {
+            node: false,
+            browser: true,
+          },
+        },
+      },
+      {
+        config: {
+          name: 'targetTwo',
           type: 'browser',
           html: {
             template: 'done.html',
           },
         },
-        targetThree: {
+        expected: {
+          name: 'targetTwo',
+          defaultTargetName: 'browser',
+          entry: {},
+          output: {},
+          originalOutput: {},
+          html: {
+            template: 'done.html',
+            filename: 'index.html',
+          },
+          type: 'browser',
+          paths: { source, build },
+          folders: { source, build },
+          hasFolder: false,
+          is: {
+            node: false,
+            browser: true,
+          },
+        },
+      },
+      {
+        config: {
+          name: 'targetThree',
           type: 'browser',
           html: {
             filename: 'done.html',
           },
         },
-        targetFour: {
+        expected: {
+          name: 'targetThree',
+          defaultTargetName: 'browser',
+          entry: {},
+          output: {},
+          originalOutput: {},
+          html: {
+            template: 'index.html',
+            filename: 'done.html',
+          },
+          type: 'browser',
+          paths: { source, build },
+          folders: { source, build },
+          hasFolder: false,
+          is: {
+            node: false,
+            browser: true,
+          },
+        },
+      },
+      {
+        config: {
+          name: 'targetFour',
           type: 'browser',
           html: {
             template: 'template.html',
             filename: 'filename.html',
           },
         },
-        targetFive: {
+        expected: {
+          name: 'targetFour',
+          defaultTargetName: 'browser',
+          entry: {},
+          output: {},
+          originalOutput: {},
+          html: {
+            template: 'template.html',
+            filename: 'filename.html',
+          },
+          type: 'browser',
+          paths: { source, build },
+          folders: { source, build },
+          hasFolder: false,
+          is: {
+            node: false,
+            browser: true,
+          },
+        },
+      },
+      {
+        config: {
+          name: 'targetFive',
           type: 'browser',
           html: {
             default: null,
           },
         },
+        expected: {
+          name: 'targetFive',
+          defaultTargetName: 'browser',
+          entry: {},
+          output: {},
+          originalOutput: {},
+          html: {
+            template: null,
+            filename: null,
+          },
+          type: 'browser',
+          paths: { source, build },
+          folders: { source, build },
+          hasFolder: false,
+          is: {
+            node: false,
+            browser: true,
+          },
+        },
       },
+    ];
+    const targetsDict = {};
+    const expectedTargets = {};
+    targetsData.forEach((data) => {
+      targetsDict[data.config.name] = data.config;
+      expectedTargets[data.expected.name] = data.expected;
+    });
+    const projectConfiguration = {
+      targets: targetsDict,
       targetsTemplates: {
         browser: {
           defaultTargetName: 'browser',
@@ -638,104 +755,6 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
-    const expectedTargets = {
-      targetOne: {
-        name: 'targetOne',
-        defaultTargetName: 'browser',
-        entry: {},
-        output: {},
-        originalOutput: {},
-        html: {
-          template: 'index.html',
-          filename: 'index.html',
-        },
-        type: 'browser',
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: false,
-          browser: true,
-        },
-      },
-      targetTwo: {
-        name: 'targetTwo',
-        defaultTargetName: 'browser',
-        entry: {},
-        output: {},
-        originalOutput: {},
-        html: {
-          template: 'done.html',
-          filename: 'index.html',
-        },
-        type: 'browser',
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: false,
-          browser: true,
-        },
-      },
-      targetThree: {
-        name: 'targetThree',
-        defaultTargetName: 'browser',
-        entry: {},
-        output: {},
-        originalOutput: {},
-        html: {
-          template: 'index.html',
-          filename: 'done.html',
-        },
-        type: 'browser',
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: false,
-          browser: true,
-        },
-      },
-      targetFour: {
-        name: 'targetFour',
-        defaultTargetName: 'browser',
-        entry: {},
-        output: {},
-        originalOutput: {},
-        html: {
-          template: 'template.html',
-          filename: 'filename.html',
-        },
-        type: 'browser',
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: false,
-          browser: true,
-        },
-      },
-      targetFive: {
-        name: 'targetFive',
-        defaultTargetName: 'browser',
-        entry: {},
-        output: {},
-        originalOutput: {},
-        html: {
-          template: null,
-          filename: null,
-        },
-        type: 'browser',
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: false,
-          browser: true,
-        },
-      },
-    };
-    const expectedTargetsNames = Object.keys(expectedTargets);
     let sut = null;
     let result = null;
     // When
@@ -749,11 +768,11 @@ describe('services/building:targets', () => {
     result = sut.getTargets();
     // Then
     expect(result).toEqual(expectedTargets);
-    expect(events.reduce).toHaveBeenCalledTimes(expectedTargetsNames.length);
-    expectedTargetsNames.forEach((targetName) => {
+    expect(events.reduce).toHaveBeenCalledTimes(targetsData.length);
+    targetsData.forEach((info) => {
       expect(events.reduce).toHaveBeenCalledWith(
         'target-load',
-        expectedTargets[targetName]
+        info.expected
       );
     });
   });

--- a/tests/services/building/targets.test.js
+++ b/tests/services/building/targets.test.js
@@ -225,92 +225,310 @@ describe('services/building:targets', () => {
     };
     const source = 'source-path';
     const build = 'build-path';
-    const projectConfiguration = {
-      targets: {
-        targetOne: {},
-        targetTwo: {
-          type: 'browser',
+    const targetsData = [
+      /**
+       * Target without any customization.
+       */
+      {
+        config: {
+          name: 'targetOne',
+        },
+        expected: {
+          name: 'targetOne',
+          type: 'node',
           entry: {
-            default: 'index.jsx',
+            development: 'index.js',
+            production: 'index.js',
           },
           output: {
-            default: {
-              js: 'statics/js/[target-name].js',
+            development: {
+              js: 'targetOne.js',
+              fonts: 'statics/fonts/[name].[ext]',
+              css: 'statics/styles/targetOne.css',
+              images: 'statics/images/[name].[ext]',
+            },
+            production: {
+              js: 'targetOne.js',
+              fonts: `statics/fonts/[name].${hash}.[ext]`,
+              css: `statics/styles/targetOne.${hash}.css`,
+              images: `statics/images/[name].${hash}.[ext]`,
+            },
+          },
+          originalOutput: {
+            development: {
+              js: '[target-name].js',
               fonts: 'statics/fonts/[name].[ext]',
               css: 'statics/styles/[target-name].css',
               images: 'statics/images/[name].[ext]',
+            },
+            production: {
+              js: '[target-name].js',
+              fonts: 'statics/fonts/[name].[hash].[ext]',
+              css: 'statics/styles/[target-name].[hash].css',
+              images: 'statics/images/[name].[hash].[ext]',
+            },
+          },
+          paths: { source, build },
+          folders: { source, build },
+          hasFolder: false,
+          is: {
+            node: true,
+            browser: false,
+          },
+        },
+      },
+      /**
+       * Target with customized default and development entries
+       */
+      {
+        config: {
+          name: 'targetTwo',
+          entry: {
+            default: 'library.js',
+            development: 'playground.js',
+          },
+        },
+        expected: {
+          name: 'targetTwo',
+          type: 'node',
+          entry: {
+            development: 'playground.js',
+            production: 'library.js',
+          },
+          output: {
+            development: {
+              js: 'targetTwo.js',
+              fonts: 'statics/fonts/[name].[ext]',
+              css: 'statics/styles/targetTwo.css',
+              images: 'statics/images/[name].[ext]',
+            },
+            production: {
+              js: 'targetTwo.js',
+              fonts: `statics/fonts/[name].${hash}.[ext]`,
+              css: `statics/styles/targetTwo.${hash}.css`,
+              images: `statics/images/[name].${hash}.[ext]`,
+            },
+          },
+          originalOutput: {
+            development: {
+              js: '[target-name].js',
+              fonts: 'statics/fonts/[name].[ext]',
+              css: 'statics/styles/[target-name].css',
+              images: 'statics/images/[name].[ext]',
+            },
+            production: {
+              js: '[target-name].js',
+              fonts: 'statics/fonts/[name].[hash].[ext]',
+              css: 'statics/styles/[target-name].[hash].css',
+              images: 'statics/images/[name].[hash].[ext]',
+            },
+          },
+          paths: { source, build },
+          folders: { source, build },
+          hasFolder: false,
+          is: {
+            node: true,
+            browser: false,
+          },
+        },
+      },
+      /**
+       * Target without a default entry and with a customized development entry.
+       */
+      {
+        config: {
+          name: 'targetThree',
+          entry: {
+            default: null,
+            development: 'playground.js',
+          },
+        },
+        expected: {
+          name: 'targetThree',
+          type: 'node',
+          entry: {
+            development: 'playground.js',
+            production: null,
+          },
+          output: {
+            development: {
+              js: 'targetThree.js',
+              fonts: 'statics/fonts/[name].[ext]',
+              css: 'statics/styles/targetThree.css',
+              images: 'statics/images/[name].[ext]',
+            },
+            production: {
+              js: 'targetThree.js',
+              fonts: `statics/fonts/[name].${hash}.[ext]`,
+              css: `statics/styles/targetThree.${hash}.css`,
+              images: `statics/images/[name].${hash}.[ext]`,
+            },
+          },
+          originalOutput: {
+            development: {
+              js: '[target-name].js',
+              fonts: 'statics/fonts/[name].[ext]',
+              css: 'statics/styles/[target-name].css',
+              images: 'statics/images/[name].[ext]',
+            },
+            production: {
+              js: '[target-name].js',
+              fonts: 'statics/fonts/[name].[hash].[ext]',
+              css: 'statics/styles/[target-name].[hash].css',
+              images: 'statics/images/[name].[hash].[ext]',
+            },
+          },
+          paths: { source, build },
+          folders: { source, build },
+          hasFolder: false,
+          is: {
+            node: true,
+            browser: false,
+          },
+        },
+      },
+      /**
+       * Target with a customized default output and no other out settings.
+       */
+      {
+        config: {
+          name: 'targetFour',
+          output: {
+            default: {
+              js: 'app/[target-name].js',
+              fonts: 'app/fonts/[name].[ext]',
+              css: 'app/styles/[target-name].css',
+              images: 'app/images/[name].[ext]',
             },
             development: null,
             production: null,
           },
         },
-        targetThree: {
-          type: 'browser',
+        expected: {
+          name: 'targetFour',
+          type: 'node',
           entry: {
-            default: 'index.jsx',
-            development: 'playground.js',
+            development: 'index.js',
+            production: 'index.js',
           },
           output: {
+            development: {
+              js: 'app/targetFour.js',
+              fonts: 'app/fonts/[name].[ext]',
+              css: 'app/styles/targetFour.css',
+              images: 'app/images/[name].[ext]',
+            },
+            production: {
+              js: 'app/targetFour.js',
+              fonts: 'app/fonts/[name].[ext]',
+              css: 'app/styles/targetFour.css',
+              images: 'app/images/[name].[ext]',
+            },
+          },
+          originalOutput: {
+            development: {
+              js: 'app/[target-name].js',
+              fonts: 'app/fonts/[name].[ext]',
+              css: 'app/styles/[target-name].css',
+              images: 'app/images/[name].[ext]',
+            },
+            production: {
+              js: 'app/[target-name].js',
+              fonts: 'app/fonts/[name].[ext]',
+              css: 'app/styles/[target-name].css',
+              images: 'app/images/[name].[ext]',
+            },
+          },
+          paths: { source, build },
+          folders: { source, build },
+          hasFolder: false,
+          is: {
+            node: true,
+            browser: false,
+          },
+        },
+      },
+      /**
+       * Target with merged output settings.
+       */
+      {
+        config: {
+          name: 'targetFive',
+          output: {
             default: {
-              fonts: 'statics/fonts/[name].[ext]',
-              css: 'statics/styles/[target-name].css',
-              images: 'statics/images/[name].[ext]',
+              fonts: 'app/fonts/[name].[ext]',
+              css: 'app/styles/[target-name].css',
+              images: 'app/images/[name].[ext]',
             },
             development: {
               fonts: null,
               css: null,
               images: null,
-              js: 'statics/js/[target-name].development.js',
+              js: 'app/[target-name].development.js',
             },
             production: {
               fonts: null,
               css: null,
               images: null,
-              js: 'statics/js/[target-name].production.js',
+              js: 'app/[target-name].production.js',
             },
           },
         },
-        targetFour: {
-          type: 'browser',
+        expected: {
+          name: 'targetFive',
+          type: 'node',
           entry: {
-            default: null,
             development: 'index.js',
+            production: 'index.js',
           },
-        },
-        targetFive: {
           output: {
-            default: 'start.js',
+            development: {
+              js: 'app/targetFive.development.js',
+              fonts: 'app/fonts/[name].[ext]',
+              css: 'app/styles/targetFive.css',
+              images: 'app/images/[name].[ext]',
+            },
+            production: {
+              js: 'app/targetFive.production.js',
+              fonts: 'app/fonts/[name].[ext]',
+              css: 'app/styles/targetFive.css',
+              images: 'app/images/[name].[ext]',
+            },
           },
-        },
-        targetSix: {
-          output: {
-            development: 'start.development.js',
+          originalOutput: {
+            development: {
+              js: 'app/[target-name].development.js',
+              fonts: 'app/fonts/[name].[ext]',
+              css: 'app/styles/[target-name].css',
+              images: 'app/images/[name].[ext]',
+            },
+            production: {
+              js: 'app/[target-name].production.js',
+              fonts: 'app/fonts/[name].[ext]',
+              css: 'app/styles/[target-name].css',
+              images: 'app/images/[name].[ext]',
+            },
           },
-        },
-        targetSeven: {
-          output: {
-            default: null,
-            production: 'start.production.js',
+          paths: { source, build },
+          folders: { source, build },
+          hasFolder: false,
+          is: {
+            node: true,
+            browser: false,
           },
         },
       },
+    ];
+    const targetsDict = {};
+    const expectedTargets = {};
+    targetsData.forEach((data) => {
+      targetsDict[data.config.name] = data.config;
+      expectedTargets[data.expected.name] = data.expected;
+    });
+    const projectConfiguration = {
+      targets: targetsDict,
       targetsTemplates: {
         node: {
-          defaultTargetName: 'node',
-          hasFolder: false,
-          entry: {
-            default: 'index.js',
-            development: null,
-            production: null,
-          },
-          output: {
-            default: '[target-name].js',
-            development: null,
-            production: null,
-          },
-        },
-        browser: {
-          defaultTargetName: 'browser',
           hasFolder: false,
           entry: {
             default: 'index.js',
@@ -319,13 +537,12 @@ describe('services/building:targets', () => {
           },
           output: {
             default: {
-              js: 'statics/js/[target-name].[hash].js',
+              js: '[target-name].js',
               fonts: 'statics/fonts/[name].[hash].[ext]',
               css: 'statics/styles/[target-name].[hash].css',
               images: 'statics/images/[name].[hash].[ext]',
             },
             development: {
-              js: 'statics/js/[target-name].js',
               fonts: 'statics/fonts/[name].[ext]',
               css: 'statics/styles/[target-name].css',
               images: 'statics/images/[name].[ext]',
@@ -340,237 +557,6 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
-    const expectedTargets = {
-      targetOne: {
-        name: 'targetOne',
-        defaultTargetName: 'node',
-        type: 'node',
-        entry: {
-          development: 'index.js',
-          production: 'index.js',
-        },
-        output: {
-          development: 'targetOne.js',
-          production: 'targetOne.js',
-        },
-        originalOutput: {
-          development: '[target-name].js',
-          production: '[target-name].js',
-        },
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: true,
-          browser: false,
-        },
-      },
-      targetTwo: {
-        name: 'targetTwo',
-        defaultTargetName: 'browser',
-        entry: {
-          development: 'index.jsx',
-          production: 'index.jsx',
-        },
-        output: {
-          development: {
-            js: 'statics/js/targetTwo.js',
-            fonts: 'statics/fonts/[name].[ext]',
-            css: 'statics/styles/targetTwo.css',
-            images: 'statics/images/[name].[ext]',
-          },
-          production: {
-            js: 'statics/js/targetTwo.js',
-            fonts: 'statics/fonts/[name].[ext]',
-            css: 'statics/styles/targetTwo.css',
-            images: 'statics/images/[name].[ext]',
-          },
-        },
-        originalOutput: {
-          development: {
-            js: 'statics/js/[target-name].js',
-            fonts: 'statics/fonts/[name].[ext]',
-            css: 'statics/styles/[target-name].css',
-            images: 'statics/images/[name].[ext]',
-          },
-          production: {
-            js: 'statics/js/[target-name].js',
-            fonts: 'statics/fonts/[name].[ext]',
-            css: 'statics/styles/[target-name].css',
-            images: 'statics/images/[name].[ext]',
-          },
-        },
-        type: 'browser',
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: false,
-          browser: true,
-        },
-      },
-      targetThree: {
-        name: 'targetThree',
-        defaultTargetName: 'browser',
-        entry: {
-          development: 'playground.js',
-          production: 'index.jsx',
-        },
-        output: {
-          development: {
-            fonts: 'statics/fonts/[name].[ext]',
-            css: 'statics/styles/targetThree.css',
-            images: 'statics/images/[name].[ext]',
-            js: 'statics/js/targetThree.development.js',
-          },
-          production: {
-            fonts: 'statics/fonts/[name].[ext]',
-            css: 'statics/styles/targetThree.css',
-            images: 'statics/images/[name].[ext]',
-            js: 'statics/js/targetThree.production.js',
-          },
-        },
-        originalOutput: {
-          development: {
-            fonts: 'statics/fonts/[name].[ext]',
-            css: 'statics/styles/[target-name].css',
-            images: 'statics/images/[name].[ext]',
-            js: 'statics/js/[target-name].development.js',
-          },
-          production: {
-            fonts: 'statics/fonts/[name].[ext]',
-            css: 'statics/styles/[target-name].css',
-            images: 'statics/images/[name].[ext]',
-            js: 'statics/js/[target-name].production.js',
-          },
-        },
-        type: 'browser',
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: false,
-          browser: true,
-        },
-      },
-      targetFour: {
-        name: 'targetFour',
-        defaultTargetName: 'browser',
-        type: 'browser',
-        entry: {
-          development: 'index.js',
-          production: null,
-        },
-        output: {
-          development: {
-            js: 'statics/js/targetFour.js',
-            fonts: 'statics/fonts/[name].[ext]',
-            css: 'statics/styles/targetFour.css',
-            images: 'statics/images/[name].[ext]',
-          },
-          production: {
-            js: `statics/js/targetFour.${hash}.js`,
-            fonts: `statics/fonts/[name].${hash}.[ext]`,
-            css: `statics/styles/targetFour.${hash}.css`,
-            images: `statics/images/[name].${hash}.[ext]`,
-          },
-        },
-        originalOutput: {
-          development: {
-            js: 'statics/js/[target-name].js',
-            fonts: 'statics/fonts/[name].[ext]',
-            css: 'statics/styles/[target-name].css',
-            images: 'statics/images/[name].[ext]',
-          },
-          production: {
-            js: 'statics/js/[target-name].[hash].js',
-            fonts: 'statics/fonts/[name].[hash].[ext]',
-            css: 'statics/styles/[target-name].[hash].css',
-            images: 'statics/images/[name].[hash].[ext]',
-          },
-        },
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: false,
-          browser: true,
-        },
-      },
-      targetFive: {
-        name: 'targetFive',
-        defaultTargetName: 'node',
-        type: 'node',
-        entry: {
-          development: 'index.js',
-          production: 'index.js',
-        },
-        output: {
-          development: 'start.js',
-          production: 'start.js',
-        },
-        originalOutput: {
-          development: 'start.js',
-          production: 'start.js',
-        },
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: true,
-          browser: false,
-        },
-      },
-      targetSix: {
-        name: 'targetSix',
-        defaultTargetName: 'node',
-        type: 'node',
-        entry: {
-          development: 'index.js',
-          production: 'index.js',
-        },
-        output: {
-          development: 'start.development.js',
-          production: 'targetSix.js',
-        },
-        originalOutput: {
-          development: 'start.development.js',
-          production: '[target-name].js',
-        },
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: true,
-          browser: false,
-        },
-      },
-      targetSeven: {
-        name: 'targetSeven',
-        defaultTargetName: 'node',
-        type: 'node',
-        entry: {
-          development: 'index.js',
-          production: 'index.js',
-        },
-        output: {
-          development: null,
-          production: 'start.production.js',
-        },
-        originalOutput: {
-          development: null,
-          production: 'start.production.js',
-        },
-        paths: { source, build },
-        folders: { source, build },
-        hasFolder: false,
-        is: {
-          node: true,
-          browser: false,
-        },
-      },
-    };
-    const expectedTargetsNames = Object.keys(expectedTargets);
     let sut = null;
     let result = null;
     // When
@@ -584,11 +570,11 @@ describe('services/building:targets', () => {
     result = sut.getTargets();
     // Then
     expect(result).toEqual(expectedTargets);
-    expect(events.reduce).toHaveBeenCalledTimes(expectedTargetsNames.length);
-    expectedTargetsNames.forEach((targetName) => {
+    expect(events.reduce).toHaveBeenCalledTimes(targetsData.length);
+    targetsData.forEach((info) => {
       expect(events.reduce).toHaveBeenCalledWith(
         'target-load',
-        expectedTargets[targetName]
+        info.expected
       );
     });
   });
@@ -626,6 +612,12 @@ describe('services/building:targets', () => {
           html: {
             template: 'template.html',
             filename: 'filename.html',
+          },
+        },
+        targetFive: {
+          type: 'browser',
+          html: {
+            default: null,
           },
         },
       },
@@ -713,6 +705,25 @@ describe('services/building:targets', () => {
         html: {
           template: 'template.html',
           filename: 'filename.html',
+        },
+        type: 'browser',
+        paths: { source, build },
+        folders: { source, build },
+        hasFolder: false,
+        is: {
+          node: false,
+          browser: true,
+        },
+      },
+      targetFive: {
+        name: 'targetFive',
+        defaultTargetName: 'browser',
+        entry: {},
+        output: {},
+        originalOutput: {},
+        html: {
+          template: null,
+          filename: null,
         },
         type: 'browser',
         paths: { source, build },


### PR DESCRIPTION
### What does this PR do?

When I refactored the targets output settings on #1 , I didn't have in mind Server Side Rendering (SSR), a case in which you can require a browser target from a Node target.

The issue is that if that would happen, the build engines don't have output settings for the browser statics, now generated by the Node target.

For that reason I updated the Node targets output and they now look like the ones for browser targets.

PS: Yes, this time I remembered (#5)

### How should it be tested manually?

```bash
yarn test
# or
npm test
```