### PR TITLE
Rename a target with the project name using the configuration file.

### DIFF
--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -216,7 +216,26 @@ class ProjectConfiguration extends ConfigurationFile {
     super._loadConfig(...args);
     if (this._config.others.findTargets.enabled) {
       const originalTargets = extend(true, {}, this._config.targets);
+      const originalTargetsNames = Object.keys(originalTargets);
       const foundTargets = this._findTargets();
+      const foundTargetsNames = Object.keys(foundTargets);
+      /**
+       * If there's only one target on the configuration file and the finder only found one, the
+       * name of the found one will be changed to the one on the configuration file.
+       *
+       * When a single target, outside a folder, is found, the finder will give it the same name
+       * as the project name on the `package.json`, but by defining a single target on the
+       * configuration file, the name can be changed.
+       */
+      if (originalTargetsNames.length === 1 && foundTargetsNames.length === 1) {
+        const [originalTargetName] = originalTargetsNames;
+        const [foundTargetName] = foundTargetsNames;
+        if (originalTargetName !== foundTargetName) {
+          foundTargets[originalTargetName] = foundTargets[foundTargetName];
+          foundTargets[originalTargetName].name = originalTargetName;
+          delete foundTargets[foundTargetName];
+        }
+      }
       this._config.targets = extend(true, {}, foundTargets, originalTargets);
     }
   }

--- a/tests/services/configurations/projectConfiguration.test.js
+++ b/tests/services/configurations/projectConfiguration.test.js
@@ -147,7 +147,59 @@ describe('services/configurations:projectConfiguration', () => {
     let sut = null;
     let result = null;
     const expectedTargets = {
-      [target.name]: Object.assign(target, targetOverwrite),
+      [target.name]: Object.assign({}, target, targetOverwrite),
+    };
+    // When
+    sut = new ProjectConfiguration(pathUtils, targetsFinder);
+    result = sut.getConfig();
+    // Then
+    expect(sut).toBeInstanceOf(ProjectConfiguration);
+    expect(sut.constructorMock).toHaveBeenCalledTimes(1);
+    expect(sut.constructorMock).toHaveBeenCalledWith(
+      pathUtils,
+      [
+        'projext.config.js',
+        'config/projext.config.js',
+        'config/project.config.js',
+      ]
+    );
+    expect(result).toBeObject();
+    expect(Object.keys(result)).toEqual(expectedKeys);
+    expect(result.targets).toEqual(expectedTargets);
+    expect(targetsFinder).toHaveBeenCalledTimes(1);
+    expect(targetsFinder).toHaveBeenCalledWith(result.paths.source);
+  });
+
+  it('should rename a target if it only found one and the configuration also has only one', () => {
+    // Given
+    const pathUtils = 'pathUtils';
+    const target = {
+      name: 'myApp',
+      type: 'browser',
+      framework: 'react',
+    };
+    const targetOverwrite = {
+      name: 'myAppNewName',
+      framework: 'aurelia',
+    };
+    ConfigurationFileMock.overwrite({
+      targets: {
+        [targetOverwrite.name]: targetOverwrite,
+      },
+    });
+    const targetsFinder = jest.fn(() => [target]);
+    const expectedKeys = [
+      'paths',
+      'targetsTemplates',
+      'targets',
+      'copy',
+      'version',
+      'others',
+    ];
+    let sut = null;
+    let result = null;
+    const expectedTargets = {
+      [targetOverwrite.name]: Object.assign({}, target, targetOverwrite),
     };
     // When
     sut = new ProjectConfiguration(pathUtils, targetsFinder);


### PR DESCRIPTION
### What does this PR do?

When your project has only one target and is not inside a folder, the targets finder will assume that its name is the same as the project name on the `package.json`. The only way to change the name is by defining a new target on the configuration file, and even then you'll end up with two targets: The one with the project name and the one you defined. You can also set the `others.findTargets` setting to `false` to avoid the double target... to much for just renaming a target.

The solution I came up with is that if you only have one target, named like the project because the finder found it, you can define a target on the configuration file and projext will automatically assume you are referring to the  same target and that it needs to be renamed.

### How should it be tested manually?

1. Create a project without a configuration file.
2. Set the `name` property of your `package.json` to something you wouldn't like your project to be named after, like `debugging-is-fun`.
3. Create an empty `src/index.js`.
4. Run `[npx|yarn] projext info targets`, you'll see that projext found a target and it has the same name as your project.
5. Create a `projext.config.js` file and add an empty target with some random name, like `test`.
6. Run `[npx|yarn] projext info targets`, you'll see that you still have one single target, but now its name is the one you defined on the configuration file.

And of course...

```bash
yarn test
# or
npm test
```