### PR TITLE
Add excludeModules settings for Node targets

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -90,6 +90,7 @@ Since there are a lot of settings for the templates, will divide them by type an
   output: { ... },
   css: { ... },
   includeModules: [],
+  excludeModules: [],
   runOnDevelopment: false,
   babel: { ... },
   flow: false,
@@ -198,9 +199,14 @@ Whether or not your application uses [CSS Modules](https://github.com/css-module
 
 This setting can be used to specify a list of node modules you want to process on your bundle.
 
-For example, let's say you are using a library that exports a native `Class` that you are `extend`ing, but you are transpiling for a browser that doesn't support native `Class`es; you can add the name of the module on this setting and projext will include it on its bundling process and transpile it if needed.
+For example, let's say you are using a library that exports a native `Class` that you are `extend`ing, but you are transpiling for an environment that doesn't support native `Class`es; you can add the name of the module on this setting and projext will include it on its bundling process and transpile it if needed.
 
 > At the end of the process, those names are converted to regular expressions, so you can also make the name a expression, while escaping especial characters of course.
+
+#### `excludeModules`
+> Default value: `[]`
+
+This setting can be used to specify a list of modules that should never be bundled. By default, projext will exclude all the dependencies from the `package.json`, but if you import modules using a sub path (like `colors/safe` instead of `colors`), you need to specify it on this list so the build engine won't try to put it inside the bundle it.
 
 #### `runOnDevelopment`
 > Default value: `false`

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -72,6 +72,7 @@ class ProjectConfiguration extends ConfigurationFile {
             modules: false,
           },
           includeModules: [],
+          excludeModules: [],
           runOnDevelopment: false,
           babel: {
             features: [],

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -371,6 +371,11 @@
  * @property {Array} [includeModules=[]]
  * This setting can be used to specify a list of node modules you want to process on your bundle.
  * This means that JS files from modules on this list will be transpiled.
+ * @property {Array} [excludeModules=[]]
+ * This setting can be used to specify a list of modules that should never be bundled. By default,
+ * projext will exclude all the dependencies from the `package.json`, but if you import modules
+ * using a sub path (like `colors/safe` instead of `colors`), you need to specify it on this list
+ * so the build engine won't try to put it inside the bundle it.
  * @property {boolean} [runOnDevelopment=false]
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
@@ -424,6 +429,11 @@
  * @property {Array} includeModules
  * This setting can be used to specify a list of node modules you want to process on your bundle.
  * This means that JS files from modules on this list will be transpiled.
+ * @property {Array} excludeModules
+ * This setting can be used to specify a list of modules that should never be bundled. By default,
+ * projext will exclude all the dependencies from the `package.json`, but if you import modules
+ * using a sub path (like `colors/safe` instead of `colors`), you need to specify it on this list
+ * so the build engine won't try to put it inside the bundle it.
  * @property {boolean} runOnDevelopment
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.


### PR DESCRIPTION
### What does this PR do?

This PR doesn't actually add any new executable code but just documents a new setting. The actual code that implements this will come from the build engines.

While working with the [webpack plugin](https://yarnpkg.com/en/package/projext-plugin-webpack) and [express](https://yarnpkg.com/en/package/express), I found out that if I implemented the plugin middleware, which inclusion path is `projext-plugin-webpack/express`, projext wouldn't find it on the `package.json` dependencies and it would try to bundle the whole thing.

Well, while this is will be fixed by the webpack plugin itself, what if this happens to you with a module like `colors`? Where you, most of the times, include `colors/safe` instead of just `colors`. This is where the new setting enters: `excludeModules`.

This new setting is a list of modules/inclusion paths that you don't want the build engine to include on your bundle.

### How should it be tested manually?

Reading?
