### PR TITLE
Babel helper

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -11,6 +11,7 @@ const {
 } = require('wootils/node/providers');
 
 const {
+  babelHelper,
   cleaner,
   copier,
   events,
@@ -84,6 +85,7 @@ class Projext extends Jimple {
     this.register(pathUtils);
     this.register(rootRequire);
 
+    this.register(babelHelper);
     this.register(cleaner);
     this.register(copier);
     this.register(events);

--- a/src/services/cli/cliGenerate.js
+++ b/src/services/cli/cliGenerate.js
@@ -57,7 +57,10 @@ class CLIGenerateCommand extends CLICommand {
         descriptionList += '\n\n';
       }
     });
-    // Update the detailed description of the command.
+    /**
+     * Update the detailed description of the command.
+     * @ignore
+     */
     this.fullDescription = `Generate a projext resource:\n\n${descriptionList}`;
   }
   /**

--- a/src/services/common/babelHelper.js
+++ b/src/services/common/babelHelper.js
@@ -1,0 +1,191 @@
+const { provider } = require('jimple');
+
+/**
+ * @typedef {function} UpdateEnvPresetFunction
+ * @param {Object} options The current options of the `env` preset.
+ * @return {Object} The updated options for the `env` preset.
+ */
+
+/**
+ * A set of utilities to easily modify a Babel configuration.
+ */
+class BabelHelper {
+  /**
+   * Adds a plugin or a list of them to a Babel configuration. If the `plugins` option doesn't
+   * exists it creates it.
+   * @param {Object}       configuration The configuration to update.
+   * @param {string|Array} plugin        A plugin name or configuration `Array` (`[name, options]`),
+   *                                     or a list of them.
+   * @return {Object} The updated configuration.
+   */
+  static addPlugin(configuration, plugin) {
+    // Get a new reference for the configuration.
+    const updatedConfiguration = Object.assign({}, configuration);
+    // Normalize the received `plugin` parameter into an `Array`.
+    const plugins = Array.isArray(plugin) ? plugin : [plugin];
+    // Define the variable for the list where the new plugin(s) will be added.
+    let newPluginsList;
+    /**
+     * Define a variable that may contain a list of the existing plugins' names. The reason for
+     * this is that when adding new plugins, the method can validate if they already are on the
+     * list by calling `.includes` on this list; otherwise, and because plugins can be either a
+     * `string` or an `Array`, it would have to do a `.some` or `.find` with a callback that checks
+     * the type of the existing plugin.
+     */
+    let existingPlugins;
+    // If the configuration already has plugins...
+    if (updatedConfiguration.plugins) {
+      // ...set the existing plugins list as the one where the new plugins are going to be added.
+      newPluginsList = updatedConfiguration.plugins;
+      // And generate a list with the names of the existing plugins.
+      existingPlugins = newPluginsList.map((existingPlugin) => (
+        (Array.isArray(existingPlugin) ? existingPlugin[0] : existingPlugin)
+      ));
+    } else {
+      // ...otherwise, set a empty list.
+      newPluginsList = [];
+    }
+    // Loop all the plugins that should be added.
+    plugins.forEach((pluginInfo) => {
+      // Get the plugin name.
+      const name = Array.isArray(pluginInfo) ? pluginInfo[0] : plugin;
+      // If the configuration didn't have plugins, or the plugin is not on the list.
+      if (!existingPlugins || !existingPlugins.includes(name)) {
+        // ...add it to the list.
+        newPluginsList.push(pluginInfo);
+      }
+    });
+
+    // Replace the `plugins` property on the configuration with the updated list.
+    updatedConfiguration.plugins = newPluginsList;
+    // Return the updated configuration.
+    return updatedConfiguration;
+  }
+  /**
+   * Update the options of the `env` preset on a Babel configuration. If the `presets` option
+   * doesn't exists, it will create one and add the preset. If `presets` exists and there's
+   * already an `env` preset, it will update it. But if `presets` exists but there's no `env`
+   * preset, it won't do anything.
+   * @param {Object}                  configuration The configuration to update.
+   * @param {UpdateEnvPresetFunction} updateFn      The function called in order to update the
+   *                                                `env` preset options.
+   * @return {Object} The updated configuration.
+   */
+  static updateEnvPreset(configuration, updateFn) {
+    // Get a new reference for the configuration.
+    const updatedConfiguration = Object.assign({}, configuration);
+    /**
+     * Define a flag that will eventually indicate whether the configuration needs the `presets`
+     * option or not.
+     */
+    let needsPresets = false;
+    // Define a flag that will eventually tell if the configuration has the `env` preset or not.
+    let hasEnvPreset = false;
+    /**
+     * Define the variable that, if the configuration has an `env` preset, indicate the index of
+     * the preset on the list.
+     */
+    let envPresetIndex = -1;
+    // Define the name of `env` preset; to avoid having the string on multiple places.
+    const envPresetName = 'env';
+    // If the configuration has presets...
+    if (updatedConfiguration.presets && updatedConfiguration.presets.length) {
+      // ...get the index of the `env` preset.
+      envPresetIndex = updatedConfiguration.presets.findIndex((preset) => {
+        const [presetName] = preset;
+        return presetName === envPresetName;
+      });
+      // Set the value of the flag that indicates if the `env` preset exists.
+      hasEnvPreset = envPresetIndex > -1;
+    } else {
+      // ...otherwise, set the flag that indicates the configuration doesn't have presets.
+      needsPresets = true;
+    }
+    /**
+     * This is the important part: Only proceed with the update if the configuration doesn't have
+     * presets or if it already has an `env` preset.
+     * If the configuration already has a list of presets that doesn't include the `env` preset,
+     * then it's probably a custom setup and adding it may cause conflicts.
+     */
+    if (needsPresets) {
+      /**
+       * Invoke the callback with an empty dictionary and add a new `presets` options with just the
+       * `env` preset.
+       */
+      updatedConfiguration.presets = [
+        [envPresetName, updateFn({})],
+      ];
+    } else if (hasEnvPreset) {
+      /**
+       * If the `env` preset already existed, invoke the callback with the current options in order
+       * to get new ones, define a new `env` preset and replace it on the list.
+       */
+      const [, currentEnvPresetOptions] = updatedConfiguration.presets[envPresetIndex];
+      updatedConfiguration.presets[envPresetIndex] = [
+        envPresetName,
+        updateFn(currentEnvPresetOptions),
+      ];
+    }
+    // Return the updated configuration.
+    return updatedConfiguration;
+  }
+  /**
+   * Add a required feature to the `env` preset options (it will go on the `include` option).
+   * @param {Object}       configuration The configuration to update.
+   * @param {string|Array} feature       The name of the feature to add or a list of them.
+   * @return {Object} The updated configuration.
+   */
+  static addEnvPresetFeature(configuration, feature) {
+    // Call the method to update the `env` preset options.
+    return this.updateEnvPreset(configuration, (options) => {
+      // Normalize the received `feature` parameter into an `Array`.
+      const features = Array.isArray(feature) ? feature : [feature];
+      // Generate a new reference for the options.
+      const updatedOptions = Object.assign({}, options);
+      // If the options already include a list of required features...
+      if (updatedOptions.include) {
+        // ...push only those that are not already present.
+        updatedOptions.include.push(
+          ...features.filter((name) => !updatedOptions.include.includes(name))
+        );
+      } else {
+        // ...otherwise, copy the entire list of features into the option.
+        updatedOptions.include = features.slice();
+      }
+
+      // Return the updated options.
+      return updatedOptions;
+    });
+  }
+  /**
+   * Disable the `env` preset `modules` option as it may cause conflict with some packages.
+   * @param {Object} configuration The configuration to update.
+   * @return {Object} The updated configuration.
+   */
+  static disableEnvPresetModules(configuration) {
+    // Call the method to update the `env` preset options.
+    return this.updateEnvPreset(
+      configuration,
+      // Return an updated dictionary of options with `modules` disabled.
+      (options) => Object.assign({}, options, { modules: false })
+    );
+  }
+}
+/**
+ * The service provider that once registered on the app container will set a reference of
+ * `BabelHelper` as the `babelHelper` service.
+ * @example
+ * // Register it on the container
+ * container.register(babelHelper);
+ * // Getting access to the service reference
+ * const babelHelper = container.get('babelHelper');
+ * @type {Provider}
+ */
+const babelHelper = provider((app) => {
+  app.set('babelHelper', () => BabelHelper);
+});
+
+module.exports = {
+  BabelHelper,
+  babelHelper,
+};

--- a/src/services/common/babelHelper.js
+++ b/src/services/common/babelHelper.js
@@ -25,7 +25,7 @@ class BabelHelper {
    * Adds a preset or a list of them to a Babel configuration. If the `presets` option doesn't
    * exist, the method will create it.
    * @param {Object}       configuration The configuration to update.
-   * @param {string|Array} plugin        A plugin name or configuration `Array` (`[name, options]`),
+   * @param {string|Array} preset        A plugin name or configuration `Array` (`[name, options]`),
    *                                     or a list of them.
    * @return {Object} The updated configuration.
    */
@@ -148,6 +148,8 @@ class BabelHelper {
    * @param {Object}       configuration The configuration to update.
    * @param {string|Array} item          An item name or configuration `Array` (`[name, options]`),
    *                                     or a list of them.
+   * @param {string}       property      The name of the items property (like `plugins` or
+   *                                     `presets`).
    * @return {Object} The updated configuration.
    * @access protected
    * @ignore

--- a/src/services/common/index.js
+++ b/src/services/common/index.js
@@ -1,3 +1,4 @@
+const { babelHelper } = require('./babelHelper');
 const { cleaner } = require('./cleaner');
 const { copier } = require('./copier');
 const { events } = require('./events');
@@ -9,6 +10,7 @@ const { versionUtils } = require('./versionUtils');
 
 module.exports = {
   appPrompt,
+  babelHelper,
   cleaner,
   copier,
   events,

--- a/tests/services/common/babelHelper.test.js
+++ b/tests/services/common/babelHelper.test.js
@@ -1,0 +1,274 @@
+const JimpleMock = require('/tests/mocks/jimple.mock');
+
+jest.mock('jimple', () => JimpleMock);
+jest.unmock('/src/services/common/babelHelper');
+
+require('jasmine-expect');
+
+const { BabelHelper, babelHelper } = require('/src/services/common/babelHelper');
+
+describe('services/common:babelHelper', () => {
+  it('should add a plugin to a Babel configuration', () => {
+    // Given
+    const configurationInitialValue = {};
+    const configuration = Object.assign({}, configurationInitialValue);
+    const plugin = 'external-helpers';
+    let result = null;
+    const expectedConfiguration = {
+      plugins: [
+        plugin,
+      ],
+    };
+    // When
+    result = BabelHelper.addPlugin(configuration, plugin);
+    // Then
+    expect(result).toEqual(expectedConfiguration);
+    expect(configuration).toEqual(configurationInitialValue);
+  });
+
+  it('should add a list of plugins to a Babel configuration', () => {
+    // Given
+    const configuration = {};
+    const pluginOne = 'external-helpers';
+    const pluginTwo = 'other-plugin';
+    let result = null;
+    const expectedConfiguration = {
+      plugins: [
+        pluginOne,
+        pluginTwo,
+      ],
+    };
+    // When
+    result = BabelHelper.addPlugin(configuration, [pluginOne, pluginTwo]);
+    // Then
+    expect(result).toEqual(expectedConfiguration);
+  });
+
+  it('should add a plugin to an existing list of plugins', () => {
+    // Given
+    const configuration = {
+      plugins: [
+        'external-helpers',
+        ['angularjs-annotate', { explicitOnly: true }],
+      ],
+    };
+    const plugin = 'transform-jsx';
+    let result = null;
+    const expectedConfiguration = Object.assign({}, configuration, {
+      plugins: [
+        ...configuration.plugins,
+        plugin,
+      ],
+    });
+    // When
+    result = BabelHelper.addPlugin(configuration, plugin);
+    // Then
+    expect(result).toEqual(expectedConfiguration);
+  });
+
+  it('should add two plugins to an existing list of plugins', () => {
+    // Given
+    const configuration = {
+      plugins: [
+        'external-helpers',
+        ['angularjs-annotate', { explicitOnly: true }],
+      ],
+    };
+    const pluginOne = 'external-helpers';
+    const pluginTwo = ['other-plugin', { option: 'value' }];
+    let result = null;
+    const expectedConfiguration = {
+      plugins: [
+        ...configuration.plugins,
+        pluginOne,
+        pluginTwo,
+      ],
+    };
+    // When
+    result = BabelHelper.addPlugin(configuration, [pluginOne, pluginTwo]);
+    // Then
+    expect(result).toEqual(expectedConfiguration);
+  });
+
+  it('shouldn\'t add a plugin that is already on the configuration', () => {
+    // Given
+    const pluginOne = 'external-helpers';
+    const pluginTwo = ['angularjs-annotate', { explicitOnly: true }];
+    const configuration = {
+      plugins: [
+        pluginOne,
+        pluginTwo,
+      ],
+    };
+    let result = null;
+    // When
+    result = BabelHelper.addPlugin(configuration, [pluginOne, pluginTwo]);
+    // Then
+    expect(result).toEqual(configuration);
+  });
+
+  it('should add the env preset with custom options', () => {
+    // Given
+    const configurationInitialValue = {};
+    const configuration = Object.assign({}, configurationInitialValue);
+    const extraOptions = { extra: 'value' };
+    let result = null;
+    const expectedConfiguration = {
+      presets: [
+        ['env', extraOptions],
+      ],
+    };
+    // When
+    result = BabelHelper.updateEnvPreset(configuration, () => extraOptions);
+    // Then
+    expect(configuration).toEqual(configurationInitialValue);
+    expect(result).toEqual(expectedConfiguration);
+  });
+
+  it('should update the options of an existing env preset', () => {
+    // Given
+    const defaultOptions = { modules: false };
+    const configurationInitialValue = {
+      presets: [
+        ['env', defaultOptions],
+      ],
+    };
+    const configuration = Object.assign({}, configurationInitialValue);
+    const extraOptions = { extra: 'value' };
+    let result = null;
+    const expectedConfiguration = {
+      presets: [
+        ['env', Object.assign({}, defaultOptions, extraOptions)],
+      ],
+    };
+    // When
+    result = BabelHelper.updateEnvPreset(
+      configuration,
+      (currentOptions) => Object.assign({}, currentOptions, extraOptions)
+    );
+    // Then
+    expect(configuration).toEqual(configurationInitialValue);
+    expect(result).toEqual(expectedConfiguration);
+  });
+
+  it('shouldn\'t update the env preset if is not on the presets list', () => {
+    // Given
+    const configuration = {
+      presets: [
+        'some-preset',
+        ['some-other-preset', {}],
+      ],
+    };
+    let result = null;
+    // When
+    result = BabelHelper.updateEnvPreset(configuration, () => {});
+    // Then
+    expect(result).toEqual(configuration);
+  });
+
+  it('should add a required feature to the env preset', () => {
+    // Given
+    const configurationInitialValue = {};
+    const configuration = Object.assign({}, configurationInitialValue);
+    const feature = 'transform-es2015-arrow-functions';
+    let result = null;
+    const expectedConfiguration = {
+      presets: [
+        [
+          'env',
+          {
+            include: [feature],
+          },
+        ],
+      ],
+    };
+    // When
+    result = BabelHelper.addEnvPresetFeature(configuration, feature);
+    // Then
+    expect(configuration).toEqual(configurationInitialValue);
+    expect(result).toEqual(expectedConfiguration);
+  });
+
+  it('should add a list of required features to the env preset', () => {
+    // Given
+    const configuration = {};
+    const features = [
+      'transform-es2015-arrow-functions',
+      'transform-es2015-classes',
+      'transform-es2015-parameters',
+    ];
+    let result = null;
+    const expectedConfiguration = {
+      presets: [
+        [
+          'env',
+          {
+            include: features,
+          },
+        ],
+      ],
+    };
+    // When
+    result = BabelHelper.addEnvPresetFeature(configuration, features);
+    // Then
+    expect(result).toEqual(expectedConfiguration);
+  });
+
+  it('shouldn\'t add a feature that is already on the env preset', () => {
+    // Given
+    const feature = 'transform-es2015-arrow-functions';
+    const configuration = {
+      presets: [
+        [
+          'env',
+          {
+            include: [feature],
+          },
+        ],
+      ],
+    };
+    let result = null;
+    // When
+    result = BabelHelper.addEnvPresetFeature(configuration, feature);
+    // Then
+    expect(result).toEqual(configuration);
+  });
+
+  it('should disable the `modules` option of the env preset', () => {
+    // Given
+    const configurationInitialValue = {};
+    const configuration = Object.assign({}, configurationInitialValue);
+    let result = null;
+    const expectedConfiguration = {
+      presets: [
+        [
+          'env',
+          {
+            modules: false,
+          },
+        ],
+      ],
+    };
+    // When
+    result = BabelHelper.disableEnvPresetModules(configuration);
+    // Then
+    expect(configuration).toEqual(configurationInitialValue);
+    expect(result).toEqual(expectedConfiguration);
+  });
+
+  it('should include a provider for the DIC', () => {
+    // Given
+    const container = {
+      set: jest.fn(),
+    };
+    let serviceName = null;
+    let serviceFn = null;
+    // When
+    babelHelper(container);
+    [[serviceName, serviceFn]] = container.set.mock.calls;
+    // Then
+    expect(serviceName).toBe('babelHelper');
+    expect(serviceFn).toBeFunction();
+    expect(serviceFn()).toBe(BabelHelper);
+  });
+});

--- a/tests/services/common/babelHelper.test.js
+++ b/tests/services/common/babelHelper.test.js
@@ -26,6 +26,24 @@ describe('services/common:babelHelper', () => {
     expect(configuration).toEqual(configurationInitialValue);
   });
 
+  it('should add a plugin with options to a Babel configuration', () => {
+    // Given
+    const configurationInitialValue = {};
+    const configuration = Object.assign({}, configurationInitialValue);
+    const plugin = ['external-helpers', { custom: true }];
+    let result = null;
+    const expectedConfiguration = {
+      plugins: [
+        plugin,
+      ],
+    };
+    // When
+    result = BabelHelper.addPlugin(configuration, plugin);
+    // Then
+    expect(result).toEqual(expectedConfiguration);
+    expect(configuration).toEqual(configurationInitialValue);
+  });
+
   it('should add a list of plugins to a Babel configuration', () => {
     // Given
     const configuration = {};
@@ -74,7 +92,7 @@ describe('services/common:babelHelper', () => {
         ['angularjs-annotate', { explicitOnly: true }],
       ],
     };
-    const pluginOne = 'external-helpers';
+    const pluginOne = 'other-helpers';
     const pluginTwo = ['other-plugin', { option: 'value' }];
     let result = null;
     const expectedConfiguration = {
@@ -103,6 +121,124 @@ describe('services/common:babelHelper', () => {
     let result = null;
     // When
     result = BabelHelper.addPlugin(configuration, [pluginOne, pluginTwo]);
+    // Then
+    expect(result).toEqual(configuration);
+  });
+
+
+  it('should add a preset to a Babel configuration', () => {
+    // Given
+    const configurationInitialValue = {};
+    const configuration = Object.assign({}, configurationInitialValue);
+    const preset = 'react-preset';
+    let result = null;
+    const expectedConfiguration = {
+      presets: [
+        preset,
+      ],
+    };
+    // When
+    result = BabelHelper.addPreset(configuration, preset);
+    // Then
+    expect(result).toEqual(expectedConfiguration);
+    expect(configuration).toEqual(configurationInitialValue);
+  });
+
+  it('should add a preset with options to a Babel configuration', () => {
+    // Given
+    const configurationInitialValue = {};
+    const configuration = Object.assign({}, configurationInitialValue);
+    const preset = ['react-preset', { jsx: 'awesome' }];
+    let result = null;
+    const expectedConfiguration = {
+      presets: [
+        preset,
+      ],
+    };
+    // When
+    result = BabelHelper.addPreset(configuration, preset);
+    // Then
+    expect(result).toEqual(expectedConfiguration);
+    expect(configuration).toEqual(configurationInitialValue);
+  });
+
+  it('should add a list of presets to a Babel configuration', () => {
+    // Given
+    const configuration = {};
+    const presetOne = 'react-preset';
+    const presetTwo = 'angularjs-preset';
+    let result = null;
+    const expectedConfiguration = {
+      presets: [
+        presetOne,
+        presetTwo,
+      ],
+    };
+    // When
+    result = BabelHelper.addPreset(configuration, [presetOne, presetTwo]);
+    // Then
+    expect(result).toEqual(expectedConfiguration);
+  });
+
+  it('should add a preset to an existing list of presets', () => {
+    // Given
+    const configuration = {
+      presets: [
+        'react-preset',
+        ['preact-preset', { cool: true }],
+      ],
+    };
+    const preset = 'angularjs-preset';
+    let result = null;
+    const expectedConfiguration = Object.assign({}, configuration, {
+      presets: [
+        ...configuration.presets,
+        preset,
+      ],
+    });
+    // When
+    result = BabelHelper.addPreset(configuration, preset);
+    // Then
+    expect(result).toEqual(expectedConfiguration);
+  });
+
+  it('should add two presets to an existing list of presets', () => {
+    // Given
+    const configuration = {
+      presets: [
+        'react-preset',
+        ['preact-preset', { cool: true }],
+      ],
+    };
+    const presetOne = 'angularjs-preset';
+    const presetTwo = ['aurelia-preset', { option: 'value' }];
+    let result = null;
+    const expectedConfiguration = {
+      presets: [
+        ...configuration.presets,
+        presetOne,
+        presetTwo,
+      ],
+    };
+    // When
+    result = BabelHelper.addPreset(configuration, [presetOne, presetTwo]);
+    // Then
+    expect(result).toEqual(expectedConfiguration);
+  });
+
+  it('shouldn\'t add a preset that is already on the configuration', () => {
+    // Given
+    const presetOne = 'react-preset';
+    const presetTwo = ['preact-annotate', { cool: true }];
+    const configuration = {
+      presets: [
+        presetOne,
+        presetTwo,
+      ],
+    };
+    let result = null;
+    // When
+    result = BabelHelper.addPreset(configuration, [presetOne, presetTwo]);
     // Then
     expect(result).toEqual(configuration);
   });


### PR DESCRIPTION
### What does this PR do?

It adds a new service called `babelHelper`. It allows plugins and services to modify a Babel configuration by adding plugins and presets on the fly:

1. The class is `BabelHelper`.
2. The service name is `babelHelper`.
3. `.addPlugin(configuration, plugin)` allows you to add a new plugin to a given configuration. The `plugin` can be either a string or a _"configuration array"_ (`[name, options]`). The method returns a new configuration.
4. `.addPreset(configuration, plugin)`, like `addPlugin` but for presets.
5. `.updateEnvPreset(configuration, updateFn)` allows you to modify the options of the `env` preset. The `updateFn` gets called with the current options and expects new ones on return.
6. `. disableEnvPresetModules(configuration)` sets the `modules` option of the `env` preset to `false`, required by plugins like react HMR and Rollup.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
