### PR TITLE
Small fixes for the Zero configuration

### DIFF
--- a/src/services/building/buildCleaner.js
+++ b/src/services/building/buildCleaner.js
@@ -120,13 +120,13 @@ class BuildCleaner {
     .then((items) => this.cleaner(target.paths.build, items))
     .then(() => {
       this.appLogger.success(
-        `The files for ${target.name} have been was successfully removed from ` +
+        `The files for '${target.name}' have been was successfully removed from ` +
         `the distribution directory (${dist})`
       );
     })
     .catch((error) => {
       this.appLogger.error(
-        `Error: There was an error while removing the files for ${target.name} ` +
+        `Error: There was an error while removing the files for '${target.name}' ` +
         `from the distribution directory (${dist})`
       );
 

--- a/src/services/building/buildCopier.js
+++ b/src/services/building/buildCopier.js
@@ -237,11 +237,11 @@ class BuildCopier {
     ))
     .then(() => {
       this.appLogger.success(
-        `The files for ${target.name} have been successfully copied (${target.paths.build})`
+        `The files for '${target.name}' have been successfully copied (${target.paths.build})`
       );
     })
     .catch((error) => {
-      this.appLogger.error(`The files for ${target.name} couldn't be copied`);
+      this.appLogger.error(`The files for '${target.name}' couldn't be copied`);
       return Promise.reject(error);
     });
   }

--- a/src/services/building/buildTranspiler.js
+++ b/src/services/building/buildTranspiler.js
@@ -65,7 +65,7 @@ class BuildTranspiler {
     })
     .catch((error) => {
       this.appLogger.error(
-        `There was an error while transpiling the ${target.name} code`
+        `There was an error while transpiling the target '${target.name}' code`
       );
       return Promise.reject(error);
     });

--- a/src/services/cli/cliSHValidateBuild.js
+++ b/src/services/cli/cliSHValidateBuild.js
@@ -101,7 +101,8 @@ class CLISHValidateBuildCommand extends CLICommand {
       if (!htmlStatus.exists) {
         this.appLogger.warning(
           `The target '${name}' doesn't have an HTML template, projext will generate one for ` +
-          'this build, but it would be best for you to create'
+          'this build, but it would be best for you to create one. You can use the ' +
+          '\'generate\' command'
         );
       }
     }

--- a/src/services/targets/targetsHTML.js
+++ b/src/services/targets/targetsHTML.js
@@ -83,18 +83,20 @@ class TargetsHTML {
     // Normalize the body attributes to avoid unnecessary spaces on the tag.
     const bodyAttrs = info.bodyAttributes ? ` ${info.bodyAttributes}` : '';
     // Generate the HTML code.
-    const htmlTpl = '<!doctype html>' +
-    '<html lang="en">' +
-    '<head>' +
-    ' <meta charset="utf-8" />' +
-    ' <meta http-equiv="x-ua-compatible" content="ie=edge" />' +
-    ' <meta name="viewport" content="width=device-width, initial-scale=1" />' +
-    ` <title>${info.title}</title>` +
-    '</head>' +
-    `<body${bodyAttrs}>` +
-    ` ${info.bodyContents}` +
-    '</body>' +
-    '</html>';
+    const htmlTpl = [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      ' <meta charset="utf-8" />',
+      ' <meta http-equiv="x-ua-compatible" content="ie=edge" />',
+      ' <meta name="viewport" content="width=device-width, initial-scale=1" />',
+      ` <title>${info.title}</title>`,
+      '</head>',
+      `<body${bodyAttrs}>`,
+      ` ${info.bodyContents}`,
+      '</body>',
+      '</html>',
+    ].join('\n');
     // Reduce the HTML code.
     const html = this.events.reduce('target-default-html', htmlTpl, target);
     // Write the file on the temp directory.

--- a/tests/services/targets/targetsFinder.test.js
+++ b/tests/services/targets/targetsFinder.test.js
@@ -257,7 +257,6 @@ describe('services/targets:targetsFinder', () => {
       },
       type: 'node',
       library: false,
-      transpile: false,
     }];
     // When
     sut = new TargetsFinder(packageInfo, pathUtils);
@@ -329,6 +328,59 @@ describe('services/targets:targetsFinder', () => {
     expect(fs.readFileSync).toHaveBeenCalledWith(`${directory}/${indexFile}`, 'utf-8');
   });
 
+  it('should find a Node target that requires bundling', () => {
+    // Given
+    const packageInfo = {
+      name: 'my-app',
+    };
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    // 1 - When checking if the source directory exists.
+    fs.pathExistsSync.mockReturnValueOnce(true);
+    // 2 - When checking if the default index exists.
+    fs.pathExistsSync.mockReturnValueOnce(true);
+    const indexFile = 'index.js';
+    const sourceDirectoryContents = ['..', '.', indexFile, 'some-other-file.js'];
+    // 1 - When reading the source directory.
+    fs.readdirSync.mockReturnValueOnce(sourceDirectoryContents);
+    // 2 - When parsing the target.
+    fs.readdirSync.mockReturnValueOnce(sourceDirectoryContents);
+    const fileContents = 'import charito from \'charito.png\';';
+    fs.readFileSync.mockReturnValueOnce(fileContents);
+    const directory = 'src';
+    let sut = null;
+    let result = null;
+    const expectedTargets = [{
+      name: packageInfo.name,
+      hasFolder: false,
+      createFolder: false,
+      entry: {
+        default: indexFile,
+        development: null,
+        production: null,
+      },
+      type: 'node',
+      library: false,
+      bundle: true,
+    }];
+    // When
+    sut = new TargetsFinder(packageInfo, pathUtils);
+    result = sut.find(directory);
+    // Then
+    expect(result).toEqual(expectedTargets);
+    expect(pathUtils.join).toHaveBeenCalledTimes(1);
+    expect(pathUtils.join).toHaveBeenCalledWith(directory);
+    expect(fs.pathExistsSync).toHaveBeenCalledTimes(['sourceDirectory', 'index'].length);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(directory);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(`${directory}/${indexFile}`);
+    expect(fs.readdirSync).toHaveBeenCalledTimes(['sourceDirectory', 'parsingTarget'].length);
+    expect(fs.readdirSync).toHaveBeenCalledWith(directory);
+    expect(fs.readdirSync).toHaveBeenCalledWith(directory);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync).toHaveBeenCalledWith(`${directory}/${indexFile}`, 'utf-8');
+  });
+
   it('should find a Node target with a single file', () => {
     // Given
     const packageInfo = {
@@ -363,7 +415,6 @@ describe('services/targets:targetsFinder', () => {
       },
       type: 'node',
       library: false,
-      transpile: false,
     }];
     // When
     sut = new TargetsFinder(packageInfo, pathUtils);
@@ -417,7 +468,6 @@ describe('services/targets:targetsFinder', () => {
       },
       type: 'node',
       library: false,
-      transpile: false,
     }];
     // When
     sut = new TargetsFinder(packageInfo, pathUtils);
@@ -436,7 +486,7 @@ describe('services/targets:targetsFinder', () => {
     expect(fs.readFileSync).toHaveBeenCalledWith(`${directory}/${productionEntryFile}`, 'utf-8');
   });
 
-  it('should find a Node target library', () => {
+  it('should find a library Node target', () => {
     // Given
     const packageInfo = {
       name: 'my-app',
@@ -470,7 +520,6 @@ describe('services/targets:targetsFinder', () => {
       },
       type: 'node',
       library: true,
-      transpile: false,
     }];
     // When
     sut = new TargetsFinder(packageInfo, pathUtils);
@@ -489,7 +538,7 @@ describe('services/targets:targetsFinder', () => {
     expect(fs.readFileSync).toHaveBeenCalledWith(`${directory}/${indexFile}`, 'utf-8');
   });
 
-  it('should find a Node target library that requires transpiling', () => {
+  it('should find a library Node target that requires transpiling', () => {
     // Given
     const packageInfo = {
       name: 'my-app',
@@ -524,6 +573,66 @@ describe('services/targets:targetsFinder', () => {
       type: 'node',
       library: true,
       transpile: true,
+    }];
+    // When
+    sut = new TargetsFinder(packageInfo, pathUtils);
+    result = sut.find(directory);
+    // Then
+    expect(result).toEqual(expectedTargets);
+    expect(pathUtils.join).toHaveBeenCalledTimes(1);
+    expect(pathUtils.join).toHaveBeenCalledWith(directory);
+    expect(fs.pathExistsSync).toHaveBeenCalledTimes(['sourceDirectory', 'index'].length);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(directory);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(`${directory}/${indexFile}`);
+    expect(fs.readdirSync).toHaveBeenCalledTimes(['sourceDirectory', 'parsingTarget'].length);
+    expect(fs.readdirSync).toHaveBeenCalledWith(directory);
+    expect(fs.readdirSync).toHaveBeenCalledWith(directory);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync).toHaveBeenCalledWith(`${directory}/${indexFile}`, 'utf-8');
+  });
+
+  it('should find a library browser target', () => {
+    // Given
+    const packageInfo = {
+      name: 'my-app',
+    };
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    // 1 - When checking if the source directory exists.
+    fs.pathExistsSync.mockReturnValueOnce(true);
+    // 2 - When checking if the default index exists.
+    fs.pathExistsSync.mockReturnValueOnce(true);
+    const indexFile = 'index.js';
+    const sourceDirectoryContents = ['..', '.', indexFile, 'some-other-file.js'];
+    // 1 - When reading the source directory.
+    fs.readdirSync.mockReturnValueOnce(sourceDirectoryContents);
+    // 2 - When parsing the target.
+    fs.readdirSync.mockReturnValueOnce(sourceDirectoryContents);
+    const fileContents = 'module.exports = () => document.querySelector(\'#app\').remove()';
+    fs.readFileSync.mockReturnValueOnce(fileContents);
+    const directory = 'src';
+    let sut = null;
+    let result = null;
+    const expectedTargets = [{
+      name: packageInfo.name,
+      hasFolder: false,
+      createFolder: false,
+      entry: {
+        default: indexFile,
+        development: null,
+        production: null,
+      },
+      output: {
+        default: {
+          js: '[target-name].js',
+        },
+        development: {
+          js: '[target-name].js',
+        },
+      },
+      type: 'browser',
+      library: true,
     }];
     // When
     sut = new TargetsFinder(packageInfo, pathUtils);

--- a/tests/services/targets/targetsHTML.test.js
+++ b/tests/services/targets/targetsHTML.test.js
@@ -78,18 +78,20 @@ describe('services/targets:targetsHTML', () => {
     let sut = null;
     let result = null;
     const expectedFilepath = `${target.name}.index.html`;
-    const expectedHTML = '<!doctype html>' +
-      '<html lang="en">' +
-      '<head>' +
-      ' <meta charset="utf-8" />' +
-      ' <meta http-equiv="x-ua-compatible" content="ie=edge" />' +
-      ' <meta name="viewport" content="width=device-width, initial-scale=1" />' +
-      ` <title>${target.name}</title>` +
-      '</head>' +
-      '<body>' +
-      ' <div id="app"></div>' +
-      '</body>' +
-      '</html>';
+    const expectedHTML = [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      ' <meta charset="utf-8" />',
+      ' <meta http-equiv="x-ua-compatible" content="ie=edge" />',
+      ' <meta name="viewport" content="width=device-width, initial-scale=1" />',
+      ` <title>${target.name}</title>`,
+      '</head>',
+      '<body>',
+      ' <div id="app"></div>',
+      '</body>',
+      '</html>',
+    ].join('\n');
     const expectedEvents = {
       'target-default-html-settings': [
         {
@@ -141,18 +143,20 @@ describe('services/targets:targetsHTML', () => {
     let sut = null;
     let result = null;
     const expectedFilepath = `${target.name}.index.html`;
-    const expectedHTML = '<!doctype html>' +
-      '<html lang="en">' +
-      '<head>' +
-      ' <meta charset="utf-8" />' +
-      ' <meta http-equiv="x-ua-compatible" content="ie=edge" />' +
-      ' <meta name="viewport" content="width=device-width, initial-scale=1" />' +
-      ` <title>${target.name}</title>` +
-      '</head>' +
-      '<body>' +
-      ' <div id="app"></div>' +
-      '</body>' +
-      '</html>';
+    const expectedHTML = [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      ' <meta charset="utf-8" />',
+      ' <meta http-equiv="x-ua-compatible" content="ie=edge" />',
+      ' <meta name="viewport" content="width=device-width, initial-scale=1" />',
+      ` <title>${target.name}</title>`,
+      '</head>',
+      '<body>',
+      ' <div id="app"></div>',
+      '</body>',
+      '</html>',
+    ].join('\n');
     const expectedEvents = {
       'target-default-html-settings': [
         {
@@ -214,18 +218,20 @@ describe('services/targets:targetsHTML', () => {
     let sut = null;
     let result = null;
     const expectedFilepath = `${target.name}.index.html`;
-    const expectedHTML = '<!doctype html>' +
-      '<html lang="en">' +
-      '<head>' +
-      ' <meta charset="utf-8" />' +
-      ' <meta http-equiv="x-ua-compatible" content="ie=edge" />' +
-      ' <meta name="viewport" content="width=device-width, initial-scale=1" />' +
-      ` <title>${settings.title}</title>` +
-      '</head>' +
-      `<body ${settings.bodyAttributes}>` +
-      ` ${settings.bodyContents}` +
-      '</body>' +
-      '</html>';
+    const expectedHTML = [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      ' <meta charset="utf-8" />',
+      ' <meta http-equiv="x-ua-compatible" content="ie=edge" />',
+      ' <meta name="viewport" content="width=device-width, initial-scale=1" />',
+      ` <title>${settings.title}</title>`,
+      '</head>',
+      `<body ${settings.bodyAttributes}>`,
+      ` ${settings.bodyContents}`,
+      '</body>',
+      '</html>',
+    ].join('\n');
     const expectedEvents = {
       [settingsEventName]: [
         {


### PR DESCRIPTION
### What does this PR do?

#### The `targetsFinder` service provider was broken

The provider wasn't injecting `packageInfo` when registering the service.

#### Detects if a Node targets requires bundling

While parsing the entry file, the Targets Finder will now check if the file is using `import` or `require` for an asset file (images, stylesheets, fonts, etc.) and in if it does, it will set the `bundle` flag to `true`.

#### Simplify the output for browser library targets

By default, the JS output settings for a browser targets are inside a `static/js` path, and in the case of a production build, a hash will be added to the filename.

Now, when the Targets Finder detects a library browser target, it will change the JS output settings to `[target-name].js` for both build types.

It makes more sense that if you are building a library browser target, you would want to use the bundled file as your `package.json` `main` entry, so it would be better if the file is on the root of your distribution directory and always with the same name.

#### Uncompress the code of the generated _"default HTML"_ for browser targets

The code was already indented and prepared for it, but I had forgot to add the `\n` after each line :P.

### Fix typos on the logged messages

- All logged messages that mention a target's name will now do it using single quotes.
- The warning message for the use of the _"default HTML"_ was incomplete.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
