### PR TITLE
Show the right target name when validating the build command

### DIFF
--- a/src/services/cli/cliSHValidateBuild.js
+++ b/src/services/cli/cliSHValidateBuild.js
@@ -92,7 +92,7 @@ class CLISHValidateBuildCommand extends CLICommand {
       !target.transpile
     ) {
       this.appLogger.warning(
-        `The target '${name}' doesn't need bundling nor transpilation, ` +
+        `The target '${target.name}' doesn't need bundling nor transpilation, ` +
         'so there\'s no need to build it'
       );
     } else if (
@@ -103,8 +103,8 @@ class CLISHValidateBuildCommand extends CLICommand {
       const htmlStatus = this.targetsHTML.validate(target);
       if (!htmlStatus.exists) {
         this.appLogger.warning(
-          `The target '${name}' doesn't have an HTML template, projext will generate one for ` +
-          'this build, but it would be best for you to create one. You can use the ' +
+          `The target '${target.name}' doesn't have an HTML template, projext will generate ` +
+          'one for this build, but it would be best for you to create one. You can use the ' +
           '\'generate\' command'
         );
       }


### PR DESCRIPTION
### What does this PR do?

When validating the build command (on `cliSHValidateBuild`), the warning messages where using the `name` variable, which was the value of the `[target]` argument, but if the user uses the default target, aka he/she didn't specify a target, the log would read `undefined` as target name.

Easy fix, use `target.name` instead of `name`.

### How should it be tested manually?

Run `projext build` for a target without an HTML file or on a Node target that doesn't requires bundling nor transpilation, you should see the target name on the warning.