### PR TITLE
Fix line breaks on the generate command help

### DIFF
--- a/src/services/cli/cliGenerate.js
+++ b/src/services/cli/cliGenerate.js
@@ -49,11 +49,16 @@ class CLIGenerateCommand extends CLICommand {
     // Set an empty description.
     let descriptionList = '';
     // Loop all the registered generators and add their help information to the description.
-    Object.keys(this.generators).forEach((resource) => {
+    const resources = Object.keys(this.generators);
+    const lastResource = resources.length - 1;
+    resources.forEach((resource, index) => {
       descriptionList += this.generators[resource].getHelpInformation();
+      if (index !== lastResource) {
+        descriptionList += '\n\n';
+      }
     });
     // Update the detailed description of the command.
-    this.fullDescription = `Generate a projext resource:${descriptionList}`;
+    this.fullDescription = `Generate a projext resource:\n\n${descriptionList}`;
   }
   /**
    * Handle the execution of the command and triggers the selected generator.

--- a/tests/services/cli/cliGenerate.test.js
+++ b/tests/services/cli/cliGenerate.test.js
@@ -43,8 +43,8 @@ describe('services/cli:generate', () => {
     };
     const generators = [generatorOne, generatorTwo];
     let sut = null;
-    const expectedDescription = 'Generate a projext resource:' +
-      `${generatorOne.description}` +
+    const expectedDescription = 'Generate a projext resource:\n\n' +
+      `${generatorOne.description}\n\n` +
       `${generatorTwo.description}`;
     // When
     sut = new CLIGenerateCommand();


### PR DESCRIPTION
### What does this PR do?

Adds extra line breaks between the resources information on the `generate` CLI command.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
