### PR TITLE
Remove the HTML file warning for a production library

### DIFF
--- a/src/services/cli/cliSHValidateBuild.js
+++ b/src/services/cli/cliSHValidateBuild.js
@@ -95,7 +95,10 @@ class CLISHValidateBuildCommand extends CLICommand {
         `The target '${name}' doesn't need bundling nor transpilation, ` +
         'so there\'s no need to build it'
       );
-    } else if (target.is.browser) {
+    } else if (
+      target.is.browser &&
+      !(target.library && type === 'production')
+    ) {
       this.tempFiles.ensureDirectorySync();
       const htmlStatus = this.targetsHTML.validate(target);
       if (!htmlStatus.exists) {

--- a/tests/services/cli/cliSHValidateBuild.test.js
+++ b/tests/services/cli/cliSHValidateBuild.test.js
@@ -170,6 +170,34 @@ describe('services/cli:sh-validate-build', () => {
     expect(appLogger.warning).toHaveBeenCalledTimes(1);
   });
 
+  it('shouldn\'t log a warning for the HTML when the target is a library for production', () => {
+    // Given
+    const appLogger = {
+      warning: jest.fn(),
+    };
+    const targetName = 'some-target';
+    const target = {
+      library: true,
+      is: {
+        node: false,
+        browser: true,
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => target),
+    };
+    const targetsHTML = 'targetsHTML';
+    const tempFiles = 'tempFiles';
+    const run = false;
+    const type = 'production';
+    let sut = null;
+    // When
+    sut = new CLISHValidateBuildCommand(appLogger, targets, targetsHTML, tempFiles);
+    sut.handle(targetName, null, { run, type });
+    // Then
+    expect(appLogger.warning).toHaveBeenCalledTimes(0);
+  });
+
   it('should validate the default target when no name is specified', () => {
     // Given
     const appLogger = {


### PR DESCRIPTION
### What does this PR do?

Right now, when you are building a browser target, if it doesn't have an HTML template file you would get a warning saying that projext will generate one for you but that you should have one.

Well, if your target is a library for the browser and you are building for production, you don't need the HTML, so it doesn't make sense for the warning to appear.

### How should it be tested manually?

Build a library browser target with for production, you shouldn't see the warning anymore.