### PR TITLE
Improve the plugins service

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -87,7 +87,7 @@ class Projext extends Jimple {
     this.register(cleaner);
     this.register(copier);
     this.register(events);
-    this.register(plugins('projext-plugin'));
+    this.register(plugins('projext-plugin-'));
     this.register(appPrompt);
     this.register(tempFiles);
     this.register(utils);

--- a/src/services/common/plugins.js
+++ b/src/services/common/plugins.js
@@ -38,6 +38,13 @@ class Plugins {
      * @type {PathUtils}
      */
     this.pathUtils = pathUtils;
+    /**
+     * After the plugins are loaded, this property will have a list with the plugins names.
+     * @type {Array}
+     * @access protected
+     * @ignore
+     */
+    this._loadedPlugins = [];
   }
   /**
    * Load all the plugins.
@@ -61,6 +68,21 @@ class Plugins {
     .forEach((name) => this._loadPlugin(name));
   }
   /**
+   * Gets the names of the loaded plugins.
+   * @return {string}
+   */
+  getLoadedPlugins() {
+    return this._loadedPlugins;
+  }
+  /**
+   * Checks whether a plugin was loaded or not.
+   * @param {string} name The plugin's name.
+   * @return {boolean}
+   */
+  loaded(name) {
+    return this.getLoadedPlugins().includes(name);
+  }
+  /**
    * Load a plugin by its package name.
    * @param  {string} packageName The name of the plugin.
    * @throws {Error} If the plugin can't be loaded or registered.
@@ -81,6 +103,9 @@ class Plugins {
       this.appLogger.error(`The plugin ${packageName} couldn't be loaded`);
       throw error;
     }
+
+    const name = packageName.substr(this.prefix.length);
+    this._loadedPlugins.push(name);
   }
 }
 /**

--- a/src/services/common/plugins.js
+++ b/src/services/common/plugins.js
@@ -72,7 +72,11 @@ class Plugins {
       const packagePath = this.pathUtils.join('node_modules', packageName);
       // eslint-disable-next-line global-require,import/no-dynamic-require
       const plugin = require(packagePath);
-      plugin(this.app);
+      if (plugin.plugin && typeof plugin.plugin === 'function') {
+        plugin.plugin(this.app);
+      } else {
+        plugin(this.app);
+      }
     } catch (error) {
       this.appLogger.error(`The plugin ${packageName} couldn't be loaded`);
       throw error;

--- a/tests/mocks/mockPluginWithFunction.js
+++ b/tests/mocks/mockPluginWithFunction.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugin: (app) => {
+    app.register('pluginWithFunction');
+  },
+};

--- a/tests/services/common/plugins.test.js
+++ b/tests/services/common/plugins.test.js
@@ -60,6 +60,37 @@ describe('services/common:plugins', () => {
     expect(app.register).toHaveBeenCalledWith('plugin');
   });
 
+  it('should load a plugin with a `plugin` function', () => {
+    // Given
+    const prefix = 'plugin-';
+    const app = {
+      register: jest.fn(),
+    };
+    const appLogger = 'appLogger';
+    const pluginName = 'plugin-for-something-with-function';
+    const packageInfo = {
+      dependencies: {
+        'jest-ex': 'latest',
+        'webpack-node-utils': 'latest',
+      },
+      devDependencies: {
+        [pluginName]: 'latest',
+      },
+    };
+    const pathUtils = {
+      join: jest.fn(() => `${mocksRelativePath}/mockPluginWithFunction.js`),
+    };
+    let sut = null;
+    // When
+    sut = new Plugins(prefix, app, appLogger, packageInfo, pathUtils);
+    sut.load();
+    // Then
+    expect(pathUtils.join).toHaveBeenCalledTimes(1);
+    expect(pathUtils.join).toHaveBeenCalledWith('node_modules', pluginName);
+    expect(app.register).toHaveBeenCalledTimes(1);
+    expect(app.register).toHaveBeenCalledWith('pluginWithFunction');
+  });
+
   it('should fail to load a plugin', () => {
     // Given
     const prefix = 'plugin-';

--- a/tests/services/common/plugins.test.js
+++ b/tests/services/common/plugins.test.js
@@ -126,6 +126,71 @@ describe('services/common:plugins', () => {
     .toHaveBeenCalledWith(`The plugin ${pluginName} couldn't be loaded`);
   });
 
+  it('should return the list of loaded plugins', () => {
+    // Given
+    const app = {
+      register: jest.fn(),
+    };
+    const appLogger = 'appLogger';
+    const prefix = 'plugin-';
+    const pluginOneName = 'one';
+    const pluginTwoName = 'two';
+    const packageInfo = {
+      dependencies: {
+        'jest-ex': 'latest',
+        'webpack-node-utils': 'latest',
+      },
+      devDependencies: {
+        [`${prefix}${pluginOneName}`]: 'latest',
+        [`${prefix}${pluginTwoName}`]: 'latest',
+      },
+    };
+    const pathUtils = {
+      join: jest.fn(() => `${mocksRelativePath}/mockPlugin.js`),
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new Plugins(prefix, app, appLogger, packageInfo, pathUtils);
+    sut.load();
+    result = sut.getLoadedPlugins();
+    // Then
+    expect(result).toEqual([pluginOneName, pluginTwoName]);
+  });
+
+  it('should check if a plugin was loaded or not', () => {
+    // Given
+    const app = {
+      register: jest.fn(),
+    };
+    const appLogger = 'appLogger';
+    const prefix = 'plugin-';
+    const pluginName = 'magic';
+    const packageInfo = {
+      dependencies: {
+        'jest-ex': 'latest',
+        'webpack-node-utils': 'latest',
+      },
+      devDependencies: {
+        [`${prefix}${pluginName}`]: 'latest',
+      },
+    };
+    const pathUtils = {
+      join: jest.fn(() => `${mocksRelativePath}/mockPlugin.js`),
+    };
+    let sut = null;
+    let resultForPlugin = null;
+    let resultForUnknownPlugin = null;
+    // When
+    sut = new Plugins(prefix, app, appLogger, packageInfo, pathUtils);
+    sut.load();
+    resultForPlugin = sut.loaded(pluginName);
+    resultForUnknownPlugin = sut.loaded('charito');
+    // Then
+    expect(resultForPlugin).toBeTrue();
+    expect(resultForUnknownPlugin).toBeFalse();
+  });
+
   it('should only search for plugins on the production dependencies', () => {
     // Given
     const prefix = 'plugin-';


### PR DESCRIPTION
### What does this PR do?

#### Changes the required plugins prefix from `projext-plugin` to `projext-plugin-`.

The reason is that, without the `-`, the service would allow plugins with names like `projext-pluginSomething` and try to load them, and I want to keep the name normalized.

On the NPM registry there are no other plugins that the ones I published, but if there were the case that some one made a private package somewhere using the invalid format, this change would prevent it from working, so that's why this PR is breaking.

#### Plugins main files can now export a `plugin` function.

The way the service works is by identifying dependencies on the `package.json` with a required prefix, then it makes a `require` of each dependency, assumes that whatever was imported is a function and calls it.

The thing is that if you were to write a plugin that has a functionality when its loaded on projext and another functionality by itself, you would need to have _"two main files"_:

- The one that is on the `main` setting of the `package.json`, that projext will import and assume that it only exports a function.
- The one that executes/exports the plugin extra functionality.

Well, now the service will check if you are exporting a `plugin` function and use that instead of the main export.

Now you can have only one main file and export the plugin functionality and the extra one at the same time.

#### `Plugins#getLoadedPlugins():Array`

This method gives you the list of names of the plugins that were loaded. Each name has the prefix the service uses to identify them removed.

#### `Plugins#loaded(name:string):boolean`

This method allows you to check if an specific plugin was loaded or not.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
