### PR TITLE
Small fixes and changes

### DIFF
--- a/documents/cli.md
+++ b/documents/cli.md
@@ -34,9 +34,10 @@ projext run [target]
 Removes the files from previous builds from the distribution directory.
 
 ```bash
-projext clean [target]
+projext clean [target] [--all]
 ```
-- **target:** The name of the target you intend to remove builds from. If no target is specified, the build directory will be deleted.
+- **target:** The name of the target you intend to remove builds from. If no target is specified, projext will try to use the default target (the one with the project's name or the first on an alphabetical list).
+- **all:** Instead of just removing a target files, it removes the entire distribution directory.
 
 > This gets automatically called when building if the target `cleanBeforeBuild` setting is `true`.
 

--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -156,12 +156,12 @@ This object is the one that tells projext which is the main file (executable) of
 > {
 >   default: {
 >     js: '[target-name].js',
->     fonts: 'statics/fonts/[name].[hash].[ext]',
+>     fonts: 'statics/fonts/[name]/[name].[hash].[ext]',
 >     css: 'statics/styles/[target-name].[hash].css',
 >     images: 'statics/images/[name].[hash].[ext]',
 >   },
 >   development: {
->     fonts: 'statics/fonts/[name].[ext]',
+>     fonts: 'statics/fonts/[name]/[name].[ext]',
 >     css: 'statics/styles/[target-name].css',
 >     images: 'statics/images/[name].[ext]',
 >   },
@@ -336,13 +336,13 @@ This object is the one that tells projext which is the main file (the one that f
 > {
 >   default: {
 >     js: 'statics/js/[target-name].[hash].js',
->     fonts: 'statics/fonts/[name].[hash].[ext]',
+>     fonts: 'statics/fonts/[name]/[name].[hash].[ext]',
 >     css: 'statics/styles/[target-name].[hash].css',
 >     images: 'statics/images/[name].[hash].[ext]',
 >   },
 >   development: {
 >     js: 'statics/js/[target-name].js',
->     fonts: 'statics/fonts/[name].[ext]',
+>     fonts: 'statics/fonts/[name]/[name].[ext]',
 >     css: 'statics/styles/[target-name].css',
 >     images: 'statics/images/[name].[ext]',
 >   },

--- a/src/abstracts/cliCommand.js
+++ b/src/abstracts/cliCommand.js
@@ -226,8 +226,11 @@ class CLICommand {
           // ...add it to the list.
           cmdOptions.push(instruction);
         }
-      } else {
-        // Finally, if is not on the command options, just add it.
+      } else if (this.allowUnknownOptions) {
+        /**
+         * Finally, if is not on the command options and the command supports unknown options,
+         * just add it.
+         */
         let instruction = `--${name}`;
         // If the option is not a flag, add its value.
         if (value !== true) {

--- a/src/abstracts/cliSubCommand.js
+++ b/src/abstracts/cliSubCommand.js
@@ -1,26 +1,25 @@
 /**
- * A helper class for creating generator commands for the CLI. A generator command works like a
- * {@link CLICommand} inside a regular {@link CLICommand}. It has a resource type that is in charge
- * of generating and it supports options for customzation.
+ * A helper class for creating sub commands for the CLI. A sub command works like a
+ * {@link CLICommand} inside a regular {@link CLICommand}.
  * @abstract
  */
-class CLIGeneratorSubCommand {
+class CLISubCommand {
   /**
    * Class constructor.
    * @throws {TypeError} If instantiated directly.
    * @abstract
    */
   constructor() {
-    if (new.target === CLIGeneratorSubCommand) {
+    if (new.target === CLISubCommand) {
       throw new TypeError(
-        'CLIGeneratorSubCommand is an abstract class, it can\'t be instantiated directly'
+        'CLISubCommand is an abstract class, it can\'t be instantiated directly'
       );
     }
     /**
-     * An identifier for the resource the generator creates.
+     * The name of the sub command for the help interface.
      * @type {string}
      */
-    this.resource = '';
+    this.name = '';
     /**
      * A short description for what the generator does.
      * @type {string}
@@ -73,13 +72,13 @@ class CLIGeneratorSubCommand {
     this.options.push(name);
   }
   /**
-   * Generate a complete description of the generator and its options in order to be used on the
+   * Generates a complete description of the sub command and its options in order to be used on the
    * help interface of the {@link CLICommand} that implements it.
    * @return {string}
    */
   getHelpInformation() {
     // Define the basic description line.
-    let description = ` - '${this.resource}': ${this.description}`;
+    let description = ` - '${this.name}': ${this.description}`;
     // If the generator has options...
     if (this.options.length) {
       // ...add the options subtitle.
@@ -114,15 +113,14 @@ class CLIGeneratorSubCommand {
     return description;
   }
   /**
-   * The method called by the {@link CLICommand} that implements the generator in order to create
-   * the resource.
+   * The method called by the {@link CLICommand} that implements the sub command.
    * It receives a dicitionary with the parsed options the command received.
-   * @return {Promise<undefined,Error>}
+   * @throws {Error} if not overwritten.
    * @abstract
    */
-  generate() {
-    return Promise.reject(Error('This method must to be overwritten'));
+  handle() {
+    throw new Error('This method must to be overwritten');
   }
 }
 
-module.exports = CLIGeneratorSubCommand;
+module.exports = CLISubCommand;

--- a/src/services/building/builder.js
+++ b/src/services/building/builder.js
@@ -114,11 +114,14 @@ class Builder {
   }
   /**
    * Removes all previous builds/copies of a target from the distribution directory.
-   * @param {string} targetName The name of the target.
+   * @param {string|target} targetName The name of the target, or the target itself.
    * @return {Promise<undefined,Error>}
    */
   cleanTarget(targetName) {
-    const target = this.targets.getTarget(targetName);
+    const target = typeof targetName === 'string' ?
+      this.targets.getTarget(targetName) :
+      targetName;
+
     return this.buildCleaner.cleanTarget(target);
   }
 }

--- a/src/services/cli/cliGenerate.js
+++ b/src/services/cli/cliGenerate.js
@@ -2,7 +2,7 @@ const { provider } = require('jimple');
 const CLICommand = require('../../abstracts/cliCommand');
 /**
  * This commands allows the user to generate new projext resources by makeing use of _"generators"_,
- * which are subclasses of {@link CLIGeneratorSubCommand}.
+ * which are subclasses of {@link CLISubCommand}.
  * @extends {CLICommand}
  */
 class CLIGenerateCommand extends CLICommand {
@@ -39,12 +39,12 @@ class CLIGenerateCommand extends CLICommand {
   /**
    * Add the list of generators this command can use. After saving the reference to the services,
    * this method will also update the `fullDescription` property with the generators information.
-   * @param {Array} generators A list of {@link CLIGeneratorSubCommand} services.
+   * @param {Array} generators A list of {@link CLISubCommand} services.
    */
   addGenerators(generators) {
     // Register the generators on the local property.
     generators.forEach((generator) => {
-      this.generators[generator.resource] = generator;
+      this.generators[generator.name] = generator;
     });
     // Set an empty description.
     let descriptionList = '';
@@ -73,7 +73,7 @@ class CLIGenerateCommand extends CLICommand {
     } else {
       const generator = this.generators[resource];
       const generatorOptions = this._parseGeneratorOptions(generator, unknownOptions);
-      result = generator.generate(generatorOptions);
+      result = generator.handle(generatorOptions);
     }
 
     return result;
@@ -82,8 +82,8 @@ class CLIGenerateCommand extends CLICommand {
    * This method is called when the command is executed and it takes care of parse and match the
    * received unkown options with the selected generator options, so they can be sent to the
    * generator.
-   * @param {CLIGeneratorSubCommand} generator The generator from which options will be matched.
-   * @param {Object}                 options   A dictionary of unkown options the command received.
+   * @param {CLISubCommand} generator The generator from which options will be matched.
+   * @param {Object}        options   A dictionary of unkown options the command received.
    * @return {Object}
    * @ignore
    * @access protected

--- a/src/services/cli/generators/projectConfigurationFile.js
+++ b/src/services/cli/generators/projectConfigurationFile.js
@@ -1,13 +1,13 @@
 const extend = require('extend');
 const fs = require('fs-extra');
 const { provider } = require('jimple');
-const CLIGeneratorSubCommand = require('../../../abstracts/cliGeneratorSubCommand');
+const CLISubCommand = require('../../../abstracts/cliSubCommand');
 /**
  * This is a CLI generator that allows the user to create a configuration file with all the
  * default settings and all the information projext assumes about the project.
- * @extends {CLIGeneratorSubCommand}
+ * @extends {CLISubCommand}
  */
-class ProjectConfigurationFileGenerator extends CLIGeneratorSubCommand {
+class ProjectConfigurationFileGenerator extends CLISubCommand {
   /**
    * Class constructor.
    * @param {Logger}                       appLogger            To inform the user when the file
@@ -54,7 +54,7 @@ class ProjectConfigurationFileGenerator extends CLIGeneratorSubCommand {
      * generator.
      * @type {string}
      */
-    this.resource = 'config';
+    this.name = 'config';
     /**
      * A short description of what the generator does.
      * @type {string}
@@ -104,7 +104,7 @@ class ProjectConfigurationFileGenerator extends CLIGeneratorSubCommand {
    *                                  ignore.
    * @return {Promise<undefined,Error>}
    */
-  generate(options = {}) {
+  handle(options = {}) {
     // Define the variable for the promise that will be returned.
     let result;
     // Define the variable for the object that will contain the settings to write.

--- a/src/services/cli/generators/targetHTML.js
+++ b/src/services/cli/generators/targetHTML.js
@@ -1,14 +1,14 @@
 const path = require('path');
 const fs = require('fs-extra');
 const { provider } = require('jimple');
-const CLIGeneratorSubCommand = require('../../../abstracts/cliGeneratorSubCommand');
+const CLISubCommand = require('../../../abstracts/cliSubCommand');
 /**
  * This is a CLI generator that allows the user to create an HTML file for a browser target.
  * What it does is to force projext to create the default HTML file it would create if the target
  * didn't have one and then it moves it to the target directory.
- * @extends {CLIGeneratorSubCommand}
+ * @extends {CLISubCommand}
  */
-class TargetHTMLGenerator extends CLIGeneratorSubCommand {
+class TargetHTMLGenerator extends CLISubCommand {
   /**
    * Class constructor.
    * @param {Logger}      appLogger   To inform the user when the file has been generated, or if
@@ -44,7 +44,7 @@ class TargetHTMLGenerator extends CLIGeneratorSubCommand {
      * generator.
      * @type {string}
      */
-    this.resource = 'html';
+    this.name = 'html';
     /**
      * A short description of what the generator does.
      * @type {string}
@@ -57,7 +57,7 @@ class TargetHTMLGenerator extends CLIGeneratorSubCommand {
    * finally moves it to the selected path.
    * @return {Promise<undefined,Error>}
    */
-  generate() {
+  handle() {
     // Get the _"default browser target"_.
     const defaultTarget = this.targets.getDefaultTarget('browser');
     // Define the prompt schema.

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -57,12 +57,12 @@ class ProjectConfiguration extends ConfigurationFile {
           output: {
             default: {
               js: '[target-name].js',
-              fonts: 'statics/fonts/[name].[hash].[ext]',
+              fonts: 'statics/fonts/[name]/[name].[hash].[ext]',
               css: 'statics/styles/[target-name].[hash].css',
               images: 'statics/images/[name].[hash].[ext]',
             },
             development: {
-              fonts: 'statics/fonts/[name].[ext]',
+              fonts: 'statics/fonts/[name]/[name].[ext]',
               css: 'statics/styles/[target-name].css',
               images: 'statics/images/[name].[ext]',
             },
@@ -99,13 +99,13 @@ class ProjectConfiguration extends ConfigurationFile {
           output: {
             default: {
               js: 'statics/js/[target-name].[hash].js',
-              fonts: 'statics/fonts/[name].[hash].[ext]',
+              fonts: 'statics/fonts/[name]/[name].[hash].[ext]',
               css: 'statics/styles/[target-name].[hash].css',
               images: 'statics/images/[name].[hash].[ext]',
             },
             development: {
               js: 'statics/js/[target-name].js',
-              fonts: 'statics/fonts/[name].[ext]',
+              fonts: 'statics/fonts/[name]/[name].[ext]',
               css: 'statics/styles/[target-name].css',
               images: 'statics/images/[name].[ext]',
             },

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -143,8 +143,8 @@
  * - `[hash]`: A random hash generated for cache busting.
  *
  * The default value is, for both `node` and `browser` targets:
- * - `development`: `'statics/fonts/[name][ext]'`.
- * - `production`: `'statics/fonts/[name].[hash].[ext]'`.
+ * - `development`: `'statics/fonts/[name]/[name][ext]'`.
+ * - `production`: `'statics/fonts/[name]/[name].[hash].[ext]'`.
  * @property {string} [fonts]
  * The path to image files once they are copied to the distribution directory.
  *

--- a/tests/abstracts/cliCommand.test.js
+++ b/tests/abstracts/cliCommand.test.js
@@ -415,6 +415,7 @@ describe('abstracts:CLICommand', () => {
     const command = 'test-command';
     const description = 'Test description';
     const subProgram = true;
+    const allowUnknownOptions = true;
     const unknownOptName = 'plugin';
     const unknownOptValue = 'pluginName';
     const unknownFlag = 'flagish';
@@ -432,6 +433,60 @@ describe('abstracts:CLICommand', () => {
     sut.command = command;
     sut.description = description;
     sut.subProgram = subProgram;
+    sut.allowUnknownOptions = allowUnknownOptions;
+    sut.addOption(option.name, option.instruction);
+    sut.register(program, cli);
+    result = sut.generate(generateOptions);
+    // Then
+    expect(sut.cliName).toBe(cli.name);
+    expect(program.command).toHaveBeenCalledTimes(1);
+    expect(program.command).toHaveBeenCalledWith(command, description, {});
+    expect(program.description).toHaveBeenCalledTimes(0);
+    expect(program.action).toHaveBeenCalledTimes(1);
+    expect(program.action).toHaveBeenCalledWith(expect.any(Function));
+    expect(result).toBe(`${cli.name} ${command} ${expectedOptions}`);
+  });
+
+  it('shouldn\'t include unknown options on a generated command if they are not supported', () => {
+    // Given
+    const program = {
+      command: jest.fn(() => program),
+      description: jest.fn(() => program),
+      option: jest.fn(() => program),
+      action: jest.fn(() => program),
+      on: jest.fn(),
+      allowUnknownOption: jest.fn(),
+    };
+    const cli = {
+      name: 'some-program',
+    };
+    const option = {
+      name: 'env',
+      instruction: '-e, --env [env]',
+    };
+    const env = 'charito';
+    const command = 'test-command';
+    const description = 'Test description';
+    const subProgram = true;
+    const allowUnknownOptions = false;
+    const unknownOptName = 'plugin';
+    const unknownOptValue = 'pluginName';
+    const unknownFlag = 'flagish';
+    const generateOptions = {
+      env,
+      [unknownOptName]: unknownOptValue,
+      [unknownFlag]: true,
+    };
+    class Sut extends CLICommand {}
+    let sut = null;
+    let result = '';
+    const expectedOptions = `--env ${env}`;
+    // When
+    sut = new Sut();
+    sut.command = command;
+    sut.description = description;
+    sut.subProgram = subProgram;
+    sut.allowUnknownOptions = allowUnknownOptions;
     sut.addOption(option.name, option.instruction);
     sut.register(program, cli);
     result = sut.generate(generateOptions);

--- a/tests/abstracts/cliSubCommand.test.js
+++ b/tests/abstracts/cliSubCommand.test.js
@@ -1,24 +1,24 @@
-jest.unmock('/src/abstracts/cliGeneratorSubCommand');
+jest.unmock('/src/abstracts/cliSubCommand');
 
 require('jasmine-expect');
-const CLIGeneratorSubCommand = require('/src/abstracts/cliGeneratorSubCommand');
+const CLISubCommand = require('/src/abstracts/cliSubCommand');
 
-describe('abstracts:CLIGeneratorSubCommand', () => {
+describe('abstracts:CLISubCommand', () => {
   it('should throw an error if used without subclassing it', () => {
     // Given/When/Then
-    expect(() => new CLIGeneratorSubCommand())
-    .toThrow(/CLIGeneratorSubCommand is an abstract class/i);
+    expect(() => new CLISubCommand())
+    .toThrow(/CLISubCommand is an abstract class/i);
   });
 
   it('should be able to be instantiated when subclassed', () => {
     // Given
-    class Sut extends CLIGeneratorSubCommand {}
+    class Sut extends CLISubCommand {}
     let sut = null;
     // When
     sut = new Sut();
     // Then
     expect(sut).toBeInstanceOf(Sut);
-    expect(sut).toBeInstanceOf(CLIGeneratorSubCommand);
+    expect(sut).toBeInstanceOf(CLISubCommand);
   });
 
   it('should be able to register new options', () => {
@@ -39,7 +39,7 @@ describe('abstracts:CLIGeneratorSubCommand', () => {
       defaultValue: true,
     };
     const numberOfOptions = 3;
-    class Sut extends CLIGeneratorSubCommand {}
+    class Sut extends CLISubCommand {}
     let sut = null;
     // When
     sut = new Sut();
@@ -76,15 +76,15 @@ describe('abstracts:CLIGeneratorSubCommand', () => {
 
   it('should be able to generate a help for the CLI', () => {
     // Given
-    const resource = 'my-resource';
+    const name = 'my-name';
     const description = 'Something';
-    class Sut extends CLIGeneratorSubCommand {}
+    class Sut extends CLISubCommand {}
     let sut = null;
     let result = null;
-    const expectedDescription = ` - '${resource}': ${description}`;
+    const expectedDescription = ` - '${name}': ${description}`;
     // When
     sut = new Sut();
-    sut.resource = resource;
+    sut.name = name;
     sut.description = description;
     result = sut.getHelpInformation();
     // Then
@@ -108,19 +108,19 @@ describe('abstracts:CLIGeneratorSubCommand', () => {
       instruction: '-b, --build',
       description: 'Set the build',
     };
-    const resource = 'my-resource';
+    const name = 'my-name';
     const description = 'Something';
-    class Sut extends CLIGeneratorSubCommand {}
+    class Sut extends CLISubCommand {}
     let sut = null;
     let result = null;
-    const expectedDescription = ` - '${resource}': ${description}` +
+    const expectedDescription = ` - '${name}': ${description}` +
       '\n   Options:\n' +
       `\n   -t, --type [type]  ${optionOne.description}` +
       `\n   -e, --env [env]    ${optionTwo.description}` +
       `\n   -b, --build        ${optionThree.description}`;
     // When
     sut = new Sut();
-    sut.resource = resource;
+    sut.name = name;
     sut.description = description;
     sut.addOption(optionOne.name, optionOne.instruction, optionOne.description);
     sut.addOption(optionTwo.name, optionTwo.instruction, optionTwo.description);
@@ -130,19 +130,12 @@ describe('abstracts:CLIGeneratorSubCommand', () => {
     expect(result).toBe(expectedDescription);
   });
 
-  it('should throw an error if the `generate` method is not overwritten', () => {
+  it('should throw an error if the `handle` method is not overwritten', () => {
     // Given
-    class Sut extends CLIGeneratorSubCommand {}
+    class Sut extends CLISubCommand {}
     let sut = null;
     // When/Then
     sut = new Sut();
-    return sut.generate()
-    .then(() => {
-      expect(true).toBeFalse();
-    })
-    .catch((result) => {
-      expect(result).toBeInstanceOf(Error);
-      expect(result.message).toMatch(/This method must to be overwritten/i);
-    });
+    expect(() => sut.handle()).toThrow(/This method must to be overwritten/i);
   });
 });

--- a/tests/mocks/cliSubCommand.mock.js
+++ b/tests/mocks/cliSubCommand.mock.js
@@ -3,7 +3,7 @@ const mocks = {
   addOption: jest.fn(),
 };
 
-class CLIGeneratorSubCommandMock {
+class CLISubCommandMock {
   static mock(name, mock) {
     mocks[name] = mock;
   }
@@ -21,4 +21,4 @@ class CLIGeneratorSubCommandMock {
   }
 }
 
-module.exports = CLIGeneratorSubCommandMock;
+module.exports = CLISubCommandMock;

--- a/tests/services/building/builder.test.js
+++ b/tests/services/building/builder.test.js
@@ -386,7 +386,7 @@ describe('services/building:builder', () => {
     });
   });
 
-  it('should clean a target files', () => {
+  it('should clean a target files using the target name', () => {
     // Given
     const buildCleaner = {
       cleanTarget: jest.fn(),
@@ -418,6 +418,41 @@ describe('services/building:builder', () => {
     // Then
     expect(targets.getTarget).toHaveBeenCalledTimes(1);
     expect(targets.getTarget).toHaveBeenCalledWith(target.name);
+    expect(buildCleaner.cleanTarget).toHaveBeenCalledTimes(1);
+    expect(buildCleaner.cleanTarget).toHaveBeenCalledWith(target);
+  });
+
+  it('should clean a target files using the target information', () => {
+    // Given
+    const buildCleaner = {
+      cleanTarget: jest.fn(),
+    };
+    const buildCopier = 'buildCopier';
+    const buildEngines = 'buildEngines';
+    const buildTranspiler = 'buildTranspiler';
+    const target = {
+      name: 'some-target',
+      bundle: false,
+      transpile: true,
+      is: {
+        node: true,
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(),
+    };
+    let sut = null;
+    // When
+    sut = new Builder(
+      buildCleaner,
+      buildCopier,
+      buildEngines,
+      buildTranspiler,
+      targets
+    );
+    sut.cleanTarget(target);
+    // Then
+    expect(targets.getTarget).toHaveBeenCalledTimes(0);
     expect(buildCleaner.cleanTarget).toHaveBeenCalledTimes(1);
     expect(buildCleaner.cleanTarget).toHaveBeenCalledWith(target);
   });

--- a/tests/services/cli/cliClean.test.js
+++ b/tests/services/cli/cliClean.test.js
@@ -20,19 +20,28 @@ describe('services/cli:clean', () => {
     // Given
     const builder = 'builder';
     const buildCleaner = 'buildCleaner';
+    const targets = 'targets';
     let sut = null;
     // When
-    sut = new CLICleanCommand(builder, buildCleaner);
+    sut = new CLICleanCommand(builder, buildCleaner, targets);
     // Then
     expect(sut).toBeInstanceOf(CLICleanCommand);
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.builder).toBe(builder);
     expect(sut.buildCleaner).toBe(buildCleaner);
+    expect(sut.targets).toBe(targets);
     expect(sut.command).not.toBeEmptyString();
     expect(sut.description).not.toBeEmptyString();
+    expect(sut.addOption).toHaveBeenCalledTimes(1);
+    expect(sut.addOption).toHaveBeenCalledWith(
+      'all',
+      '-a, --all',
+      expect.any(String),
+      false
+    );
   });
 
-  it('should call the method to clean a target files if it receives a target name', () => {
+  it('should call the method to clean a target', () => {
     // Given
     const target = 'some-target';
     const message = 'done';
@@ -40,29 +49,54 @@ describe('services/cli:clean', () => {
       cleanTarget: jest.fn(() => message),
     };
     const buildCleaner = 'buildCleaner';
+    const targets = 'targets';
     let sut = null;
     let result = null;
     // When
-    sut = new CLICleanCommand(builder, buildCleaner);
-    result = sut.handle(target);
+    sut = new CLICleanCommand(builder, buildCleaner, targets);
+    result = sut.handle(target, null, {});
     // Then
     expect(result).toBe(message);
     expect(builder.cleanTarget).toHaveBeenCalledTimes(1);
     expect(builder.cleanTarget).toHaveBeenCalledWith(target);
   });
 
-  it('should call the method to clean everything if no target name is received', () => {
+  it('should clean the default target if no target name is received', () => {
+    // Given
+    const target = 'some-target';
+    const message = 'done';
+    const builder = {
+      cleanTarget: jest.fn(() => message),
+    };
+    const buildCleaner = 'buildCleaner';
+    const targets = {
+      getDefaultTarget: jest.fn(() => target),
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new CLICleanCommand(builder, buildCleaner, targets);
+    result = sut.handle(null, null, {});
+    // Then
+    expect(result).toBe(message);
+    expect(targets.getDefaultTarget).toHaveBeenCalledTimes(1);
+    expect(builder.cleanTarget).toHaveBeenCalledTimes(1);
+    expect(builder.cleanTarget).toHaveBeenCalledWith(target);
+  });
+
+  it('should call the method to clean everything the `all` flag is used', () => {
     // Given
     const message = 'done';
     const builder = 'builder';
     const buildCleaner = {
       cleanAll: jest.fn(() => message),
     };
+    const targets = 'targets';
     let sut = null;
     let result = null;
     // When
-    sut = new CLICleanCommand(builder, buildCleaner);
-    result = sut.handle();
+    sut = new CLICleanCommand(builder, buildCleaner, targets);
+    result = sut.handle(null, null, { all: true });
     // Then
     expect(result).toBe(message);
     expect(buildCleaner.cleanAll).toHaveBeenCalledTimes(1);
@@ -87,5 +121,6 @@ describe('services/cli:clean', () => {
     expect(sut).toBeInstanceOf(CLICleanCommand);
     expect(sut.builder).toBe('builder');
     expect(sut.buildCleaner).toBe('buildCleaner');
+    expect(sut.targets).toBe('targets');
   });
 });

--- a/tests/services/cli/cliGenerate.test.js
+++ b/tests/services/cli/cliGenerate.test.js
@@ -32,12 +32,12 @@ describe('services/cli:generate', () => {
   it('should register new generators', () => {
     // Given
     const generatorOne = {
-      resource: 'js',
+      name: 'js',
       description: 'generatorOneDescription',
       getHelpInformation: jest.fn(() => generatorOne.description),
     };
     const generatorTwo = {
-      resource: 'jsx',
+      name: 'jsx',
       description: 'generatorTwoDescription',
       getHelpInformation: jest.fn(() => generatorTwo.description),
     };
@@ -50,9 +50,9 @@ describe('services/cli:generate', () => {
     sut = new CLIGenerateCommand();
     sut.addGenerators(generators);
     // Then
-    expect(sut.generators[generatorOne.resource]).toEqual(generatorOne);
+    expect(sut.generators[generatorOne.name]).toEqual(generatorOne);
     expect(generatorOne.getHelpInformation).toHaveBeenCalledTimes(1);
-    expect(sut.generators[generatorTwo.resource]).toEqual(generatorTwo);
+    expect(sut.generators[generatorTwo.name]).toEqual(generatorTwo);
     expect(generatorTwo.getHelpInformation).toHaveBeenCalledTimes(1);
     expect(sut.fullDescription).toBe(expectedDescription);
   });
@@ -74,9 +74,9 @@ describe('services/cli:generate', () => {
     };
     const message = 'Done!';
     const generator = {
-      resource: 'js',
+      name: 'js',
       getHelpInformation: jest.fn(() => 'description'),
-      generate: jest.fn(() => message),
+      handle: jest.fn(() => message),
       optionsByName: generatorOptions,
       options: Object.keys(generatorOptions),
     };
@@ -90,11 +90,11 @@ describe('services/cli:generate', () => {
     // When
     sut = new CLIGenerateCommand();
     sut.addGenerators([generator]);
-    result = sut.handle(generator.resource, {}, {}, unknownOptions);
+    result = sut.handle(generator.name, {}, {}, unknownOptions);
     // Then
     expect(result).toBe(message);
-    expect(generator.generate).toHaveBeenCalledTimes(1);
-    expect(generator.generate).toHaveBeenCalledWith({
+    expect(generator.handle).toHaveBeenCalledTimes(1);
+    expect(generator.handle).toHaveBeenCalledWith({
       target: unknownOptions.t,
       buildType: generatorOptions.buildType.defaultValue,
       run: unknownOptions.r,

--- a/tests/services/cli/generators/projectConfigurationFile.test.js
+++ b/tests/services/cli/generators/projectConfigurationFile.test.js
@@ -1,8 +1,8 @@
 const JimpleMock = require('/tests/mocks/jimple.mock');
-const CLIGeneratorSubCommandMock = require('/tests/mocks/cliGeneratorSubCommand.mock');
+const CLISubCommandMock = require('/tests/mocks/cliSubCommand.mock');
 
 jest.mock('jimple', () => JimpleMock);
-jest.mock('/src/abstracts/cliGeneratorSubCommand', () => CLIGeneratorSubCommandMock);
+jest.mock('/src/abstracts/cliSubCommand', () => CLISubCommandMock);
 jest.mock('fs-extra');
 jest.unmock('/src/services/cli/generators/projectConfigurationFile');
 
@@ -16,7 +16,7 @@ const {
 
 describe('services/cli/generators:config', () => {
   beforeEach(() => {
-    CLIGeneratorSubCommandMock.reset();
+    CLISubCommandMock.reset();
     fs.pathExistsSync.mockReset();
     fs.writeFile.mockReset();
   });
@@ -40,7 +40,7 @@ describe('services/cli/generators:config', () => {
     // Then
     expect(sut).toBeInstanceOf(ProjectConfigurationFileGenerator);
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
-    expect(sut.resource).not.toBeEmptyString();
+    expect(sut.name).not.toBeEmptyString();
     expect(sut.description).not.toBeEmptyString();
     expect(sut.appLogger).toBe(appLogger);
     expect(sut.appPrompt).toBe(appPrompt);
@@ -111,7 +111,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       expect(utils.humanReadableList).toHaveBeenCalledTimes(1);
@@ -224,7 +224,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate(options)
+    return sut.handle(options)
     .then(() => {
       // Then
       expect(utils.humanReadableList).toHaveBeenCalledTimes(1);
@@ -331,7 +331,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate(options)
+    return sut.handle(options)
     .then(() => {
       // Then
       expect(utils.humanReadableList).toHaveBeenCalledTimes(1);
@@ -451,7 +451,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate(options)
+    return sut.handle(options)
     .then(() => {
       // Then
       expect(utils.humanReadableList).toHaveBeenCalledTimes(1);
@@ -559,7 +559,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate(options)
+    return sut.handle(options)
     .then(() => {
       // Then
       expect(utils.humanReadableList).toHaveBeenCalledTimes(1);
@@ -660,7 +660,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate(options)
+    return sut.handle(options)
     .then(() => {
       // Then
       expect(utils.humanReadableList).toHaveBeenCalledTimes(1);
@@ -770,7 +770,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       expect(utils.humanReadableList).toHaveBeenCalledTimes(1);
@@ -867,7 +867,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       expect(utils.humanReadableList).toHaveBeenCalledTimes(1);
@@ -960,7 +960,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       expect(utils.humanReadableList).toHaveBeenCalledTimes(1);
@@ -1052,7 +1052,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       expect(true).toBeFalse();
     })
@@ -1139,7 +1139,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate(options)
+    return sut.handle(options)
     .then(() => {
       expect(true).toBeFalse();
     })
@@ -1200,7 +1200,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       [[{ filename: { conform: fileValidation } }]] = appPrompt.ask.mock.calls;
@@ -1255,7 +1255,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       [[{ filename: { before: fileFormatter } }]] = appPrompt.ask.mock.calls;
@@ -1315,7 +1315,7 @@ describe('services/cli/generators:config', () => {
       projectConfiguration,
       utils
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       [[{ overwrite: { ask: overwriteValidation } }]] = appPrompt.ask.mock.calls;

--- a/tests/services/cli/generators/targetHTML.test.js
+++ b/tests/services/cli/generators/targetHTML.test.js
@@ -1,8 +1,8 @@
 const JimpleMock = require('/tests/mocks/jimple.mock');
-const CLIGeneratorSubCommandMock = require('/tests/mocks/cliGeneratorSubCommand.mock');
+const CLISubCommandMock = require('/tests/mocks/cliSubCommand.mock');
 
 jest.mock('jimple', () => JimpleMock);
-jest.mock('/src/abstracts/cliGeneratorSubCommand', () => CLIGeneratorSubCommandMock);
+jest.mock('/src/abstracts/cliSubCommand', () => CLISubCommandMock);
 jest.mock('fs-extra');
 jest.unmock('/src/services/cli/generators/targetHTML');
 
@@ -16,7 +16,7 @@ const {
 
 describe('services/cli/generators:html', () => {
   beforeEach(() => {
-    CLIGeneratorSubCommandMock.reset();
+    CLISubCommandMock.reset();
     fs.pathExistsSync.mockReset();
     fs.move.mockReset();
   });
@@ -38,7 +38,7 @@ describe('services/cli/generators:html', () => {
     // Then
     expect(sut).toBeInstanceOf(TargetHTMLGenerator);
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
-    expect(sut.resource).not.toBeEmptyString();
+    expect(sut.name).not.toBeEmptyString();
     expect(sut.description).not.toBeEmptyString();
     expect(sut.appLogger).toBe(appLogger);
     expect(sut.appPrompt).toBe(appPrompt);
@@ -88,7 +88,7 @@ describe('services/cli/generators:html', () => {
       targets,
       targetsHTML
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       expect(targets.getDefaultTarget).toHaveBeenCalledTimes(1);
@@ -174,7 +174,7 @@ describe('services/cli/generators:html', () => {
       targets,
       targetsHTML
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       expect(targets.getDefaultTarget).toHaveBeenCalledTimes(1);
@@ -258,7 +258,7 @@ describe('services/cli/generators:html', () => {
       targets,
       targetsHTML
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       expect(targets.getDefaultTarget).toHaveBeenCalledTimes(1);
@@ -334,7 +334,7 @@ describe('services/cli/generators:html', () => {
       targets,
       targetsHTML
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       expect(targets.getDefaultTarget).toHaveBeenCalledTimes(1);
@@ -409,7 +409,7 @@ describe('services/cli/generators:html', () => {
       targets,
       targetsHTML
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       expect(true).toBeFalse();
     })
@@ -521,7 +521,7 @@ describe('services/cli/generators:html', () => {
       targets,
       targetsHTML
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       [[{ target: { conform: targetValidation } }]] = appPrompt.ask.mock.calls;
@@ -587,7 +587,7 @@ describe('services/cli/generators:html', () => {
       targets,
       targetsHTML
     );
-    return sut.generate()
+    return sut.handle()
     .then(() => {
       // Then
       [[{ overwrite: { ask: overwriteValidation } }]] = appPrompt.ask.mock.calls;

--- a/tests/services/targets/targetsFinder.test.js
+++ b/tests/services/targets/targetsFinder.test.js
@@ -842,6 +842,50 @@ describe('services/targets:targetsFinder', () => {
     expect(result).toEqual(expectedTargets);
   });
 
+  it('should find a node target that uses React SSR', () => {
+    // Given
+    const packageInfo = {
+      name: 'my-app',
+    };
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    // 1 - When checking if the source directory exists.
+    fs.pathExistsSync.mockReturnValueOnce(true);
+    // 2 - When checking if the default index exists.
+    fs.pathExistsSync.mockReturnValueOnce(true);
+    const indexFile = 'index.js';
+    const sourceDirectoryContents = ['..', '.', indexFile];
+    // 1 - When reading the source directory.
+    fs.readdirSync.mockReturnValueOnce(sourceDirectoryContents);
+    // 2 - When parsing the target.
+    fs.readdirSync.mockReturnValueOnce(sourceDirectoryContents);
+    const fileContents = 'import React from \'react\';\n' +
+      'import ReactDOM from \'react-dom/server\'';
+    fs.readFileSync.mockReturnValueOnce(fileContents);
+    const directory = 'src';
+    let sut = null;
+    let result = null;
+    const expectedTargets = [{
+      name: packageInfo.name,
+      hasFolder: false,
+      createFolder: false,
+      entry: {
+        default: indexFile,
+        development: null,
+        production: null,
+      },
+      type: 'node',
+      library: false,
+      framework: 'react',
+    }];
+    // When
+    sut = new TargetsFinder(packageInfo, pathUtils);
+    result = sut.find(directory);
+    // Then
+    expect(result).toEqual(expectedTargets);
+  });
+
   it('should find a browser target that uses AngularJS', () => {
     // Given
     const packageInfo = {


### PR DESCRIPTION
### What does this PR do?

#### `CLIGeneratorSubCommand` -> `CLISubCommand`

As mentioned on #12, I changed the name of the service, its `resource` property (is now `name`) and its `generate` method (is now `handle), so other CLI commands can make use of it on the future.

#### Fix for unkown options on `CLICommand.generate`

On `CLISHBuildCommand`, I was relying on the fact that `generate` ignored unknown options, but after the change from #14 , it was allowing them and some commands started throwing an error regarding the unknown options.

So instead of fixing it and only sent supported options, something I'll do later, it made more sense to only allow unknown options on `generate` when the command itself supports unknown options.

#### Change the output path for fonts.

To make it short, if you have more than one web font on your project, the generated directory will end up having ALL of their files together... not cool.

Now, the new path for fonts is `statics/fonts/[name]/[name].[hash].[ext]` (the `.[hash]` is still only for production), so each font is saved inside a folder with its own name.

#### Change the way the CLI `clean` command behave

Previously, if you didn't specify a target name for the CLI `clean` command, it would delete the entire distribution directory.

Well, after the changes of #12 , this command was quite _"aligned"_ with `build` and `run`, where if you didn't specify a target, they would use the _"default target"_, so that was the change.

Now, if you don't specify a target name, it will clean the files for the _"default target"_, and to remove the entire distribution directory, you need to use the new flag **`--all`** (or `-a`).

#### Detect SSR

While experimenting with SSR (Server Side Rendering), I noticed that importing React on the Node target would generate a _"false positive"_ and mark the target as a browser, so I added a dictionary of expressions on the Targets Finder that would identify frameworks that can also be used on Node.

The only added case for now is React, so if you import `react` and `react-dom/server`, the target is identified as a Node target.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
