### PR TITLE
Identify a browser target when it imports the fetch polyfill

### DIFF
--- a/src/services/targets/targetsFinder.js
+++ b/src/services/targets/targetsFinder.js
@@ -103,6 +103,7 @@ class TargetsFinder {
     this._browserExpressions = [
       /(?:^|\s|=)doc(?:ument?)\s*\.\s*(?:getElementBy(?:Id|ClassName)|querySelector(?:All)?)\s*\(/ig,
       /(?:^|\s|=)(?:window|global)\s*\.(?:document?)/i,
+      /['|"]whatwg-fetch['|"]/i,
     ];
     /**
      * @ignore


### PR DESCRIPTION
### What does this PR do?

Adds a new expression on the Targets Finder to identify browser targets: A mention of the [`fetch` polyfill](https://yarnpkg.com/en/package/whatwg-fetch).

### How should it be tested manually?

Create a target entry file with the following code:

```js
import 'whatwg-fetch';
```

Then use the `info` command to see the target type projext resolved:

```bash
yarn projext info targets
# or
npx projext info targets
```

The type should be `browser`.

And of course...

```bash
yarn test
# or
npm test
```