### PR TITLE
Always overwrite the output path for JS files when the target is a library

### DIFF
--- a/src/services/targets/targetsFinder.js
+++ b/src/services/targets/targetsFinder.js
@@ -347,10 +347,11 @@ class TargetsFinder {
       }
     }
     /**
-     * If the target is a library for the browser, change the output so it won't be adding hashes
-     * to the bundled filename nor saving it on a sub directory.
+     * If the target is a library, normalize the output so it won't add sub directories nor hashes.
+     * A library path is usually set on the `package.json` as the `main` setting, so the path
+     * shouldn't be dynamic.
      */
-    if (isBrowser && info.library) {
+    if (info.library) {
       info.output = {
         default: {
           js: '[target-name].js',

--- a/tests/services/targets/targetsFinder.test.js
+++ b/tests/services/targets/targetsFinder.test.js
@@ -571,6 +571,14 @@ describe('services/targets:targetsFinder', () => {
         development: null,
         production: null,
       },
+      output: {
+        default: {
+          js: '[target-name].js',
+        },
+        development: {
+          js: '[target-name].js',
+        },
+      },
       type: 'node',
       library: true,
     }];
@@ -622,6 +630,14 @@ describe('services/targets:targetsFinder', () => {
         default: indexFile,
         development: null,
         production: null,
+      },
+      output: {
+        default: {
+          js: '[target-name].js',
+        },
+        development: {
+          js: '[target-name].js',
+        },
       },
       type: 'node',
       library: true,


### PR DESCRIPTION
### What does this PR do?

When the `targetFinder` detects a library target, it will automatically set the output path for JS files (both for production and development) to `[target-name].js`.

The reason of the change is that libraries use the `main` key of the `package.json` and it should be a static path.

This change is breaking because if a library target didn't have its path overwritten, this change will updated to the new format.

### How should it be tested manually?

Create a library target and use `projext info targets` to see the `output` settings, the path for JS files should be `[target-name].js` for both production and development.

And of course...

```bash
npm test
# or
yarn test
```
