### PR TITLE
Add new settings

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -88,6 +88,8 @@ Since there are a lot of settings for the templates, will divide them by type an
   folder: '',
   entry: { ... },
   output: { ... },
+  css: { ... },
+  includeModules: [],
   runOnDevelopment: false,
   babel: { ... },
   flow: false,
@@ -176,6 +178,30 @@ You can use the following placeholders:
 - `[name]`: The file original name (Not available for `css` and `js`).
 - `[ext]`: The file original extension (Not available for `css` and `js`).
 
+#### `css`
+> Default value:
+>
+> ```js
+> {
+>   modules: false,
+> }
+> ```
+
+These options help you customize the way the bundling process handles your CSS code.
+
+**`css.modules`**
+
+Whether or not your application uses [CSS Modules](https://github.com/css-modules/css-modules). If this is enabled, all your styles will be prefixed with a unique identifier.
+
+#### `includeModules`
+> Default value: `[]`
+
+This setting can be used to specify a list of node modules you want to process on your bundle.
+
+For example, let's say you are using a library that exports a native `Class` that you are `extend`ing, but you are transpiling for a browser that doesn't support native `Class`es; you can add the name of the module on this setting and projext will include it on its bundling process and transpile it if needed.
+
+> At the end of the process, those names are converted to regular expressions, so you can also make the name a expression, while escaping especial characters of course.
+
 #### `runOnDevelopment`
 > Default value: `false`
 
@@ -255,10 +281,11 @@ Whether or not to remove all code from previous builds from the distribution dir
   output: { ... },
   sourceMap: { ... },
   html: { ... },
+  css: { ... },
+  includeModules: [],
   runOnDevelopment: false,
   babel: { ... },
   flow: false,
-  CSSModules: false,
   library: false,
   libraryOptions: { ... },
   cleanBeforeBuild: true,
@@ -369,6 +396,35 @@ The file inside your target source that will be used to generate the `html`.
 
 The file that will be generated when your target is bundled. It will automatically include the `<script />` tag to the generated bundle.
 
+#### `css`
+> Default value:
+>
+> ```js
+> {
+>   modules: false,
+>   inject: false,
+> }
+> ```
+
+These options help you customize the way the bundling process handles your CSS code.
+
+**`css.modules`**
+
+Whether or not your application uses [CSS Modules](https://github.com/css-modules/css-modules). If this is enabled, all your styles will be prefixed with a unique identifier.
+
+**`css.inject`**
+
+If this setting is set to `true`, instead of generating a CSS file with your styles, they'll be dynamically injected on HTML when the bundle gets executed.
+
+#### `includeModules`
+> Default value: `[]`
+
+This setting can be used to specify a list of node modules you want to process on your bundle.
+
+For example, let's say you are using a library that exports a native `Class` that you are `extend`ing, but you are transpiling for a browser that doesn't support native `Class`es; you can add the name of the module on this setting and projext will include it on its bundling process and transpile it if needed.
+
+> At the end of the process, those names are converted to regular expressions, so you can also make the name a expression, while escaping especial characters of course.
+
 #### `runOnDevelopment`
 > Default value: `false`
 
@@ -417,11 +473,6 @@ If you know how to use Babel and need stuff that is not covered by projext, you 
 > Default value: `false`
 
 Whether or not your target uses [flow](https://flow.org/). This will update the Babel configuration in order to add support for it.
-
-#### `CSSModules`
-> Default value: `false`
-
-Whether or not your application uses CSS Modules.
 
 #### `library`
 > Default value: `false`

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -68,6 +68,10 @@ class ProjectConfiguration extends ConfigurationFile {
             },
             production: null,
           },
+          css: {
+            modules: false,
+          },
+          includeModules: [],
           runOnDevelopment: false,
           babel: {
             features: [],
@@ -116,6 +120,11 @@ class ProjectConfiguration extends ConfigurationFile {
             template: null,
             filename: null,
           },
+          css: {
+            modules: false,
+            inject: false,
+          },
+          includeModules: [],
           runOnDevelopment: false,
           babel: {
             features: [],
@@ -125,7 +134,6 @@ class ProjectConfiguration extends ConfigurationFile {
             overwrites: {},
           },
           flow: false,
-          CSSModules: false,
           hot: false,
           library: false,
           libraryOptions: {

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -199,6 +199,13 @@
  */
 
 /**
+ * @typedef {Object} ProjectConfigurationNodeTargetTemplateCSSSettings
+ * @property {boolean} [modules=false]
+ * Whether or not your application uses CSS Modules. If this is enabled, all your styles will be
+ * prefixed with a unique identifier.
+ */
+
+/**
  * ================================================================================================
  * Project configuration > Targets templates > Sub properties > Browser
  * ================================================================================================
@@ -225,6 +232,16 @@
  * The file that will be generated when your target is bundled. It will automatically include
  * the `<script />` tag to the generated bundle. If `null`, it will fallback to the value of the
  * `default` setting.
+ */
+
+/**
+ * @typedef {Object} ProjectConfigurationBrowserTargetTemplateCSSSettings
+ * @property {boolean} [modules=false]
+ * Whether or not your application uses CSS Modules. If this is enabled, all your styles will be
+ * prefixed with a unique identifier.
+ * @property {boolean} [inject=false]
+ * If this setting is set to `true`, instead of generating a CSS file with your styles, they'll be
+ * dynamically injected on HTML when the bundle gets executed.
  */
 
 /**
@@ -349,6 +366,11 @@
  * The target entry files for each specific build type.
  * @property {ProjectConfigurationTargetTemplateOutput} [output]
  * The target output settings for each specific build type.
+ * @property {ProjectConfigurationNodeTargetTemplateCSSSettings} [css]
+ * These options help you customize the way the bundling process handles your CSS code.
+ * @property {Array} [includeModules=[]]
+ * This setting can be used to specify a list of node modules you want to process on your bundle.
+ * This means that JS files from modules on this list will be transpiled.
  * @property {boolean} [runOnDevelopment=false]
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
@@ -397,6 +419,11 @@
  * The target output settings for each specific build type.
  * @property {ProjectConfigurationTargetTemplateOutput} originalOutput
  * The target output settings for each specific build type, without the placeholders replaced.
+ * @property {ProjectConfigurationNodeTargetTemplateCSSSettings} css
+ * These options help you customize the way the bundling process handles your CSS code.
+ * @property {Array} includeModules
+ * This setting can be used to specify a list of node modules you want to process on your bundle.
+ * This means that JS files from modules on this list will be transpiled.
  * @property {boolean} runOnDevelopment
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
@@ -453,6 +480,11 @@
  * @property {ProjectConfigurationBrowserTargetTemplateHTMLSettings} [html]
  * In the case the target is an app, these are the options for the `html` file that will include
  * the bundle `<script />`; and if your target is a library, this can be used to test your library.
+ * @property {ProjectConfigurationBrowserTargetTemplateCSSSettings} [css]
+ * These options help you customize the way the bundling process handles your CSS code.
+ * @property {Array} [includeModules=[]]
+ * This setting can be used to specify a list of node modules you want to process on your bundle.
+ * This means that JS files from modules on this list will be transpiled.
  * @property {boolean} [runOnDevelopment=false]
  * This will tell the build engine that when you build the target for a development environment,
  * it should bring up an `http` server to _"run"_ your target.
@@ -461,8 +493,6 @@
  * @property {boolean} [flow=false]
  * Whether or not your target uses [flow](https://flow.org/). This will update the Babel
  * configuration in order to add support for it.
- * @property {boolean} [CSSModules=false]
- * Whether or not your application uses CSS Modules.
  * @property {boolean} [library=false]
  * This will tell the build engine that it needs to be builded as a library to be `require`d.
  * @property {ProjectConfigurationBrowserTargetTemplateLibraryOptions} [libraryOptions]
@@ -504,6 +534,11 @@
  * @property {ProjectConfigurationBrowserTargetTemplateHTMLSettings} html
  * In the case the target is an app, these are the options for the `html` file that will include
  * the bundle `<script />`; and if your target is a library, this can be used to test your library.
+ * @property {ProjectConfigurationBrowserTargetTemplateCSSSettings} css
+ * These options help you customize the way the bundling process handles your CSS code.
+ * @property {Array} includeModules
+ * This setting can be used to specify a list of node modules you want to process on your bundle.
+ * This means that JS files from modules on this list will be transpiled.
  * @property {boolean} runOnDevelopment
  * This will tell the build engine that when you build the target for a development environment,
  * it should bring up an `http` server to _"run"_ your target.


### PR DESCRIPTION
### What does this PR do?

This PR doesn't actually add any new executable code but just documents some changes on the project settings.

> The actual code that implements this will come from the build engines.

#### No more `CSSModules`, welcome `css`

Since I was adding a new setting related to CSS, it didn't have a lot of sense to have the two of them by themselves on the target settings, so I created a new settings group called `css` and moved them there:

```diff
{
- CSSModules: false,
+ css: {
+   modules: false,
+   inject: false,
+ }
}
```

#### New `css.inject` setting

For those working on really tiny apps where the amount of CSS don't justify an extra request, well, now you can turn this setting to `true` and the styles will be automatically injected on `html>head>style` when the bundle gets executed.

#### `css` settings for the Node targets

Since Node targets can now generate stylesheets (#8), I've added the `css` setting on the `targetsTemplates.node` object, but different from the browser targets, they only have the `modules` option, since it doesn't make sense for a Node app.

#### New `includeModules` setting

Both target types have this new setting and it can be used to specify a list of Node modules that you need to process on your bundle. The example from the documentation will explain it better:

> Let's say you are using a library that exports a native `Class` that you are `extend`ing, but you are transpiling for a browser that doesn't support native `Class`es; you can add the name of the module on this setting and projext will include it on its bundling process and transpile it if needed.

### How should it be tested manually?

Reading?
