### PR TITLE
Enable unknown options for all the build and run commands

### DIFF
--- a/src/services/cli/cliRun.js
+++ b/src/services/cli/cliRun.js
@@ -23,7 +23,7 @@ class CLIRunCommand extends CLICommand {
      */
     this.description = 'Run a target on a development build type';
     /**
-     * Enable unknown options so other services can customize the build command.
+     * Enable unknown options so other services can customize the run command.
      * @type {Boolean}
      */
     this.allowUnknownOptions = true;

--- a/src/services/cli/cliSHNodeRun.js
+++ b/src/services/cli/cliSHNodeRun.js
@@ -38,6 +38,11 @@ class CLISHNodeRunCommand extends CLICommand {
      * @type {boolean}
      */
     this.hidden = true;
+    /**
+     * Enable unknown options so other services can customize the run command.
+     * @type {Boolean}
+     */
+    this.allowUnknownOptions = true;
   }
   /**
    * Handle the execution of the command and runs a Node target.

--- a/src/services/cli/cliSHRun.js
+++ b/src/services/cli/cliSHRun.js
@@ -42,7 +42,7 @@ class CLISHRunCommand extends CLICommand {
      */
     this.hidden = true;
     /**
-     * Enable unknown options so other services can customize the build command.
+     * Enable unknown options so other services can customize the run command.
      * @type {Boolean}
      */
     this.allowUnknownOptions = true;

--- a/src/services/cli/cliSHValidateBuild.js
+++ b/src/services/cli/cliSHValidateBuild.js
@@ -66,6 +66,11 @@ class CLISHValidateBuildCommand extends CLICommand {
      * @type {boolean}
      */
     this.hidden = true;
+    /**
+     * Enable unknown options so other services can customize the build command.
+     * @type {Boolean}
+     */
+    this.allowUnknownOptions = true;
   }
   /**
    * Handle the execution of the command and validate all the arguments.

--- a/src/services/cli/cliSHValidateRun.js
+++ b/src/services/cli/cliSHValidateRun.js
@@ -48,6 +48,11 @@ class CLISHValidateRunCommand extends CLICommand {
      * @type {boolean}
      */
     this.hidden = true;
+    /**
+     * Enable unknown options so other services can customize the run command.
+     * @type {Boolean}
+     */
+    this.allowUnknownOptions = true;
   }
   /**
    * Handle the execution of the command and validate the target existence.

--- a/tests/services/cli/cliSHBuild.test.js
+++ b/tests/services/cli/cliSHBuild.test.js
@@ -162,6 +162,7 @@ describe('services/cli:sh-build', () => {
       false
     );
     expect(sut.hidden).toBeTrue();
+    expect(sut.allowUnknownOptions).toBeTrue();
   });
 
   it('should return the command to build the default target', () => {

--- a/tests/services/cli/cliSHNodeRun.test.js
+++ b/tests/services/cli/cliSHNodeRun.test.js
@@ -31,6 +31,7 @@ describe('services/cli:sh-node-run', () => {
     expect(sut.command).not.toBeEmptyString();
     expect(sut.description).not.toBeEmptyString();
     expect(sut.hidden).toBeTrue();
+    expect(sut.allowUnknownOptions).toBeTrue();
   });
 
   it('should call the method to run a node target when executed', () => {

--- a/tests/services/cli/cliSHValidateBuild.test.js
+++ b/tests/services/cli/cliSHValidateBuild.test.js
@@ -48,6 +48,7 @@ describe('services/cli:sh-validate-build', () => {
       false
     );
     expect(sut.hidden).toBeTrue();
+    expect(sut.allowUnknownOptions).toBeTrue();
   });
 
   it('should log a warning when trying to build a target that doesn\'t need it', () => {

--- a/tests/services/cli/cliSHValidateRun.test.js
+++ b/tests/services/cli/cliSHValidateRun.test.js
@@ -42,6 +42,7 @@ describe('services/cli:validate-run', () => {
       false
     );
     expect(sut.hidden).toBeTrue();
+    expect(sut.allowUnknownOptions).toBeTrue();
   });
 
   it('should validate the target exists when executed', () => {


### PR DESCRIPTION
### What does this PR do?

When the build command was being generated with unknown options, the `sh-validate-build` _"hook command"_ was failing due to these options, so what I did was to add support for all build-related commands.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
