### PR TITLE
Add support for custom options on the build and run command

### DIFF
--- a/src/abstracts/cliCommand.js
+++ b/src/abstracts/cliCommand.js
@@ -226,6 +226,13 @@ class CLICommand {
           // ...add it to the list.
           cmdOptions.push(instruction);
         }
+      } else {
+        let instruction = `--${name}`;
+        if (value !== true) {
+          instruction += ` ${value}`;
+        }
+
+        cmdOptions.push(instruction);
       }
     });
 

--- a/src/abstracts/cliCommand.js
+++ b/src/abstracts/cliCommand.js
@@ -227,11 +227,13 @@ class CLICommand {
           cmdOptions.push(instruction);
         }
       } else {
+        // Finally, if is not on the command options, just add it.
         let instruction = `--${name}`;
+        // If the option is not a flag, add its value.
         if (value !== true) {
           instruction += ` ${value}`;
         }
-
+        // Push it to the list
         cmdOptions.push(instruction);
       }
     });

--- a/src/services/cli/cliBuild.js
+++ b/src/services/cli/cliBuild.js
@@ -34,6 +34,11 @@ class CLIBuildCommand extends CLICommand {
         'build type is development',
       false
     );
+    /**
+     * Enable unknown options so other services can customize the build command.
+     * @type {Boolean}
+     */
+    this.allowUnknownOptions = true;
   }
 }
 /**

--- a/src/services/cli/cliGenerate.js
+++ b/src/services/cli/cliGenerate.js
@@ -31,7 +31,7 @@ class CLIGenerateCommand extends CLICommand {
     this.description = 'Generate a projext resource. Use the --help flag on this command ' +
       'for more information';
     /**
-     * Enable unkonwn options in order to pick the generator options.
+     * Enable unknown options in order to pick the generator options.
      * @type {Boolean}
      */
     this.allowUnknownOptions = true;

--- a/src/services/cli/cliRun.js
+++ b/src/services/cli/cliRun.js
@@ -22,6 +22,11 @@ class CLIRunCommand extends CLICommand {
      * @type {string}
      */
     this.description = 'Run a target on a development build type';
+    /**
+     * Enable unknown options so other services can customize the build command.
+     * @type {Boolean}
+     */
+    this.allowUnknownOptions = true;
   }
 }
 /**

--- a/src/services/cli/cliSHBuild.js
+++ b/src/services/cli/cliSHBuild.js
@@ -129,19 +129,25 @@ class CLISHBuildCommand extends CLICommand {
      * @type {boolean}
      */
     this.hidden = true;
+    /**
+     * Enable unknown options so other services can customize the build command.
+     * @type {Boolean}
+     */
+    this.allowUnknownOptions = true;
   }
   /**
    * Handle the execution of the command and outputs the list of commands to run.
    * This method emits the event reducer `build-target-commands-list` with the list of commands,
    * the target information, the type of build and whether or not the target should be executed;
    * and it expects a list of commands on return.
-   * @param {?string} name         The name of the target.
-   * @param {Command} command      The executed command (sent by `commander`).
-   * @param {Object}  options      The command options.
-   * @param {string}  options.type The type of build.
-   * @param {boolean} options.run  Whether or not the target also needs to be executed.
+   * @param {?string} name           The name of the target.
+   * @param {Command} command        The executed command (sent by `commander`).
+   * @param {Object}  options        The command options.
+   * @param {string}  options.type   The type of build.
+   * @param {boolean} options.run    Whether or not the target also needs to be executed.
+   * @param {Object}  unknownOptions A dictionary of extra options that command may have received.
    */
-  handle(name, command, options) {
+  handle(name, command, options, unknownOptions) {
     const { type } = options;
     // Get the target information
     const target = name ?
@@ -161,7 +167,8 @@ class CLISHBuildCommand extends CLICommand {
       commands.filter((cmd) => !!cmd),
       target,
       type,
-      run
+      run,
+      unknownOptions
     )
     // Join the commands on a single string.
     .join(';');

--- a/src/services/cli/cliSHRun.js
+++ b/src/services/cli/cliSHRun.js
@@ -41,23 +41,35 @@ class CLISHRunCommand extends CLICommand {
      * @type {boolean}
      */
     this.hidden = true;
+    /**
+     * Enable unknown options so other services can customize the build command.
+     * @type {Boolean}
+     */
+    this.allowUnknownOptions = true;
   }
   /**
    * Handle the execution of the command and outputs the list of commands to run.
    * @param {?string} name The name of the target.
+   * @param {Command} command        The executed command (sent by `commander`).
+   * @param {Object}  options        The command options.
+   * @param {Object}  unknownOptions A dictionary of extra options that command may have received.
    */
-  handle(name) {
+  handle(name, command, options, unknownOptions) {
     const target = name ?
       // If the target doesn't exist, this will throw an error.
       this.targets.getTarget(name) :
       // Get the default target or throw an error if the project doesn't have targets.
       this.targets.getDefaultTarget();
 
-    this.output(this.cliBuildCommand.generate({
-      target: target.name,
-      type: 'development',
-      run: true,
-    }));
+    this.output(this.cliBuildCommand.generate(Object.assign(
+      {},
+      unknownOptions,
+      {
+        target: target.name,
+        type: 'development',
+        run: true,
+      }
+    )));
   }
 }
 /**

--- a/tests/abstracts/cliCommand.test.js
+++ b/tests/abstracts/cliCommand.test.js
@@ -394,6 +394,57 @@ describe('abstracts:CLICommand', () => {
     expect(result).toBe(`${cli.name} ${command} ${expectedOption}`);
   });
 
+  it('should be able to generate the command as a string and include unknown options', () => {
+    // Given
+    const program = {
+      command: jest.fn(() => program),
+      description: jest.fn(() => program),
+      option: jest.fn(() => program),
+      action: jest.fn(() => program),
+      on: jest.fn(),
+      allowUnknownOption: jest.fn(),
+    };
+    const cli = {
+      name: 'some-program',
+    };
+    const option = {
+      name: 'env',
+      instruction: '-e, --env [env]',
+    };
+    const env = 'charito';
+    const command = 'test-command';
+    const description = 'Test description';
+    const subProgram = true;
+    const unknownOptName = 'plugin';
+    const unknownOptValue = 'pluginName';
+    const unknownFlag = 'flagish';
+    const generateOptions = {
+      env,
+      [unknownOptName]: unknownOptValue,
+      [unknownFlag]: true,
+    };
+    class Sut extends CLICommand {}
+    let sut = null;
+    let result = '';
+    const expectedOptions = `--env ${env} --${unknownOptName} ${unknownOptValue} --${unknownFlag}`;
+    // When
+    sut = new Sut();
+    sut.command = command;
+    sut.description = description;
+    sut.subProgram = subProgram;
+    sut.addOption(option.name, option.instruction);
+    sut.register(program, cli);
+    result = sut.generate(generateOptions);
+    // Then
+    expect(sut.cliName).toBe(cli.name);
+    expect(program.command).toHaveBeenCalledTimes(1);
+    expect(program.command).toHaveBeenCalledWith(command, description, {});
+    expect(program.description).toHaveBeenCalledTimes(0);
+    expect(program.action).toHaveBeenCalledTimes(1);
+    expect(program.action).toHaveBeenCalledWith(expect.any(Function));
+    expect(result).toBe(`${cli.name} ${command} ${expectedOptions}`);
+  });
+
   it('should be able to generate the command as a string and include boolean options', () => {
     // Given
     const program = {

--- a/tests/services/cli/cliBuild.test.js
+++ b/tests/services/cli/cliBuild.test.js
@@ -39,6 +39,7 @@ describe('services/cli:build', () => {
       expect.any(String),
       false
     );
+    expect(sut.allowUnknownOptions).toBeTrue();
   });
 
   it('should include a provider for the DIC', () => {

--- a/tests/services/cli/cliGenerate.test.js
+++ b/tests/services/cli/cliGenerate.test.js
@@ -26,6 +26,7 @@ describe('services/cli:generate', () => {
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.command).not.toBeEmptyString();
     expect(sut.description).not.toBeEmptyString();
+    expect(sut.allowUnknownOptions).toBeTrue();
   });
 
   it('should register new generators', () => {

--- a/tests/services/cli/cliRun.test.js
+++ b/tests/services/cli/cliRun.test.js
@@ -26,6 +26,7 @@ describe('services/cli:build', () => {
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.command).not.toBeEmptyString();
     expect(sut.description).not.toBeEmptyString();
+    expect(sut.allowUnknownOptions).toBeTrue();
   });
 
   it('should include a provider for the DIC', () => {

--- a/tests/services/cli/cliSHBuild.test.js
+++ b/tests/services/cli/cliSHBuild.test.js
@@ -96,8 +96,9 @@ describe('services/cli:sh-build', () => {
     test.run = (
       type,
       run,
-      name = test.targetName
-    ) => test.sut.handle(name, null, { type, run });
+      name = test.targetName,
+      unknownOptions = {}
+    ) => test.sut.handle(name, null, { type, run }, unknownOptions);
 
     return test;
   };
@@ -184,7 +185,8 @@ describe('services/cli:sh-build', () => {
       [test.buildCommand],
       test.target,
       buildType,
-      false
+      false,
+      {}
     );
     expect(test.sut.output).toHaveBeenCalledTimes(1);
     expect(test.sut.output).toHaveBeenCalledWith([
@@ -213,7 +215,8 @@ describe('services/cli:sh-build', () => {
       [test.buildCommand],
       test.target,
       buildType,
-      false
+      false,
+      {}
     );
     expect(test.sut.output).toHaveBeenCalledTimes(1);
     expect(test.sut.output).toHaveBeenCalledWith([
@@ -640,6 +643,39 @@ describe('services/cli:sh-build', () => {
       test.buildCommand,
       test.copyCommand,
       test.transpileCommand,
+    ].join(';'));
+  });
+
+  it('should return the command to build a node target and include unknown options', () => {
+    // Given
+    const buildType = 'development';
+    const unknownOptions = {
+      name: 'Rosario',
+    };
+    const test = getTestForTheBuildCommand();
+    // When
+    test.run(buildType, false, test.targetName, unknownOptions);
+    // Then
+    expect(test.targets.getTarget).toHaveBeenCalledTimes(1);
+    expect(test.targets.getTarget).toHaveBeenCalledWith(test.targetName);
+    expect(test.cliCleanCommand.generate).toHaveBeenCalledTimes(0);
+    expect(test.cliSHCopyCommand.generate).toHaveBeenCalledTimes(0);
+    expect(test.cliSHNodeRunCommand.generate).toHaveBeenCalledTimes(0);
+    expect(test.cliSHTranspileCommand.generate).toHaveBeenCalledTimes(0);
+    expect(test.cliRevisionCommand.generate).toHaveBeenCalledTimes(0);
+    expect(test.cliCopyProjectFilesCommand.generate).toHaveBeenCalledTimes(0);
+    expect(test.events.reduce).toHaveBeenCalledTimes(1);
+    expect(test.events.reduce).toHaveBeenCalledWith(
+      'build-target-commands-list',
+      [test.buildCommand],
+      test.target,
+      buildType,
+      false,
+      unknownOptions
+    );
+    expect(test.sut.output).toHaveBeenCalledTimes(1);
+    expect(test.sut.output).toHaveBeenCalledWith([
+      test.buildCommand,
     ].join(';'));
   });
 

--- a/tests/services/cli/cliSHRun.test.js
+++ b/tests/services/cli/cliSHRun.test.js
@@ -31,6 +31,7 @@ describe('services/cli:sh-run', () => {
     expect(sut.command).not.toBeEmptyString();
     expect(sut.description).not.toBeEmptyString();
     expect(sut.hidden).toBeTrue();
+    expect(sut.allowUnknownOptions).toBeTrue();
   });
 
   it('should return the command to run a target when executed', () => {
@@ -55,6 +56,40 @@ describe('services/cli:sh-run', () => {
       target,
       type: 'development',
       run: true,
+    });
+    expect(sut.output).toHaveBeenCalledTimes(1);
+    expect(sut.output).toHaveBeenCalledWith(buildCommand);
+  });
+
+  it('should return the command to run a target when executed and include unkown options', () => {
+    // Given
+    const target = 'some-target';
+    const buildCommand = 'build';
+    const cliBuildCommand = {
+      generate: jest.fn(() => buildCommand),
+    };
+    const targets = {
+      getTarget: jest.fn(() => ({ name: target })),
+    };
+    const unknownOptName = 'name';
+    const unknownOptValue = 'Rosario';
+    const unknownOptions = {
+      target: 'someTarget',
+      [unknownOptName]: unknownOptValue,
+    };
+    let sut = null;
+    // When
+    sut = new CLISHRunCommand(cliBuildCommand, targets);
+    sut.handle(target, null, null, unknownOptions);
+    // Then
+    expect(targets.getTarget).toHaveBeenCalledTimes(1);
+    expect(targets.getTarget).toHaveBeenCalledWith(target);
+    expect(cliBuildCommand.generate).toHaveBeenCalledTimes(1);
+    expect(cliBuildCommand.generate).toHaveBeenCalledWith({
+      target,
+      type: 'development',
+      run: true,
+      [unknownOptName]: unknownOptValue,
     });
     expect(sut.output).toHaveBeenCalledTimes(1);
     expect(sut.output).toHaveBeenCalledWith(buildCommand);


### PR DESCRIPTION
### What does this PR do?

Now, plugins and/or other services can extend the build and run commands by including custom options when generating them.

For example, the running plugin will (soon) do this:

```js
cliBuildCommand.generate({
  target: 'some-target',
  plugin: 'projext-plugin-runner',
});
```

This would generate something like this:

```bash
projext build some-target --plugin projext-plugin-runner
```

Also, reducer events like `build-target-commands-list` will receive a new parameter will all the options that the command didn't recognize (like `plugin` from the previous example).

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
