### PR TITLE
Fix the ToDos

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -16,6 +16,7 @@ const {
   events,
   plugins,
   versionUtils,
+  utils,
 } = require('../services/common');
 
 const {
@@ -78,6 +79,7 @@ class Projext extends Jimple {
     this.register(events);
     this.register(plugins('projext-plugin'));
     this.register(versionUtils);
+    this.register(utils);
 
     this.register(buildCleaner);
     this.register(buildCopier);

--- a/src/services/building/buildTranspiler.js
+++ b/src/services/building/buildTranspiler.js
@@ -227,15 +227,13 @@ class BuildTranspiler {
    * @param {string} file The file that will be used to obtain the target and then the Babel
    *                      configuration.
    * @return {Object}
-   * @throws {Error} If no target can be found.
    */
   getTargetConfigurationForFile(file) {
-    // Find target using the received filepath.
+    /**
+     * Find target using the received filepath. The method will throw an error if a target is not
+     * found.
+     */
     const target = this.targets.findTargetForFile(file);
-    // If no target was found...
-    if (!target) {
-      throw new Error(`A target couldn't be find for the following file: ${file}`);
-    }
     // Return the Babel configuration for the found target.
     return this.babelConfiguration.getConfigForTarget(target);
   }

--- a/src/services/building/targets.js
+++ b/src/services/building/targets.js
@@ -175,7 +175,6 @@ class Targets {
    * @param {string} file The path of the file that should match with a target path.
    * @return {Target}
    * @throws {Error} If no target is found.
-   * @todo The implementation of this method also throws an error if no target is found.
    */
   findTargetForFile(file) {
     const targets = this.getTargets();
@@ -185,7 +184,7 @@ class Targets {
     });
 
     if (!targetName) {
-      throw new Error(`A target for the following file couldn't be found: ${file}`);
+      throw new Error(`A target couldn't be find for the following file: ${file}`);
     }
 
     return targets[targetName];

--- a/src/services/building/targets.js
+++ b/src/services/building/targets.js
@@ -17,13 +17,16 @@ class Targets {
    *                                                            templates.
    * @param {RootRequire}                  rootRequire          To send to the configuration
    *                                                            service used by the browser targets.
+   * @param {Utils}                        utils                To replace plaholders on the targets
+   *                                                            paths.
    */
   constructor(
     events,
     environmentUtils,
     pathUtils,
     projectConfiguration,
-    rootRequire
+    rootRequire,
+    utils
   ) {
     /**
      * A local reference for the `events` service.
@@ -50,6 +53,11 @@ class Targets {
      * @type {RootRequire}
      */
     this.rootRequire = rootRequire;
+    /**
+     * A local reference for the `utils` service.
+     * @type {Utils}
+     */
+    this.utils = utils;
     /**
      * A dictionary that will be filled with the targets information.
      * @type {Object}
@@ -326,10 +334,10 @@ class Targets {
     Object.keys(newOutput).forEach((name) => {
       const value = newOutput[name];
       if (typeof value === 'string') {
-        newOutput[name] = this._replacePlaceholdersOnString(value, placeholders);
+        newOutput[name] = this.utils.replacePlaceholders(value, placeholders);
       } else if (value) {
         Object.keys(value).forEach((propName) => {
-          newOutput[name][propName] = this._replacePlaceholdersOnString(
+          newOutput[name][propName] = this.utils.replacePlaceholders(
             newOutput[name][propName],
             placeholders
           );
@@ -338,25 +346,6 @@ class Targets {
     });
 
     return newOutput;
-  }
-  /**
-   * Replace a dictionary of given placeholders on a string.
-   * @param {string} string       The target string where the placeholders will be replaced.
-   * @param {Object} placeholders A dictionary of placeholders and their values.
-   * @return {string}
-   * @ignore
-   * @protected
-   */
-  _replacePlaceholdersOnString(string, placeholders) {
-    let newString = string;
-    Object.keys(placeholders).forEach((name) => {
-      newString = newString.replace(
-        RegExp(`\\[${name}\\]`, 'ig'),
-        placeholders[name]
-      );
-    });
-
-    return newString;
   }
   /**
    * Checks if there are missing HTML settings that need to be replaced with the default fallback,
@@ -412,7 +401,8 @@ const targets = provider((app) => {
     app.get('environmentUtils'),
     app.get('pathUtils'),
     app.get('projectConfiguration').getConfig(),
-    app.get('rootRequire')
+    app.get('rootRequire'),
+    app.get('utils')
   ));
 });
 

--- a/src/services/common/index.js
+++ b/src/services/common/index.js
@@ -3,6 +3,7 @@ const { copier } = require('./copier');
 const { events } = require('./events');
 const { plugins } = require('./plugins');
 const { versionUtils } = require('./versionUtils');
+const { utils } = require('./utils');
 
 module.exports = {
   cleaner,
@@ -10,4 +11,5 @@ module.exports = {
   events,
   plugins,
   versionUtils,
+  utils,
 };

--- a/src/services/common/utils.js
+++ b/src/services/common/utils.js
@@ -1,0 +1,56 @@
+const { provider } = require('jimple');
+/**
+ * A set of generic utilities that can be used in any context.
+ */
+class Utils {
+  /**
+   * Replace a dictionary of given placeholders on a string.
+   * @param  {string} string              The target string where the placeholders will be
+   *                                      replaced.
+   * @param  {Object} placeholders        A dictionary with its placholders and their values.
+   * @param  {String} [beforePlaceholder] Optional. The left limiter for the placeholder. This will
+   *                                      end up on a regular expression, so if it includes special
+   *                                      symbols (`[]{}/.`), they neeed to be escaped.
+   *                                      The default value is `\\[`.
+   * @param  {String} [afterPlaceholder]  Optional. The right limiter for the placeholder. This will
+   *                                      end up on a regular expression, so if it includes special
+   *                                      symbols (`[]{}/.`), they neeed to be escaped.
+   *                                      The default value is `\\[`.
+   * @return {string}
+   */
+  static replacePlaceholders(
+    string,
+    placeholders,
+    beforePlaceholder = '\\[',
+    afterPlaceholder = '\\]'
+  ) {
+    let newString = string;
+    Object.keys(placeholders).forEach((name) => {
+      newString = newString.replace(
+        RegExp(`${beforePlaceholder}${name}${afterPlaceholder}`, 'ig'),
+        placeholders[name]
+      );
+    });
+
+    return newString;
+  }
+}
+
+/**
+ * The service provider that once registered on the app container will set a reference of
+ * `Utils` as the `utils` service.
+ * @example
+ * // Register it on the container
+ * container.register(utils);
+ * // Getting access to the service reference
+ * const utils = container.get('utils');
+ * @type {Provider}
+ */
+const utils = provider((app) => {
+  app.set('utils', () => Utils);
+});
+
+module.exports = {
+  Utils,
+  utils,
+};

--- a/tests/services/building/buildTranspiler.test.js
+++ b/tests/services/building/buildTranspiler.test.js
@@ -510,30 +510,6 @@ describe('services/building:buildTranspiler', () => {
     expect(fs.writeFileSync).toHaveBeenCalledTimes(0);
   });
 
-  it('should throw an error if it can\'t find a target for a file', () => {
-    // Given
-    const file = 'file.jsx';
-    const babelConfiguration = 'babelConfiguration';
-    const appLogger = 'appLogger';
-    const pathUtils = 'pathUtils';
-    const projectConfiguration = 'projectConfiguration';
-    const targets = {
-      findTargetForFile: jest.fn(),
-    };
-    let sut = null;
-    // When
-    sut = new BuildTranspiler(
-      babelConfiguration,
-      appLogger,
-      pathUtils,
-      projectConfiguration,
-      targets
-    );
-    // Then
-    expect(() => sut.getTargetConfigurationForFile(file))
-    .toThrow(/A target couldn't be find/i);
-  });
-
   it('should include a provider for the DIC', () => {
     // Given
     let sut = null;

--- a/tests/services/building/buildTranspiler.test.js
+++ b/tests/services/building/buildTranspiler.test.js
@@ -30,24 +30,18 @@ describe('services/building:buildTranspiler', () => {
     // Given
     const babelConfiguration = 'babelConfiguration';
     const appLogger = 'appLogger';
-    const pathUtils = 'pathUtils';
-    const projectConfiguration = 'projectConfiguration';
     const targets = 'targets';
     let sut = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      pathUtils,
-      projectConfiguration,
       targets
     );
     // Then
     expect(sut).toBeInstanceOf(BuildTranspiler);
     expect(sut.babelConfiguration).toBe(babelConfiguration);
     expect(sut.appLogger).toBe(appLogger);
-    expect(sut.pathUtils).toBe(pathUtils);
-    expect(sut.projectConfiguration).toBe(projectConfiguration);
     expect(sut.targets).toBe(targets);
   });
 
@@ -73,20 +67,13 @@ describe('services/building:buildTranspiler', () => {
       success: jest.fn(),
       info: jest.fn(),
     };
-    const pathUtils = {
-      path: 'some-path',
-      join: jest.fn((...args) => path.join(...args)),
-    };
-    const projectConfiguration = {
-      paths: {
-        build: 'build-path',
-      },
-    };
     const targets = 'targets';
-    const buildType = 'development';
     const target = {
-      entry: {
-        [buildType]: 'index.js',
+      paths: {
+        build: '/some-absolute-path/to-the/build/directory',
+      },
+      folders: {
+        build: 'build/directory',
       },
     };
     let sut = null;
@@ -94,23 +81,16 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      pathUtils,
-      projectConfiguration,
       targets
     );
-    return sut.transpileTargetFiles(target, buildType)
+    return sut.transpileTargetFiles(target)
     .then(() => {
       // Then
-      expect(pathUtils.join).toHaveBeenCalledTimes(1);
-      expect(pathUtils.join).toHaveBeenCalledWith(
-        projectConfiguration.paths.build,
-        target.entry[buildType]
-      );
       expect(glob).toHaveBeenCalledTimes(1);
       expect(glob).toHaveBeenCalledWith(
         '**/*.{js,jsx}',
         {
-          cwd: projectConfiguration.paths.build,
+          cwd: target.paths.build,
         },
         expect.any(Function)
       );
@@ -120,18 +100,12 @@ describe('services/building:buildTranspiler', () => {
       expect(fs.writeFile).toHaveBeenCalledTimes(files.length);
       files.forEach((file) => {
         expect(babel.transformFile).toHaveBeenCalledWith(
-          path.join(
-            projectConfiguration.paths.build,
-            file
-          ),
+          path.join(target.paths.build, file),
           {},
           expect.any(Function)
         );
         expect(fs.writeFile).toHaveBeenCalledWith(
-          path.join(
-            projectConfiguration.paths.build,
-            file
-          ),
+          path.join(target.paths.build, file),
           code
         );
       });
@@ -154,20 +128,13 @@ describe('services/building:buildTranspiler', () => {
     const appLogger = {
       error: jest.fn(),
     };
-    const pathUtils = {
-      path: 'some-path',
-      join: jest.fn((...args) => path.join(...args)),
-    };
-    const projectConfiguration = {
-      paths: {
-        build: 'build-path',
-      },
-    };
     const targets = 'targets';
-    const buildType = 'development';
     const target = {
-      entry: {
-        [buildType]: 'index.js',
+      paths: {
+        build: '/some-absolute-path/to-the/build/directory',
+      },
+      folders: {
+        build: 'build/directory',
       },
     };
     let sut = null;
@@ -175,26 +142,19 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      pathUtils,
-      projectConfiguration,
       targets
     );
-    return sut.transpileTargetFiles(target, buildType)
+    return sut.transpileTargetFiles(target)
     .then(() => {
       expect(true).toBeFalse();
     })
     .catch((errorResult) => {
       // Then
-      expect(pathUtils.join).toHaveBeenCalledTimes(1);
-      expect(pathUtils.join).toHaveBeenCalledWith(
-        projectConfiguration.paths.build,
-        target.entry[buildType]
-      );
       expect(glob).toHaveBeenCalledTimes(1);
       expect(glob).toHaveBeenCalledWith(
         '**/*.{js,jsx}',
         {
-          cwd: projectConfiguration.paths.build,
+          cwd: target.paths.build,
         },
         expect.any(Function)
       );
@@ -215,8 +175,6 @@ describe('services/building:buildTranspiler', () => {
       getConfigForTarget: jest.fn(() => ({})),
     };
     const appLogger = 'appLogger';
-    const pathUtils = 'pathUtils';
-    const projectConfiguration = 'projectConfiguration';
     const target = {
       name: 'some-target',
     };
@@ -228,8 +186,6 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      pathUtils,
-      projectConfiguration,
       targets
     );
     return sut.transpileFile(file)
@@ -263,8 +219,6 @@ describe('services/building:buildTranspiler', () => {
       getConfigForTarget: jest.fn(() => ({})),
     };
     const appLogger = 'appLogger';
-    const pathUtils = 'pathUtils';
-    const projectConfiguration = 'projectConfiguration';
     const target = {
       name: 'some-target',
     };
@@ -276,8 +230,6 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      pathUtils,
-      projectConfiguration,
       targets
     );
     return sut.transpileFile({
@@ -313,8 +265,6 @@ describe('services/building:buildTranspiler', () => {
       getConfigForTarget: jest.fn(() => ({})),
     };
     const appLogger = 'appLogger';
-    const pathUtils = 'pathUtils';
-    const projectConfiguration = 'projectConfiguration';
     const target = {
       name: 'some-target',
     };
@@ -326,8 +276,6 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      pathUtils,
-      projectConfiguration,
       targets
     );
     return sut.transpileFile(file, {}, false)
@@ -361,8 +309,6 @@ describe('services/building:buildTranspiler', () => {
       getConfigForTarget: jest.fn(() => ({})),
     };
     const appLogger = 'appLogger';
-    const pathUtils = 'pathUtils';
-    const projectConfiguration = 'projectConfiguration';
     const target = {
       name: 'some-target',
     };
@@ -374,8 +320,6 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      pathUtils,
-      projectConfiguration,
       targets
     );
     return sut.transpileFile(file)
@@ -405,8 +349,6 @@ describe('services/building:buildTranspiler', () => {
       getConfigForTarget: jest.fn(() => ({})),
     };
     const appLogger = 'appLogger';
-    const pathUtils = 'pathUtils';
-    const projectConfiguration = 'projectConfiguration';
     const target = {
       name: 'some-target',
     };
@@ -418,8 +360,6 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      pathUtils,
-      projectConfiguration,
       targets
     );
     sut.transpileFileSync(file);
@@ -442,8 +382,6 @@ describe('services/building:buildTranspiler', () => {
       getConfigForTarget: jest.fn(() => ({})),
     };
     const appLogger = 'appLogger';
-    const pathUtils = 'pathUtils';
-    const projectConfiguration = 'projectConfiguration';
     const target = {
       name: 'some-target',
     };
@@ -455,8 +393,6 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      pathUtils,
-      projectConfiguration,
       targets
     );
     sut.transpileFileSync({
@@ -481,8 +417,6 @@ describe('services/building:buildTranspiler', () => {
       getConfigForTarget: jest.fn(() => ({})),
     };
     const appLogger = 'appLogger';
-    const pathUtils = 'pathUtils';
-    const projectConfiguration = 'projectConfiguration';
     const target = {
       name: 'some-target',
     };
@@ -495,8 +429,6 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      pathUtils,
-      projectConfiguration,
       targets
     );
     result = sut.transpileFileSync(file, {}, false);
@@ -515,13 +447,7 @@ describe('services/building:buildTranspiler', () => {
     let sut = null;
     const container = {
       set: jest.fn(),
-      get: jest.fn(
-        (service) => (
-          service === 'projectConfiguration' ?
-            { getConfig: () => service } :
-            service
-        )
-      ),
+      get: jest.fn((service) => service),
     };
     let serviceName = null;
     let serviceFn = null;
@@ -535,8 +461,6 @@ describe('services/building:buildTranspiler', () => {
     expect(sut).toBeInstanceOf(BuildTranspiler);
     expect(sut.babelConfiguration).toBe('babelConfiguration');
     expect(sut.appLogger).toBe('appLogger');
-    expect(sut.pathUtils).toBe('pathUtils');
-    expect(sut.projectConfiguration).toBe('projectConfiguration');
     expect(sut.targets).toBe('targets');
   });
 });

--- a/tests/services/building/targets.test.js
+++ b/tests/services/building/targets.test.js
@@ -982,7 +982,7 @@ describe('services/building:targets', () => {
     );
     // Then
     expect(() => sut.findTargetForFile('some-file'))
-    .toThrow(/A target for the following file couldn't be found/i);
+    .toThrow(/A target couldn't be find for the following file/i);
   });
 
   it('should throw an error when trying to generate a configuration for a Node target', () => {

--- a/tests/services/building/targets.test.js
+++ b/tests/services/building/targets.test.js
@@ -37,6 +37,7 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
+    const utils = 'utils';
     let sut = null;
     // When
     sut = new Targets(
@@ -44,7 +45,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     // Then
     expect(sut).toBeInstanceOf(Targets);
@@ -53,6 +55,7 @@ describe('services/building:targets', () => {
     expect(sut.pathUtils).toBe(pathUtils);
     expect(sut.projectConfiguration).toEqual(projectConfiguration);
     expect(sut.rootRequire).toEqual(rootRequire);
+    expect(sut.utils).toEqual(utils);
   });
 
   it('should load the project targets', () => {
@@ -102,6 +105,7 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
+    const utils = 'utils';
     const expectedTargets = {
       targetOne: {
         defaultTargetName: 'node',
@@ -198,7 +202,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     result = sut.getTargets();
     // Then
@@ -242,20 +247,6 @@ describe('services/building:targets', () => {
           },
           output: {
             development: {
-              js: 'targetOne.js',
-              fonts: 'statics/fonts/[name].[ext]',
-              css: 'statics/styles/targetOne.css',
-              images: 'statics/images/[name].[ext]',
-            },
-            production: {
-              js: 'targetOne.js',
-              fonts: `statics/fonts/[name].${hash}.[ext]`,
-              css: `statics/styles/targetOne.${hash}.css`,
-              images: `statics/images/[name].${hash}.[ext]`,
-            },
-          },
-          originalOutput: {
-            development: {
               js: '[target-name].js',
               fonts: 'statics/fonts/[name].[ext]',
               css: 'statics/styles/[target-name].css',
@@ -297,20 +288,6 @@ describe('services/building:targets', () => {
           },
           output: {
             development: {
-              js: 'targetTwo.js',
-              fonts: 'statics/fonts/[name].[ext]',
-              css: 'statics/styles/targetTwo.css',
-              images: 'statics/images/[name].[ext]',
-            },
-            production: {
-              js: 'targetTwo.js',
-              fonts: `statics/fonts/[name].${hash}.[ext]`,
-              css: `statics/styles/targetTwo.${hash}.css`,
-              images: `statics/images/[name].${hash}.[ext]`,
-            },
-          },
-          originalOutput: {
-            development: {
               js: '[target-name].js',
               fonts: 'statics/fonts/[name].[ext]',
               css: 'statics/styles/[target-name].css',
@@ -351,20 +328,6 @@ describe('services/building:targets', () => {
             production: null,
           },
           output: {
-            development: {
-              js: 'targetThree.js',
-              fonts: 'statics/fonts/[name].[ext]',
-              css: 'statics/styles/targetThree.css',
-              images: 'statics/images/[name].[ext]',
-            },
-            production: {
-              js: 'targetThree.js',
-              fonts: `statics/fonts/[name].${hash}.[ext]`,
-              css: `statics/styles/targetThree.${hash}.css`,
-              images: `statics/images/[name].${hash}.[ext]`,
-            },
-          },
-          originalOutput: {
             development: {
               js: '[target-name].js',
               fonts: 'statics/fonts/[name].[ext]',
@@ -412,20 +375,6 @@ describe('services/building:targets', () => {
             production: 'index.js',
           },
           output: {
-            development: {
-              js: 'app/targetFour.js',
-              fonts: 'app/fonts/[name].[ext]',
-              css: 'app/styles/targetFour.css',
-              images: 'app/images/[name].[ext]',
-            },
-            production: {
-              js: 'app/targetFour.js',
-              fonts: 'app/fonts/[name].[ext]',
-              css: 'app/styles/targetFour.css',
-              images: 'app/images/[name].[ext]',
-            },
-          },
-          originalOutput: {
             development: {
               js: 'app/[target-name].js',
               fonts: 'app/fonts/[name].[ext]',
@@ -483,20 +432,6 @@ describe('services/building:targets', () => {
           },
           output: {
             development: {
-              js: 'app/targetFive.development.js',
-              fonts: 'app/fonts/[name].[ext]',
-              css: 'app/styles/targetFive.css',
-              images: 'app/images/[name].[ext]',
-            },
-            production: {
-              js: 'app/targetFive.production.js',
-              fonts: 'app/fonts/[name].[ext]',
-              css: 'app/styles/targetFive.css',
-              images: 'app/images/[name].[ext]',
-            },
-          },
-          originalOutput: {
-            development: {
               js: 'app/[target-name].development.js',
               fonts: 'app/fonts/[name].[ext]',
               css: 'app/styles/[target-name].css',
@@ -521,9 +456,25 @@ describe('services/building:targets', () => {
     ];
     const targetsDict = {};
     const expectedTargets = {};
+    const expectedReplacements = [];
     targetsData.forEach((data) => {
       targetsDict[data.config.name] = data.config;
       expectedTargets[data.expected.name] = data.expected;
+      expectedTargets[data.expected.name].originalOutput = data.expected.output;
+      expectedReplacements.push(
+        ...Object.keys(data.expected.output.development)
+        .map((name) => ({
+          targetName: data.expected.name,
+          string: data.expected.output.development[name],
+        }))
+      );
+      expectedReplacements.push(
+        ...Object.keys(data.expected.output.production)
+        .map((name) => ({
+          targetName: data.expected.name,
+          string: data.expected.output.production[name],
+        }))
+      );
     });
     const projectConfiguration = {
       targets: targetsDict,
@@ -557,6 +508,9 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
+    const utils = {
+      replacePlaceholders: jest.fn((string) => string),
+    };
     let sut = null;
     let result = null;
     // When
@@ -565,7 +519,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     result = sut.getTargets();
     // Then
@@ -576,6 +531,13 @@ describe('services/building:targets', () => {
         'target-load',
         info.expected
       );
+    });
+    expect(utils.replacePlaceholders).toHaveBeenCalledTimes(expectedReplacements.length);
+    expectedReplacements.forEach((info) => {
+      expect(utils.replacePlaceholders).toHaveBeenCalledWith(info.string, {
+        'target-name': info.targetName,
+        hash,
+      });
     });
   });
 
@@ -755,6 +717,7 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
+    const utils = 'utils';
     let sut = null;
     let result = null;
     // When
@@ -763,7 +726,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     result = sut.getTargets();
     // Then
@@ -807,6 +771,7 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
+    const utils = 'utils';
     const expectedTarget = {
       defaultTargetName: 'node',
       type: 'node',
@@ -836,7 +801,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     result = sut.getTarget(targetName);
     // Then
@@ -867,13 +833,15 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
+    const utils = 'utils';
     // When/Then
     expect(() => new Targets(
       events,
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     ))
     .toThrow(/invalid type/i);
   });
@@ -894,6 +862,7 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
+    const utils = 'utils';
     let sut = null;
     // When
     sut = new Targets(
@@ -901,7 +870,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     // Then
     expect(() => sut.getTarget('some-target'))
@@ -941,6 +911,7 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
+    const utils = 'utils';
     let sut = null;
     let result = null;
     // When
@@ -949,7 +920,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     result = sut.findTargetForFile(file);
     // Then
@@ -971,6 +943,7 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
+    const utils = 'utils';
     let sut = null;
     // When
     sut = new Targets(
@@ -978,7 +951,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     // Then
     expect(() => sut.findTargetForFile('some-file'))
@@ -999,6 +973,7 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
+    const utils = 'utils';
     const target = {
       is: {
         node: true,
@@ -1011,7 +986,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     // Then
     expect(() => sut.getBrowserTargetConfiguration(target))
@@ -1032,6 +1008,7 @@ describe('services/building:targets', () => {
       },
     };
     const rootRequire = 'rootRequire';
+    const utils = 'utils';
     const target = {
       name: 'my-target',
       is: {
@@ -1049,7 +1026,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     result = sut.getBrowserTargetConfiguration(target);
     // Then
@@ -1073,6 +1051,7 @@ describe('services/building:targets', () => {
       someProp: 'someValue',
     };
     const rootRequire = jest.fn(() => defaultConfig);
+    const utils = 'utils';
     const getConfig = jest.fn(() => defaultConfig);
     WootilsAppConfigurationMock.mock('getConfig', getConfig);
     const target = {
@@ -1098,7 +1077,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     result = sut.getBrowserTargetConfiguration(target);
     // Then
@@ -1138,6 +1118,7 @@ describe('services/building:targets', () => {
       someProp: 'someValue',
     };
     const rootRequire = jest.fn(() => defaultConfig);
+    const utils = 'utils';
     const getConfig = jest.fn(() => defaultConfig);
     WootilsAppConfigurationMock.mock('getConfig', getConfig);
     const target = {
@@ -1163,7 +1144,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     result = sut.getBrowserTargetConfiguration(target);
     // Then
@@ -1203,6 +1185,7 @@ describe('services/building:targets', () => {
       someProp: 'someValue',
     };
     const rootRequire = jest.fn();
+    const utils = 'utils';
     const getConfig = jest.fn(() => defaultConfig);
     WootilsAppConfigurationMock.mock('getConfig', getConfig);
     const target = {
@@ -1228,7 +1211,8 @@ describe('services/building:targets', () => {
       environmentUtils,
       pathUtils,
       projectConfiguration,
-      rootRequire
+      rootRequire,
+      utils
     );
     result = sut.getBrowserTargetConfiguration(target);
     // Then
@@ -1285,5 +1269,6 @@ describe('services/building:targets', () => {
     expect(sut.pathUtils).toBe('pathUtils');
     expect(sut.projectConfiguration).toEqual(projectConfiguration);
     expect(sut.rootRequire).toBe('rootRequire');
+    expect(sut.utils).toBe('utils');
   });
 });

--- a/tests/services/common/utils.test.js
+++ b/tests/services/common/utils.test.js
@@ -1,0 +1,101 @@
+const JimpleMock = require('/tests/mocks/jimple.mock');
+
+jest.mock('jimple', () => JimpleMock);
+jest.unmock('/src/services/common/utils');
+
+require('jasmine-expect');
+
+const { Utils, utils } = require('/src/services/common/utils');
+
+describe('services/common:utils', () => {
+  it('should replace placeholders on a string', () => {
+    // Given
+    const placeholders = {
+      name: 'Charito',
+      birthday: 'September 25, 2015',
+    };
+    const strings = [
+      // One placeholder
+      {
+        original: 'Hello [name]',
+        expected: `Hello ${placeholders.name}`,
+      },
+      // Multiple placeholders
+      {
+        original: '[name] was born on [birthday]',
+        expected: `${placeholders.name} was born on ${placeholders.birthday}`,
+      },
+      // Same placeholder, multiple times
+      {
+        original: '[name] [name] [name]!!!',
+        expected: `${placeholders.name} ${placeholders.name} ${placeholders.name}!!!`,
+      },
+    ];
+    let results = null;
+    // When
+    results = strings.map((info) => Utils.replacePlaceholders(info.original, placeholders));
+    // Then
+    strings.forEach((info, index) => {
+      expect(results[index]).toBe(info.expected);
+    });
+  });
+
+  it('should replace placeholders on a string, with custom placeholders limiters', () => {
+    // Given
+    const placeholders = {
+      name: 'Charito',
+      birthday: 'September 25, 2015',
+    };
+    const strings = [
+      // One placeholder
+      {
+        original: 'Hello [name]',
+        expected: `Hello ${placeholders.name}`,
+        beforePlaceholder: '\\[',
+        afterPlaceholder: '\\]',
+      },
+      // Multiple placeholders
+      {
+        original: '{name} was born on {birthday}',
+        expected: `${placeholders.name} was born on ${placeholders.birthday}`,
+        beforePlaceholder: '\\{',
+        afterPlaceholder: '\\}',
+      },
+      // Same placeholder, multiple times
+      {
+        original: ':name :name :name!!!',
+        expected: `${placeholders.name} ${placeholders.name} ${placeholders.name}!!!`,
+        beforePlaceholder: '\\:',
+        afterPlaceholder: '',
+      },
+    ];
+    let results = null;
+    // When
+    results = strings.map((info) => Utils.replacePlaceholders(
+      info.original,
+      placeholders,
+      info.beforePlaceholder,
+      info.afterPlaceholder
+    ));
+    // Then
+    strings.forEach((info, index) => {
+      expect(results[index]).toBe(info.expected);
+    });
+  });
+
+  it('should include a provider for the DIC', () => {
+    // Given
+    const container = {
+      set: jest.fn(),
+    };
+    let serviceName = null;
+    let serviceFn = null;
+    // When
+    utils(container);
+    [[serviceName, serviceFn]] = container.set.mock.calls;
+    // Then
+    expect(serviceName).toBe('utils');
+    expect(serviceFn).toBeFunction();
+    expect(serviceFn()).toBe(Utils);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

It fixes the three to-dos the project had:

#### Remove an unnecessary throw

`BuildTranspiler#getTargetConfigurationForFile` had a check that if the target couldn't be found, it would throw an error, but `Targets#findTargetForFile` (the method it calls) already have the same functionality, so I removed it from `BuildTranspiler`.

#### Refactor how the `BuildTranspiler` reads paths

When transpiling a target, `BuildTranspiler` was using the the project configuration paths and the target entry to generate the path of where it was going to look for files and transpile. This was probably left from the original project that ended up becoming `projext`, since a `Target` already has its paths on the properties.

I removed the dependencies from `ProjectConfiguration` and `PathUtils` (that's why this commit is breaking) and made the service use the received target properties.

This change is the reason for the `bug` label, since before this change, if the entry file of a target was on a sub directory, inside its directory, it would try to find files inside that directory and end up only transpiling the entry file.

#### The `Utils` service

It all started with the `_replacePlaceholdersOnString` method, duplicated on `Targets` and `BuildCleaner`. I wanted to avoid the duplication, but I didn't have a generic place to move it, so I created the `Utils` service to store all the small functions that don't belong anywhere specific.

Since `Utils` is now a dependency of both services, this commit is also breaking.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```

### TODOs

This closes all the open `@todo`s on the code :D 
