### PR TITLE
File rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
       "jest-ex": "4.0.0",
       "jest-cli": "22.1.4",
       "jasmine-expect": "3.8.3",
+      "minimatch": "3.0.4",
       "esdoc": "1.0.4",
       "esdoc-standard-plugin": "1.0.0",
       "esdoc-node": "1.0.3",

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -60,6 +60,7 @@ const {
 
 const {
   targets,
+  targetsFileRules,
   targetsFinder,
   targetsHTML,
 } = require('../services/targets');
@@ -127,6 +128,7 @@ class Projext extends Jimple {
     this.register(targetConfiguration);
 
     this.register(targets);
+    this.register(targetsFileRules);
     this.register(targetsFinder);
     this.register(targetsHTML);
 

--- a/src/services/targets/index.js
+++ b/src/services/targets/index.js
@@ -1,9 +1,11 @@
 const { targets } = require('./targets');
+const { targetsFileRules } = require('./targetsFileRules');
 const { targetsFinder } = require('./targetsFinder');
 const { targetsHTML } = require('./targetsHTML');
 
 module.exports = {
   targets,
+  targetsFileRules,
   targetsFinder,
   targetsHTML,
 };

--- a/src/services/targets/targetsFileRules/index.js
+++ b/src/services/targets/targetsFileRules/index.js
@@ -1,0 +1,5 @@
+const { targetsFileRules } = require('./targetsFileRules');
+
+module.exports = {
+  targetsFileRules,
+};

--- a/src/services/targets/targetsFileRules/targetFileRule.js
+++ b/src/services/targets/targetsFileRules/targetFileRule.js
@@ -1,0 +1,132 @@
+const extend = require('extend');
+/**
+ * Helper service used by {@link TargetsFileRules} in order to create dynamic file rules for
+ * multiple purposes.
+ */
+class TargetFileRule {
+  /**
+   * @param {Events}                events                   To reduce the rule settings updated.
+   * @param {string}                ruleType                 A reference identifier that tells for
+   *                                                         which kind file type the rule is
+   *                                                         being used for.
+   * @param {TargetFileRuleHandler} getSettingsForTargetRule To define the rule settings whenever
+   *                                                         a new target is added.
+   * @throws {Error} If `getSettingsForTargetRule` is not a function.
+   */
+  constructor(events, ruleType, getSettingsForTargetRule) {
+    /**
+     * A local reference for the `events` service.
+     * @type {Events}
+     */
+    this.events = events;
+    // Validate the handler function.
+    if (typeof getSettingsForTargetRule !== 'function') {
+      throw new Error('You need to specify a handler function for when a new target is added');
+    }
+    /**
+     * The reference identifier for the kind of rule this is for.
+     * @type {string}
+     * @access protected
+     * @ignore
+     */
+    this._ruleType = ruleType;
+    /**
+     * The function that generates the new settings when a new target is added.
+     * @type {TargetFileRuleHandler}
+     * @access protected
+     * @ignore
+     */
+    this._getSettingsForTargetRule = getSettingsForTargetRule;
+    /**
+     * The rule settings.
+     * @type {TargetFileRuleSettings}
+     * @access protected
+     * @ignore
+     */
+    this._rule = {
+      extension: /\.\w+$/i,
+      glob: '**/*.css',
+      paths: {
+        include: [],
+        exclude: [],
+      },
+      files: {
+        include: [],
+        exclude: [],
+        glob: {
+          include: [],
+          exclude: [],
+        },
+      },
+    };
+    /**
+     * Whether or not a target has been added to the rule.
+     * @type {boolean}
+     * @access protected
+     * @ignore
+     */
+    this._hasTarget = false;
+  }
+  /**
+   * Get the rule settings.
+   * @return {TargetFileRuleSettings}
+   */
+  getRule() {
+    return this._rule;
+  }
+  /**
+   * Add a target to the rule. This means the instance will process it and eventually add its
+   * paths to the settings.
+   * This method uses the reducer event `target-file-rule`, and if a target was already added,
+   * `target-file-rule-update` too. Both events receive the next state of the settings as well
+   * as the current, and expect the final state on return.
+   * @param {Target} target The target information.
+   */
+  addTarget(target) {
+    const changes = extend(
+      true,
+      {},
+      this._getSettingsForTargetRule(target, this._hasTarget, this._rule)
+    );
+
+    const finalRule = this._mergeRule(this._rule, changes);
+
+    const events = ['target-file-rule'];
+    if (this._hasTarget) {
+      events.push('target-file-rule-update');
+    }
+
+    this._hasTarget = true;
+    this._rule = this.events.reduce(events, finalRule, this._rule);
+  }
+  /**
+   * Merge two sets of rule settings. This is also used recursively to merge nested settings.
+   * @param {TargetFileRuleSettings|Object} base    The original rule or a set of properties of
+   *                                                the original rule.
+   * @param {TargetFileRuleSettings|Object} changes The rule that will be merged into the origina,
+   *                                                or a set of properties from it.
+   * @return {TargetFileRuleSettings|Object} The merged rule, or a set of merge properties.
+   * @access protected
+   * @ignore
+   */
+  _mergeRule(base, changes) {
+    const newRule = extend(true, {}, base);
+    Object.keys(changes).forEach((property) => {
+      const value = changes[property];
+      const propertyType = typeof value;
+      if (Array.isArray(value)) {
+        newRule[property].push(...value);
+      } else if (value instanceof RegExp) {
+        newRule[property] = value;
+      } else if (propertyType === 'object') {
+        newRule[property] = this._mergeRule(newRule[property], value);
+      } else {
+        newRule[property] = value;
+      }
+    });
+
+    return newRule;
+  }
+}
+
+module.exports = TargetFileRule;

--- a/src/services/targets/targetsFileRules/targetsFileRules.js
+++ b/src/services/targets/targetsFileRules/targetsFileRules.js
@@ -1,0 +1,488 @@
+const { provider } = require('jimple');
+const TargetFileRule = require('./targetFileRule');
+/**
+ * This service is intended as a helper for plugins or build engines that need to find targets
+ * files by creating a set of _"rules"_ for the basic type of files projext manages: JS, SCSS,
+ * CSS, fonts, images and favicons.
+ */
+class TargetsFileRules {
+  /**
+   * @param {Events}    events    To send to {@link TargetFileRule} and to inform when rules are
+   *                              created.
+   * @param {PathUtils} pathUtils To build the path to the configuration directory, in order to
+   *                              add it on the JS rule.
+   * @param {Targets}   targets   To get a target information when a set of rules is generated.
+   */
+  constructor(events, pathUtils, targets) {
+    /**
+     * A local reference for the `events` service.
+     * @type {Events}
+     */
+    this.events = events;
+    /**
+     * A local reference for the `pathUtils` service.
+     * @type {PathUtils}
+     */
+    this.pathUtils = pathUtils;
+    /**
+     * A local reference for the `targets` service.
+     * @type {Targets}
+     */
+    this.targets = targets;
+  }
+  /**
+   * Get a set of file rules for an specific target.
+   * @param {string|Target} target The target information or its name.
+   * @return {TargetFilesRules}
+   */
+  getRulesForTarget(target) {
+    // If the received `target` is a `string`, get its info.
+    const targetInfo = typeof target === 'string' ?
+      this.targets.getTarget(target) :
+      target;
+
+    // Define the rules.
+    const rules = {
+      js: this._getJSRule(targetInfo),
+      scss: this._getSCSSRule(targetInfo),
+      css: this._getCSSRule(targetInfo),
+      fonts: {
+        common: this._getCommonFontsRule(targetInfo),
+        svg: this._getSVGFontsRule(targetInfo),
+      },
+      images: this._getImagesRule(targetInfo),
+      favicon: this._getFaviconRule(targetInfo),
+    };
+
+    // Emit the event informing the rule has been created.
+    this.events.emit('target-file-rules', rules, targetInfo);
+    // Return teh rules.
+    return rules;
+  }
+  /**
+   * Creates the rule object for a target JS files.
+   * @param {Target} target The target information.
+   * @return {TargetFileRule}
+   * @access protected
+   * @ignore
+   */
+  _getJSRule(target) {
+    const rule = new TargetFileRule(this.events, 'js', (ruleTarget, hasTarget) => {
+      const pathsInclude = [];
+      const filesInclude = [];
+      const filesGlobInclude = [];
+      /**
+       * If this is the first time a target is being added to the rule, add the configuration
+       * directory path to the lists of allowed paths.
+       */
+      if (!hasTarget) {
+        // Get the configuration directory path.
+        const config = this.pathUtils.join('config');
+        // Push it to the list of paths.
+        pathsInclude.push(new RegExp(config, 'i'));
+        // Push it to the lists of files.
+        filesInclude.push(new RegExp(`${config}/.*?\\.jsx?$`, 'i'));
+        filesGlobInclude.push(`${config}/**/*.{js,jsx}`);
+      }
+      // Define the allowed paths.
+      pathsInclude.push(...[
+        // The target path.
+        new RegExp(ruleTarget.paths.source, 'i'),
+        // The paths for modules that have been explicity included on the target settings.
+        ...ruleTarget.includeModules.map((modName) => (
+          new RegExp(`/node_modules/${modName}`)
+        )),
+      ]);
+      // Define the allowed file paths.
+      filesInclude.push(...[
+        // Target files.
+        new RegExp(`${ruleTarget.paths.source}/.*?\\.jsx?$`, 'i'),
+        // Files of modules that have been explicity included on the target settings.
+        ...ruleTarget.includeModules.map((modName) => (
+          new RegExp(`/node_modules/${modName}/.*?\\.jsx?$`, 'i')
+        )),
+      ]);
+      // Define the allowed file paths, on glob format.
+      filesGlobInclude.push(...[
+        // Target files.
+        `${ruleTarget.paths.source}/**/*.{js,jsx}`,
+        // Files of modules that have been explicity included on the target settings.
+        ...ruleTarget.includeModules.map((modName) => (
+          `/node_modules/${modName}/**/*.{js,jsx}`
+        )),
+      ]);
+      // Return the rule settings.
+      return {
+        extension: /\.jsx?$/i,
+        glob: '**/*.{js,jsx}',
+        paths: {
+          include: pathsInclude,
+          exclude: [],
+        },
+        files: {
+          include: filesInclude,
+          exclude: [],
+          glob: {
+            include: filesGlobInclude,
+            exclude: [],
+          },
+        },
+      };
+    });
+    // Add the target to the rule.
+    rule.addTarget(target);
+    // Emit the event informing the rule has been created.
+    this.events.emit('target-js-files-rule', rule, target);
+    // Return the rule.
+    return rule;
+  }
+  /**
+   * Creates the rule object for a target SCSS files.
+   * @param {Target} target The target information.
+   * @return {TargetFileRule}
+   * @access protected
+   * @ignore
+   */
+  _getSCSSRule(target) {
+    const rule = new TargetFileRule(this.events, 'scss', (ruleTarget) => ({
+      extension: /\.scss$/i,
+      glob: '**/*.scss',
+      paths: {
+        // Define the allowed paths.
+        include: [
+          // The target path.
+          new RegExp(ruleTarget.paths.source, 'i'),
+          // The paths for modules that have been explicity included on the target settings.
+          ...ruleTarget.includeModules.map((modName) => (
+            new RegExp(`/node_modules/${modName}`)
+          )),
+        ],
+        exclude: [],
+      },
+      files: {
+        // Define the allowed file paths.
+        include: [
+          // Target files.
+          new RegExp(`${ruleTarget.paths.source}/.*?\\.scss$`, 'i'),
+          // Files of modules that have been explicity included on the target settings.
+          ...ruleTarget.includeModules.map((modName) => (
+            new RegExp(`/node_modules/${modName}/.*?\\.scss$`, 'i')
+          )),
+        ],
+        exclude: [],
+        glob: {
+          // Define the allowed file paths, on glob format.
+          include: [
+            // Target files.
+            `${ruleTarget.paths.source}/**/*.scss`,
+            // Files of modules that have been explicity included on the target settings.
+            ...ruleTarget.includeModules.map((modName) => (
+              `/node_modules/${modName}/**/*.scss`
+            )),
+          ],
+          exclude: [],
+        },
+      },
+    }));
+    // Add the target to the rule.
+    rule.addTarget(target);
+    // Emit the event informing the rule has been created.
+    this.events.emit('target-scss-files-rule', rule, target);
+    // Return the rule.
+    return rule;
+  }
+  /**
+   * Creates the rule object for a target CSS files.
+   * @param {Target} target The target information.
+   * @return {TargetFileRule}
+   * @access protected
+   * @ignore
+   */
+  _getCSSRule(target) {
+    const rule = new TargetFileRule(this.events, 'css', (ruleTarget) => ({
+      extension: /\.css$/i,
+      glob: '**/*.css',
+      paths: {
+        // Define the allowed paths.
+        include: [
+          // The target path.
+          new RegExp(ruleTarget.paths.source, 'i'),
+          // Any path inside the `node_modules` directory.
+          /\/node_modules\//i,
+        ],
+        exclude: [],
+      },
+      files: {
+        // Define the allowed file paths.
+        include: [
+          // Target files.
+          new RegExp(`${ruleTarget.paths.source}/.*?\\.css$`, 'i'),
+          // Any file inside the `node_modules` directory.
+          /\/node_modules\/.*?\.css$/i,
+        ],
+        exclude: [],
+        glob: {
+          // Define the allowed file paths, on glob format.
+          include: [
+            // Target files.
+            `${ruleTarget.paths.source}/**/*.css`,
+            // Any file inside the `node_modules` directory.
+            '/node_modules/**/*.css',
+          ],
+          exclude: [],
+        },
+      },
+    }));
+    // Add the target to the rule.
+    rule.addTarget(target);
+    // Emit the event informing the rule has been created.
+    this.events.emit('target-css-files-rule', rule, target);
+    // Return the rule.
+    return rule;
+  }
+  /**
+   * Creates the rule object for a target common font files. By _"common"_, it means that it
+   * doesn't include `.svg` files; the reason is that have some very specific expressions so they
+   * can be differentiated from images.
+   * @param {Target} target The target information.
+   * @return {TargetFileRule}
+   * @access protected
+   * @ignore
+   */
+  _getCommonFontsRule(target) {
+    const rule = new TargetFileRule(this.events, 'fonts.common', (ruleTarget) => ({
+      extension: /\.(?:woff2?|ttf|eot)$/i,
+      glob: '**/*.{woff,woff2,ttf,eot}',
+      paths: {
+        // Define the allowed paths.
+        include: [
+          // The target path.
+          new RegExp(ruleTarget.paths.source, 'i'),
+          // Any path inside the `node_modules` directory.
+          /\/node_modules\//i,
+        ],
+        exclude: [],
+      },
+      files: {
+        // Define the allowed file paths.
+        include: [
+          // Target files.
+          new RegExp(`${ruleTarget.paths.source}/.*?\\.(?:woff2?|ttf|eot)`, 'i'),
+          // Any file inside the `node_modules` directory.
+          /\/node_modules\/.*?\.(?:woff2?|ttf|eot)$/i,
+        ],
+        exclude: [],
+        glob: {
+          // Define the allowed file paths, on glob format.
+          include: [
+            // Target files.
+            `${ruleTarget.paths.source}/**/*.{woff,woff2,ttf,eot}`,
+            // Any file inside the `node_modules` directory.
+            '/node_modules/**/*.{woff,woff2,ttf,eot}',
+          ],
+          exclude: [],
+        },
+      },
+    }));
+    // Add the target to the rule.
+    rule.addTarget(target);
+    // Emit the event informing the rule has been created.
+    this.events.emit('target-common-font-files-rule', rule, target);
+    // Return the rule.
+    return rule;
+  }
+  /**
+   * Creates the rule object for a target SVG font files. This is separated from the _"common"_
+   * fonts because projext only recognizes `.svg` files as fonts when they are inside a `fonts`
+   * directory.
+   * @param {Target} target The target information.
+   * @return {TargetFileRule}
+   * @access protected
+   * @ignore
+   */
+  _getSVGFontsRule(target) {
+    const rule = new TargetFileRule(this.events, 'fonts.svg', (ruleTarget) => ({
+      extension: /\.svg$/i,
+      glob: '**/*.svg',
+      paths: {
+        // Define the allowed paths.
+        include: [
+          // Any path inside the target directory that contains a `fonts` component.
+          new RegExp(`${ruleTarget.paths.source}/(?:.*?/)?fonts(?:/.*?)?$`, 'i'),
+          // Any path on the `node_modules` that contains a `fonts` component.
+          /\/node_modules\/(?:.*?\/)?fonts(?:\/.*?)?$/i,
+        ],
+        exclude: [],
+      },
+      files: {
+        // Define the allowed file paths.
+        include: [
+          // Any `.svg` inside a `fonts` directory, on the target directory or the `node_modules`.
+          new RegExp(`${ruleTarget.paths.source}/(?:.*?/)?fonts/.*?\\.svg$`, 'i'),
+          /\/node_modules\/(?:.*?\/)?fonts\/.*?\.svg$/i,
+        ],
+        exclude: [],
+        glob: {
+          // Define the allowed file paths, on glob format.
+          include: [
+            /**
+             * Any `.svg` inside a `fonts` directory, on the target directory or the
+             * `node_modules`.
+             */
+            `${ruleTarget.paths.source}/**/fonts/**/*.svg`,
+            '/node_modules/**/fonts/**/*.svg',
+          ],
+          exclude: [],
+        },
+      },
+    }));
+    // Add the target to the rule.
+    rule.addTarget(target);
+    // Emit the event informing the rule has been created.
+    this.events.emit('target-svg-font-files-rule', rule, target);
+    // Return the rule.
+    return rule;
+  }
+  /**
+   * Creates the rule object for a target image files.
+   * @param {Target} target The target information.
+   * @return {TargetFileRule}
+   * @access protected
+   * @ignore
+   */
+  _getImagesRule(target) {
+    const rule = new TargetFileRule(this.events, 'images', (ruleTarget) => {
+      /**
+       * Define the excluded paths.
+       * The issue here is that the rule should pick `.svg` files as images, but not if they
+       * are inside a `fonts` directory, that's why the path expressions also include extensions.
+       * The same goes for favicons, it should pick `png` and `ico` files, but not if they are
+       * called `favicon`.
+       */
+      const exclude = [
+        // Any path for an `.svg` file inside a `fonts` directory.
+        new RegExp(`${ruleTarget.paths.source}/(?:.*?/)?fonts/.*?\\.svg$`, 'i'),
+        // Any path for a `favicon` file with extension `png` or `ico`.
+        new RegExp(`${ruleTarget.paths.source}/.*?favicon\\.(png|ico)$`, 'i'),
+        // Any path for an `.svg` file with a `fonts` component inside the `node_modules`.
+        /\/node_modules\/(?:.*?\/)?fonts\/.*?\.svg$/i,
+      ];
+
+      return {
+        extension: /\.(jpe?g|png|gif|svg)$/i,
+        glob: '**/*.{jpg,jpeg,png,gif,svg}',
+        paths: {
+          // Define the allowed paths.
+          include: [
+            // The target path.
+            new RegExp(ruleTarget.paths.source, 'i'),
+            // Any path inside the `node_modules` directory.
+            /\/node_modules\//i,
+          ],
+          // Exclude anything related to fonts.
+          exclude,
+        },
+        files: {
+          // Define the allowed file paths.
+          include: [
+            // Target files.
+            new RegExp(`${ruleTarget.paths.source}/.*?\\.(?:jpe?g|png|gif|svg)`, 'i'),
+            // Any file inside the `node_modules` directory.
+            /\/node_modules\/.*?\.(?:jpe?g|png|gif|svg)$/i,
+          ],
+          // Exclude anything related to fonts.
+          exclude,
+          glob: {
+            // Define the allowed file paths, on glob format.
+            include: [
+              // Target files.
+              `${ruleTarget.paths.source}/**/*.{jpg,jpeg,png,gif,svg}`,
+              // Any file inside the `node_modules` directory.
+              '/node_modules/**/*.{jpg,jpeg,png,gif,svg}',
+            ],
+            // Exclude anything related to fonts.
+            exclude: [
+              // Any path for an `.svg` file inside a `fonts` directory.
+              `${ruleTarget.paths.source}/**/fonts/**/*.svg`,
+              // Any path for a `favicon` file with extension `png` or `ico`.
+              `${ruleTarget.paths.source}/**/favicon.{png,ico}`,
+              // Any path for an `.svg` file with a `fonts` component inside the `node_modules`.
+              '/node_modules/**/fonts/**/*.svg',
+            ],
+          },
+        },
+      };
+    });
+    // Add the target to the rule.
+    rule.addTarget(target);
+    // Emit the event informing the rule has been created.
+    this.events.emit('target-image-files-rule', rule, target);
+    // Return the rule.
+    return rule;
+  }
+  /**
+   * Creates the rule object for a target favicon files.
+   * @param {Target} target The target information.
+   * @return {TargetFileRule}
+   * @access protected
+   * @ignore
+   */
+  _getFaviconRule(target) {
+    const rule = new TargetFileRule(this.events, 'favicon', (ruleTarget) => ({
+      extension: /\.(png|ico)$/i,
+      glob: '**/*.{png,ico}',
+      paths: {
+        // Define the allowed paths.
+        include: [
+          // The target path.
+          new RegExp(ruleTarget.paths.source, 'i'),
+        ],
+        exclude: [],
+      },
+      files: {
+        // Define the allowed file paths.
+        include: [
+          // Any file called `favicon` with the extension `png` or `ico`
+          new RegExp(`${ruleTarget.paths.source}/.*?favicon\\.(png|ico)$`, 'i'),
+        ],
+        exclude: [],
+        glob: {
+          // Define the allowed file paths, on glob format.
+          include: [
+            // Any file called `favicon` with the extension `png` or `ico`
+            `${ruleTarget.paths.source}/**/favicon.{png,ico}`,
+          ],
+          exclude: [],
+        },
+      },
+    }));
+    // Add the target to the rule.
+    rule.addTarget(target);
+    // Emit the event informing the rule has been created.
+    this.events.emit('target-favicon-files-rule', rule, target);
+    // Return the rule.
+    return rule;
+  }
+}
+/**
+ * The service provider that once registered on the app container will set an instance of
+ * `TargetsFileRules` as the `targetsFileRules` service.
+ * @example
+ * // Register it on the container
+ * container.register(targetsFileRules);
+ * // Getting access to the service instance
+ * const targetsFileRules = container.get('targetsFileRules');
+ * @type {Provider}
+ */
+const targetsFileRules = provider((app) => {
+  app.set('targetsFileRules', () => new TargetsFileRules(
+    app.get('events'),
+    app.get('pathUtils'),
+    app.get('targets')
+  ));
+});
+
+module.exports = {
+  TargetsFileRules,
+  targetsFileRules,
+};

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -736,6 +736,70 @@
  */
 
 /**
+ * @typedef {Object} TargetFileRulePathSettings
+ * @property {Array} include The list of expressions that match the allowed paths for a rule.
+ * @property {Array} exclude The list of expressions that match the paths that should be excluded
+ *                           from a rule.
+ */
+
+/**
+ * @typedef {Object} TargetFileRuleGlobFilesSettings
+ * @property {Array} include The list of glob patterns that match the allowed files for a rule.
+ * @property {Array} exclude The list of glob patterns that match the files that should be excluded
+ *                           from a rule.
+ */
+
+/**
+ * @typedef {Object} TargetFileRuleFilesSettings
+ * @property {Array}                           include The list of expressions that match the
+ *                                                     allowed files for a rule.
+ * @property {Array}                           exclude The list of expressions that match the
+ *                                                     files that should be excluded from a rule.
+ * @property {TargetFileRuleGlobFilesSettings} glob    The settings for files but on glob pattern
+ *                                                     version. For plugins and libraries that
+ *                                                     don't support, or maybe prefer glob over,
+ *                                                     expressions.
+ */
+
+/**
+ * @typedef {Object} TargetFileRuleSettings
+ * @property {RegExp}                      extension A expression that validates the extension(s)
+ *                                                   the rule is for.
+ * @property {string}                      glob      A glob pattern that validates the extension(s)
+ *                                                   the rule is for.
+ * @property {TargetFileRulePathSettings}  paths     A set of allowed and excluded expressions to
+ *                                                   validate the paths where the files can be
+ *                                                   found.
+ * @property {TargetFileRuleFilesSettings} files     A set of allowed and excluded expressions and
+ *                                                   glob patterns for files that would match with
+ *                                                   the rule.
+ */
+
+/**
+ * @typedef {function} TargetFileRuleHandler
+ * @param {Target}                 target      The target information.
+ * @param {boolean}                hasTarget   Whether or not the rule already has a target, or if
+ *                                             this is the first one being added.
+ * @param {TargetFileRuleSettings} currentRule The current settings of the rule.
+ */
+
+/**
+ * @typedef {Object} TargetFontsFileRules
+ * @property {TargetFileRule} common The rule for all font files that aren't SVG.
+ * @property {TargetFileRule} svg    The rule for SVG fonts.
+ */
+
+/**
+ * @typedef {Object} TargetFilesRules
+ * @property {TargetFileRule}       js      The rule for JS files.
+ * @property {TargetFileRule}       scss    The rule for SCSS files.
+ * @property {TargetFileRule}       css     The rule for CSS files.
+ * @property {TargetFontsFileRules} fonts   The rules for font files.
+ * @property {TargetFileRule}       images  The rule for image files.
+ * @property {TargetFileRule}       favicon The rule for favicon files.
+ */
+
+/**
  * ================================================================================================
  * "Interfaces"
  * ================================================================================================

--- a/tests/services/targets/targetsFileRules/targetFileRule.test.js
+++ b/tests/services/targets/targetsFileRules/targetFileRule.test.js
@@ -1,0 +1,202 @@
+jest.unmock('/src/services/targets/targetsFileRules/targetFileRule');
+
+require('jasmine-expect');
+
+const TargetFileRule = require('/src/services/targets/targetsFileRules/targetFileRule');
+
+describe('services/targets:targetsFileRules', () => {
+  const getEmptyRule = () => ({
+    extension: /\.\w+$/i,
+    glob: '**/*.css',
+    paths: {
+      include: [],
+      exclude: [],
+    },
+    files: {
+      include: [],
+      exclude: [],
+      glob: {
+        include: [],
+        exclude: [],
+      },
+    },
+  });
+
+  it('should be instantiated with all its dependencies', () => {
+    // Given
+    const events = 'events';
+    let sut = null;
+    // When
+    sut = new TargetFileRule(events, 'something', () => {});
+    // Then
+    expect(sut).toBeInstanceOf(TargetFileRule);
+    expect(sut.events).toBe(events);
+  });
+
+  it('should throw an error if instantiated without a handler function', () => {
+    // Given/When/Then
+    expect(() => new TargetFileRule()).toThrow(/you need to specify a handler function/i);
+  });
+
+  it('should return an empty rule if no target was added', () => {
+    // Given
+    const events = 'events';
+    let sut = null;
+    let result = null;
+    // When
+    sut = new TargetFileRule(events, 'something', () => {});
+    result = sut.getRule();
+    // Then
+    expect(result).toEqual(getEmptyRule());
+  });
+
+  it('should call the handler function when a new target is added', () => {
+    // Given
+    const events = {
+      reduce: jest.fn((eventName, rule) => rule),
+    };
+    const target = 'my-target';
+    const targetRule = {
+      extension: /\.jsx?$/i,
+      glob: '**/*.{js,jsx}',
+      paths: {
+        include: ['include-some-regex-path'],
+        exclude: ['exclude-some-regex-path'],
+      },
+      files: {
+        include: ['include-some-regex-filepath'],
+        exclude: ['exclude-some-regex-filepath'],
+        glob: {
+          include: ['include-some-glob-filepath'],
+          exclude: ['exclude-some-glob-filepath'],
+        },
+      },
+    };
+    const handler = jest.fn(() => targetRule);
+    let sut = null;
+    let result = null;
+    const expectedEmptyRule = getEmptyRule();
+    // When
+    sut = new TargetFileRule(events, 'something', handler);
+    sut.addTarget(target);
+    result = sut.getRule();
+    // Then
+    expect(result).toEqual(targetRule);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(target, false, expectedEmptyRule);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(
+      ['target-file-rule'],
+      targetRule,
+      expectedEmptyRule
+    );
+  });
+
+  it('should update the rule when multiple targets are added', () => {
+    // Given
+    const events = {
+      reduce: jest.fn((eventName, rule) => rule),
+    };
+    const targetOne = 'my-target';
+    const targetOneRule = {
+      extension: /\.jsx?$/i,
+      glob: '**/*.{js,jsx}',
+      paths: {
+        include: ['target-one-include-some-regex-path'],
+        exclude: ['target-one-exclude-some-regex-path'],
+      },
+      files: {
+        include: ['target-one-include-some-regex-filepath'],
+        exclude: ['target-one-exclude-some-regex-filepath'],
+        glob: {
+          include: ['target-one-include-some-glob-filepath'],
+          exclude: ['target-one-exclude-some-glob-filepath'],
+        },
+      },
+    };
+    const targetTwo = 'my-other-target';
+    const targetTwoRule = {
+      paths: {
+        include: ['target-two-include-some-regex-path'],
+        exclude: ['target-two-exclude-some-regex-path'],
+      },
+      files: {
+        include: ['target-two-include-some-regex-filepath'],
+        exclude: ['target-two-exclude-some-regex-filepath'],
+        glob: {
+          include: ['target-two-include-some-glob-filepath'],
+          exclude: ['target-two-exclude-some-glob-filepath'],
+        },
+      },
+    };
+    const rulesByTarget = {
+      [targetOne]: targetOneRule,
+      [targetTwo]: targetTwoRule,
+    };
+    const handler = jest.fn((targetInfo) => rulesByTarget[targetInfo]);
+    let sut = null;
+    let resultBeforeAddingAnything = null;
+    let resultAfterAddingOneTarget = null;
+    let resultAfterAddingAnotherTarget = null;
+    const expectedEmptyRule = getEmptyRule();
+    const expectedFinalRule = {
+      extension: targetOneRule.extension,
+      glob: targetOneRule.glob,
+      paths: {
+        include: [
+          ...targetOneRule.paths.include,
+          ...targetTwoRule.paths.include,
+        ],
+        exclude: [
+          ...targetOneRule.paths.exclude,
+          ...targetTwoRule.paths.exclude,
+        ],
+      },
+      files: {
+        include: [
+          ...targetOneRule.files.include,
+          ...targetTwoRule.files.include,
+        ],
+        exclude: [
+          ...targetOneRule.files.exclude,
+          ...targetTwoRule.files.exclude,
+        ],
+        glob: {
+          include: [
+            ...targetOneRule.files.glob.include,
+            ...targetTwoRule.files.glob.include,
+          ],
+          exclude: [
+            ...targetOneRule.files.glob.exclude,
+            ...targetTwoRule.files.glob.exclude,
+          ],
+        },
+      },
+    };
+    // When
+    sut = new TargetFileRule(events, 'something', handler);
+    resultBeforeAddingAnything = sut.getRule();
+    sut.addTarget(targetOne);
+    resultAfterAddingOneTarget = sut.getRule();
+    sut.addTarget(targetTwo);
+    resultAfterAddingAnotherTarget = sut.getRule();
+    // Then
+    expect(resultBeforeAddingAnything).toEqual(expectedEmptyRule);
+    expect(resultAfterAddingOneTarget).toEqual(targetOneRule);
+    expect(resultAfterAddingAnotherTarget).toEqual(expectedFinalRule);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenCalledWith(targetOne, false, expectedEmptyRule);
+    expect(handler).toHaveBeenCalledWith(targetTwo, true, targetOneRule);
+    expect(events.reduce).toHaveBeenCalledTimes(2);
+    expect(events.reduce).toHaveBeenCalledWith(
+      ['target-file-rule'],
+      targetOneRule,
+      expectedEmptyRule
+    );
+    expect(events.reduce).toHaveBeenCalledWith(
+      ['target-file-rule', 'target-file-rule-update'],
+      expectedFinalRule,
+      targetOneRule
+    );
+  });
+});

--- a/tests/services/targets/targetsFileRules/targetsFileRules.test.js
+++ b/tests/services/targets/targetsFileRules/targetsFileRules.test.js
@@ -1,0 +1,1303 @@
+const JimpleMock = require('/tests/mocks/jimple.mock');
+
+jest.mock('jimple', () => JimpleMock);
+jest.unmock('/src/services/targets/targetsFileRules/targetsFileRules');
+
+require('jasmine-expect');
+const minimatch = require('minimatch');
+
+const TargetFileRule = require('/src/services/targets/targetsFileRules/targetFileRule');
+const {
+  TargetsFileRules,
+  targetsFileRules,
+} = require('/src/services/targets/targetsFileRules/targetsFileRules');
+
+describe('services/targets:targetsFileRules', () => {
+  const testRuleProperty = (shouldMatch, pathToTest, expression, glob = null, debug = false) => {
+    if (shouldMatch) {
+      expect(pathToTest).toMatch(expression);
+      if (glob) {
+        expect(minimatch(pathToTest, glob, (debug ? { debug: true } : {}))).toBeTrue();
+      }
+    } else {
+      expect(pathToTest).not.toMatch(expression);
+      if (glob) {
+        expect(minimatch(pathToTest, glob, (debug ? { debug: true } : {}))).toBeFalse();
+      }
+    }
+  };
+
+  beforeEach(() => {
+    TargetFileRule.mockReset();
+  });
+
+  it('should be instantiated with all its dependencies', () => {
+    // Given
+    const events = 'events';
+    const pathUtils = 'pathUtils';
+    const targets = 'targets';
+    let sut = null;
+    // When
+    sut = new TargetsFileRules(events, pathUtils, targets);
+    // Then
+    expect(sut).toBeInstanceOf(TargetsFileRules);
+    expect(sut.events).toBe(events);
+    expect(sut.pathUtils).toBe(pathUtils);
+    expect(sut.targets).toBe(targets);
+  });
+
+  it('should generate the rules for a target', () => {
+    // Given
+    const events = {
+      emit: jest.fn(),
+    };
+    const pathUtils = 'pathUtils';
+    const targets = 'targets';
+    const target = {
+      name: 'my-target',
+    };
+    let sut = null;
+    let result = null;
+    const basicRuleTypes = [
+      'js',
+      'scss',
+      'css',
+      'images',
+      'favicon',
+    ];
+    const expectedRuleTypes = [
+      ...basicRuleTypes,
+      'fonts.common',
+      'fonts.svg',
+    ];
+    const expectedRules = {
+      fonts: {
+        common: expect.any(TargetFileRule),
+        svg: expect.any(TargetFileRule),
+      },
+    };
+    basicRuleTypes.forEach((ruleType) => {
+      expectedRules[ruleType] = expect.any(TargetFileRule);
+    });
+    const expectedRuleTypeEvents = [
+      'target-js-files-rule',
+      'target-scss-files-rule',
+      'target-css-files-rule',
+      'target-common-font-files-rule',
+      'target-svg-font-files-rule',
+      'target-image-files-rule',
+      'target-favicon-files-rule',
+    ];
+    // When
+    sut = new TargetsFileRules(events, pathUtils, targets);
+    result = sut.getRulesForTarget(target);
+    // Then
+    expect(result).toEqual(expectedRules);
+    expect(TargetFileRule).toHaveBeenCalledTimes(expectedRuleTypes.length);
+    expectedRuleTypes.forEach((ruleType) => {
+      expect(TargetFileRule).toHaveBeenCalledWith(events, ruleType, expect.any(Function));
+    });
+    expect(events.emit).toHaveBeenCalledTimes(expectedRuleTypeEvents.length + 1);
+    expectedRuleTypeEvents.forEach((eventName) => {
+      expect(events.emit).toHaveBeenCalledWith(eventName, expect.any(TargetFileRule), target);
+    });
+    expect(events.emit).toHaveBeenCalledWith(
+      'target-file-rules',
+      {
+        js: expect.any(TargetFileRule),
+        scss: expect.any(TargetFileRule),
+        css: expect.any(TargetFileRule),
+        fonts: {
+          common: expect.any(TargetFileRule),
+          svg: expect.any(TargetFileRule),
+        },
+        images: expect.any(TargetFileRule),
+        favicon: expect.any(TargetFileRule),
+      },
+      target
+    );
+  });
+
+  it('should generate the rules for a target using its name', () => {
+    // Given
+    const events = {
+      emit: jest.fn(),
+    };
+    const pathUtils = 'pathUtils';
+    const target = 'my-name';
+    const targetInfo = {
+      name: target,
+    };
+    const targets = {
+      getTarget: jest.fn(() => targetInfo),
+    };
+    let sut = null;
+    let result = null;
+    const basicRuleTypes = [
+      'js',
+      'scss',
+      'css',
+      'images',
+      'favicon',
+    ];
+    const expectedRuleTypes = [
+      ...basicRuleTypes,
+      'fonts.common',
+      'fonts.svg',
+    ];
+    const expectedRules = {
+      fonts: {
+        common: expect.any(TargetFileRule),
+        svg: expect.any(TargetFileRule),
+      },
+    };
+    basicRuleTypes.forEach((ruleType) => {
+      expectedRules[ruleType] = expect.any(TargetFileRule);
+    });
+    const expectedRuleTypeEvents = [
+      'target-js-files-rule',
+      'target-scss-files-rule',
+      'target-css-files-rule',
+      'target-common-font-files-rule',
+      'target-svg-font-files-rule',
+      'target-image-files-rule',
+      'target-favicon-files-rule',
+    ];
+    // When
+    sut = new TargetsFileRules(events, pathUtils, targets);
+    result = sut.getRulesForTarget(target);
+    // Then
+    expect(result).toEqual(expectedRules);
+    expect(TargetFileRule).toHaveBeenCalledTimes(expectedRuleTypes.length);
+    expectedRuleTypes.forEach((ruleType) => {
+      expect(TargetFileRule).toHaveBeenCalledWith(events, ruleType, expect.any(Function));
+    });
+    expect(targets.getTarget).toHaveBeenCalledTimes(1);
+    expect(targets.getTarget).toHaveBeenCalledWith(target);
+    expect(events.emit).toHaveBeenCalledTimes(expectedRuleTypeEvents.length + 1);
+    expectedRuleTypeEvents.forEach((eventName) => {
+      expect(events.emit).toHaveBeenCalledWith(eventName, expect.any(TargetFileRule), targetInfo);
+    });
+    expect(events.emit).toHaveBeenCalledWith(
+      'target-file-rules',
+      {
+        js: expect.any(TargetFileRule),
+        scss: expect.any(TargetFileRule),
+        css: expect.any(TargetFileRule),
+        fonts: {
+          common: expect.any(TargetFileRule),
+          svg: expect.any(TargetFileRule),
+        },
+        images: expect.any(TargetFileRule),
+        favicon: expect.any(TargetFileRule),
+      },
+      targetInfo
+    );
+  });
+
+  it('should generate the JS rules for a target', () => {
+    // Given
+    const events = {
+      emit: jest.fn(),
+    };
+    const configAbsPath = '/some-config-path';
+    const pathUtils = {
+      join: jest.fn(() => configAbsPath),
+    };
+    const targets = 'targets';
+    const moduleToInclude = 'jimpex';
+    const source = 'target-source';
+    const target = {
+      name: 'my-target',
+      paths: {
+        source,
+      },
+      includeModules: [moduleToInclude],
+    };
+    let sut = null;
+    let rule = null;
+    let fn = null;
+    let result = null;
+    const extension = {
+      regex: null,
+      glob: null,
+    };
+    const paths = {
+      config: null,
+      target: null,
+      module: null,
+    };
+    const regexs = {
+      config: null,
+      target: null,
+      module: null,
+    };
+    const globs = {
+      config: null,
+      target: null,
+      module: null,
+    };
+    // When
+    sut = new TargetsFileRules(events, pathUtils, targets);
+    rule = sut.getRulesForTarget(target).js;
+    [[,, fn]] = TargetFileRule.mock.calls;
+    result = fn(target);
+    extension.regex = result.extension;
+    extension.glob = result.glob;
+    [
+      paths.config,
+      paths.target,
+      paths.module,
+    ] = result.paths.include;
+    [
+      regexs.config,
+      regexs.target,
+      regexs.module,
+    ] = result.files.include;
+    [
+      globs.config,
+      globs.target,
+      globs.module,
+    ] = result.files.glob.include;
+    // Then
+    expect(rule.addTarget).toHaveBeenCalledTimes(1);
+    expect(rule.addTarget).toHaveBeenCalledWith(target);
+    expect(result).toEqual({
+      extension: expect.any(RegExp),
+      glob: expect.any(String),
+      paths: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+      },
+      files: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+        glob: {
+          include: [
+            expect.any(String),
+            expect.any(String),
+            expect.any(String),
+          ],
+          exclude: [],
+        },
+      },
+    });
+
+    expect(pathUtils.join).toHaveBeenCalledTimes(1);
+    expect(pathUtils.join).toHaveBeenCalledWith('config');
+
+    // Extension
+    testRuleProperty(true, 'file.js', extension.regex, extension.glob);
+    testRuleProperty(true, 'file.jsx', extension.regex, extension.glob);
+    testRuleProperty(false, 'file.css', extension.regex, extension.glob);
+
+    // Paths
+    // -- Config
+
+    testRuleProperty(true, `${configAbsPath}/something`, paths.config);
+    testRuleProperty(true, `${configAbsPath}/something/else`, paths.config);
+    testRuleProperty(false, 'ramdom-path/to/something', paths.config);
+
+    // -- Target
+    testRuleProperty(true, `${source}/something`, paths.target);
+    testRuleProperty(true, `${source}/something/else`, paths.target);
+    testRuleProperty(false, 'random-path/to/something', paths.target);
+
+    // -- Module
+    testRuleProperty(true, `/node_modules/${moduleToInclude}/something`, paths.module);
+    testRuleProperty(true, `/node_modules/${moduleToInclude}/something/else`, paths.module);
+    testRuleProperty(false, '/node_modules/wootils/something/else', paths.module);
+
+    // Files
+    // -- Config
+    testRuleProperty(true, `${configAbsPath}/file.js`, regexs.config, globs.config);
+    testRuleProperty(true, `${configAbsPath}/other/file.js`, regexs.config, globs.config);
+    testRuleProperty(false, `${configAbsPath}/other.txt`, regexs.config, globs.config);
+    testRuleProperty(false, 'random-config/file.js', regexs.config, globs.config);
+
+    // -- Target
+    testRuleProperty(true, `${source}/modules/file.js`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.jsx`, regexs.target, globs.target);
+    testRuleProperty(false, `${source}/modules/other.css`, regexs.target, globs.target);
+
+    // --- Module
+    testRuleProperty(
+      true,
+      `/node_modules/${moduleToInclude}/file.js`,
+      regexs.module,
+      globs.module
+    );
+    testRuleProperty(
+      true,
+      `/node_modules/${moduleToInclude}/other/file.jsx`,
+      regexs.module,
+      globs.module
+    );
+    testRuleProperty(
+      false,
+      '/node_modules/wootils/other.js',
+      regexs.module,
+      globs.module
+    );
+    testRuleProperty(
+      false,
+      `/node_modules/${moduleToInclude}/other.tsx`,
+      regexs.module,
+      globs.module
+    );
+  });
+
+  it('shouldn\'t include the config path on the JS rule when adding a second target', () => {
+    // Given
+    const events = {
+      emit: jest.fn(),
+    };
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    const targets = 'targets';
+    const moduleToInclude = 'jimpex';
+    const source = 'target-source';
+    const target = {
+      name: 'my-target',
+      paths: {
+        source,
+      },
+      includeModules: [moduleToInclude],
+    };
+    let sut = null;
+    let fn = null;
+    let result = null;
+    // When
+    sut = new TargetsFileRules(events, pathUtils, targets);
+    sut.getRulesForTarget(target);
+    [[,, fn]] = TargetFileRule.mock.calls;
+    result = fn(target, true);
+    // Then
+    expect(result).toEqual({
+      extension: expect.any(RegExp),
+      glob: expect.any(String),
+      paths: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+      },
+      files: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+        glob: {
+          include: [
+            expect.any(String),
+            expect.any(String),
+          ],
+          exclude: [],
+        },
+      },
+    });
+
+    expect(pathUtils.join).toHaveBeenCalledTimes(0);
+  });
+
+  it('should generate the SCSS rules for a target', () => {
+    // Given
+    const events = {
+      emit: jest.fn(),
+    };
+    const pathUtils = 'pathUtils';
+    const targets = 'targets';
+    const moduleToInclude = 'jimpex';
+    const source = 'target-source';
+    const target = {
+      name: 'my-target',
+      paths: {
+        source,
+      },
+      includeModules: [moduleToInclude],
+    };
+    let sut = null;
+    let rule = null;
+    let fn = null;
+    let result = null;
+    const extension = {
+      regex: null,
+      glob: null,
+    };
+    const paths = {
+      target: null,
+      module: null,
+    };
+    const regexs = {
+      target: null,
+      module: null,
+    };
+    const globs = {
+      target: null,
+      module: null,
+    };
+    // When
+    sut = new TargetsFileRules(events, pathUtils, targets);
+    rule = sut.getRulesForTarget(target).scss;
+    [, [,, fn]] = TargetFileRule.mock.calls;
+    result = fn(target);
+    extension.regex = result.extension;
+    extension.glob = result.glob;
+    [
+      paths.target,
+      paths.module,
+    ] = result.paths.include;
+    [
+      regexs.target,
+      regexs.module,
+    ] = result.files.include;
+    [
+      globs.target,
+      globs.module,
+    ] = result.files.glob.include;
+    // Then
+    expect(rule.addTarget).toHaveBeenCalledTimes(1);
+    expect(rule.addTarget).toHaveBeenCalledWith(target);
+    expect(result).toEqual({
+      extension: expect.any(RegExp),
+      glob: expect.any(String),
+      paths: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+      },
+      files: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+        glob: {
+          include: [
+            expect.any(String),
+            expect.any(String),
+          ],
+          exclude: [],
+        },
+      },
+    });
+
+    // Extension
+    testRuleProperty(true, 'file.scss', extension.regex, extension.glob);
+    testRuleProperty(false, 'file.css', extension.regex, extension.glob);
+
+    // Paths
+    // -- Target
+    testRuleProperty(true, `${source}/something`, paths.target);
+    testRuleProperty(true, `${source}/something/else`, paths.target);
+    testRuleProperty(false, 'random-path/to/something', paths.target);
+
+    // -- Module
+    testRuleProperty(true, `/node_modules/${moduleToInclude}/something`, paths.module);
+    testRuleProperty(true, `/node_modules/${moduleToInclude}/something/else`, paths.module);
+    testRuleProperty(false, '/node_modules/wootils/something/else', paths.module);
+
+    // Files
+    // -- Target
+    testRuleProperty(true, `${source}/modules/file.scss`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.scss`, regexs.target, globs.target);
+    testRuleProperty(false, `${source}/modules/other.css`, regexs.target, globs.target);
+
+    // --- Module
+    testRuleProperty(
+      true,
+      `/node_modules/${moduleToInclude}/file.scss`,
+      regexs.module,
+      globs.module
+    );
+    testRuleProperty(
+      true,
+      `/node_modules/${moduleToInclude}/other/file.scss`,
+      regexs.module,
+      globs.module
+    );
+    testRuleProperty(
+      false,
+      '/node_modules/wootils/other.scss',
+      regexs.module,
+      globs.module
+    );
+    testRuleProperty(
+      false,
+      `/node_modules/${moduleToInclude}/other.tsx`,
+      regexs.module,
+      globs.module
+    );
+  });
+
+  it('should generate the CSS rules for a target', () => {
+    // Given
+    const events = {
+      emit: jest.fn(),
+    };
+    const pathUtils = 'pathUtils';
+    const targets = 'targets';
+    const source = 'source';
+    const target = {
+      name: 'my-target',
+      paths: {
+        source,
+      },
+    };
+    let sut = null;
+    let rule = null;
+    let fn = null;
+    let result = null;
+    const extension = {
+      regex: null,
+      glob: null,
+    };
+    const paths = {
+      target: null,
+      modules: null,
+    };
+    const regexs = {
+      target: null,
+      modules: null,
+    };
+    const globs = {
+      target: null,
+      modules: null,
+    };
+    // When
+    sut = new TargetsFileRules(events, pathUtils, targets);
+    rule = sut.getRulesForTarget(target).css;
+    [,, [,, fn]] = TargetFileRule.mock.calls;
+    result = fn(target);
+    extension.regex = result.extension;
+    extension.glob = result.glob;
+    [
+      paths.target,
+      paths.modules,
+    ] = result.paths.include;
+    [
+      regexs.target,
+      regexs.modules,
+    ] = result.files.include;
+    [
+      globs.target,
+      globs.modules,
+    ] = result.files.glob.include;
+    // Then
+    expect(rule.addTarget).toHaveBeenCalledTimes(1);
+    expect(rule.addTarget).toHaveBeenCalledWith(target);
+    expect(result).toEqual({
+      extension: expect.any(RegExp),
+      glob: expect.any(String),
+      paths: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+      },
+      files: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+        glob: {
+          include: [
+            expect.any(String),
+            expect.any(String),
+          ],
+          exclude: [],
+        },
+      },
+    });
+
+    // Extension
+    testRuleProperty(true, 'file.css', extension.regex, extension.glob);
+    testRuleProperty(false, 'file.scss', extension.regex, extension.glob);
+
+    // Paths
+    // -- Target
+    testRuleProperty(true, `${source}/something`, paths.target);
+    testRuleProperty(true, `${source}/something/else`, paths.target);
+    testRuleProperty(false, 'random-path/to/something', paths.target);
+
+    // -- Modules
+    testRuleProperty(true, '/node_modules/jimpex/something', paths.modules);
+    testRuleProperty(true, '/node_modules/jimpex/something/else', paths.modules);
+
+    // Files
+    // -- Target
+    testRuleProperty(true, `${source}/modules/file.css`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.css`, regexs.target, globs.target);
+    testRuleProperty(false, `${source}/modules/other.scss`, regexs.target, globs.target);
+    testRuleProperty(false, 'random-path/to/something/other.css', regexs.target, globs.target);
+
+    // --- Modules
+    testRuleProperty(
+      true,
+      '/node_modules/jimpex/file.css',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      true,
+      '/node_modules/wootils/other/file.css',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      false,
+      '/node_modules/jimpex/other.tsx',
+      regexs.modules,
+      globs.module
+    );
+  });
+
+  it('should generate the common font rules for a target', () => {
+    // Given
+    const events = {
+      emit: jest.fn(),
+    };
+    const pathUtils = 'pathUtils';
+    const targets = 'targets';
+    const source = 'target-source';
+    const target = {
+      name: 'my-target',
+      paths: {
+        source,
+      },
+    };
+    let sut = null;
+    let rule = null;
+    let fn = null;
+    let result = null;
+    const extension = {
+      regex: null,
+      glob: null,
+    };
+    const paths = {
+      target: null,
+      modules: null,
+    };
+    const regexs = {
+      target: null,
+      modules: null,
+    };
+    const globs = {
+      target: null,
+      modules: null,
+    };
+    // When
+    sut = new TargetsFileRules(events, pathUtils, targets);
+    rule = sut.getRulesForTarget(target).fonts.common;
+    [,,, [,, fn]] = TargetFileRule.mock.calls;
+    result = fn(target);
+    extension.regex = result.extension;
+    extension.glob = result.glob;
+    [
+      paths.target,
+      paths.modules,
+    ] = result.paths.include;
+    [
+      regexs.target,
+      regexs.modules,
+    ] = result.files.include;
+    [
+      globs.target,
+      globs.modules,
+    ] = result.files.glob.include;
+    // Then
+    expect(rule.addTarget).toHaveBeenCalledTimes(1);
+    expect(rule.addTarget).toHaveBeenCalledWith(target);
+    expect(result).toEqual({
+      extension: expect.any(RegExp),
+      glob: expect.any(String),
+      paths: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+      },
+      files: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+        glob: {
+          include: [
+            expect.any(String),
+            expect.any(String),
+          ],
+          exclude: [],
+        },
+      },
+    });
+
+    // Extension
+    testRuleProperty(true, 'file.woff', extension.regex, extension.glob);
+    testRuleProperty(true, 'file.woff2', extension.regex, extension.glob);
+    testRuleProperty(true, 'file.ttf', extension.regex, extension.glob);
+    testRuleProperty(true, 'file.eot', extension.regex, extension.glob);
+    testRuleProperty(false, 'file.woff3', extension.regex, extension.glob);
+
+    // Paths
+    // -- Target
+    testRuleProperty(true, `${source}/something`, paths.target);
+    testRuleProperty(true, `${source}/something/else`, paths.target);
+    testRuleProperty(false, 'random-path/to/something', paths.target);
+
+    // -- Modules
+    testRuleProperty(true, '/node_modules/jimpex/something', paths.modules);
+    testRuleProperty(true, '/node_modules/jimpex/something/else', paths.modules);
+
+    // Files
+    // -- Target
+    testRuleProperty(true, `${source}/modules/file.woff`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/file.woff2`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/file.ttf`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/file.eot`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.woff`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.woff2`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.ttf`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.eot`, regexs.target, globs.target);
+    testRuleProperty(false, `${source}/modules/other.scss`, regexs.target, globs.target);
+    testRuleProperty(false, 'random-path/to/something/other.ttf', regexs.target, globs.target);
+
+    // -- Modules
+    testRuleProperty(
+      true,
+      '/node_modules/jimpex/file.woff',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      true,
+      '/node_modules/jimpex/file.woff2',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      true,
+      '/node_modules/wootils/other/file.ttf',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      true,
+      '/node_modules/wootils/other/file.eot',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      false,
+      '/node_modules/jimpex/other.tsx',
+      regexs.modules,
+      globs.module
+    );
+  });
+
+  it('should generate the SVG font rules for a target', () => {
+    // Given
+    const events = {
+      emit: jest.fn(),
+    };
+    const pathUtils = 'pathUtils';
+    const targets = 'targets';
+    const source = 'target-source';
+    const target = {
+      name: 'my-target',
+      paths: {
+        source,
+      },
+    };
+    let sut = null;
+    let rule = null;
+    let fn = null;
+    let result = null;
+    const extension = {
+      regex: null,
+      glob: null,
+    };
+    const paths = {
+      target: null,
+      modules: null,
+    };
+    const regexs = {
+      target: null,
+      modules: null,
+    };
+    const globs = {
+      target: null,
+      modules: null,
+    };
+    // When
+    sut = new TargetsFileRules(events, pathUtils, targets);
+    rule = sut.getRulesForTarget(target).fonts.svg;
+    [,,,, [,, fn]] = TargetFileRule.mock.calls;
+    result = fn(target);
+    extension.regex = result.extension;
+    extension.glob = result.glob;
+    [
+      paths.target,
+      paths.modules,
+    ] = result.paths.include;
+    [
+      regexs.target,
+      regexs.modules,
+    ] = result.files.include;
+    [
+      globs.target,
+      globs.modules,
+    ] = result.files.glob.include;
+    // Then
+    expect(rule.addTarget).toHaveBeenCalledTimes(1);
+    expect(rule.addTarget).toHaveBeenCalledWith(target);
+    expect(result).toEqual({
+      extension: expect.any(RegExp),
+      glob: expect.any(String),
+      paths: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+      },
+      files: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [],
+        glob: {
+          include: [
+            expect.any(String),
+            expect.any(String),
+          ],
+          exclude: [],
+        },
+      },
+    });
+
+    // Extension
+    testRuleProperty(true, 'file.svg', extension.regex, extension.glob);
+    testRuleProperty(false, 'file.png', extension.regex, extension.glob);
+
+    // Paths
+    // -- Target
+    testRuleProperty(true, `${source}/something/fonts/roboto`, paths.target);
+    testRuleProperty(true, `${source}/fonts/roboto`, paths.target);
+    testRuleProperty(true, `${source}/fonts`, paths.target);
+    testRuleProperty(true, `${source}/fonts/`, paths.target);
+    testRuleProperty(false, `${source}/fonts-something/`, paths.target);
+    testRuleProperty(false, 'random-path/to/fonts', paths.target);
+
+    // -- Modules
+    testRuleProperty(true, '/node_modules/jimpex/something/fonts', paths.modules);
+    testRuleProperty(true, '/node_modules/jimpex/fonts', paths.modules);
+    testRuleProperty(true, '/node_modules/jimpex/assets/fonts/', paths.modules);
+    testRuleProperty(false, '/node_modules/jimpex/fonts-something/else', paths.modules);
+    testRuleProperty(false, '/node_modules/jimpex/something/else', paths.modules);
+
+    // Files
+    // -- Target
+    testRuleProperty(true, `${source}/modules/fonts/file.svg`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/assets/fonts/my.svg`, regexs.target, globs.target);
+    testRuleProperty(false, `${source}/modules/fonts/file.ttf`, regexs.target, globs.target);
+    testRuleProperty(false, `${source}/modules/other.svg`, regexs.target, globs.target);
+    testRuleProperty(false, 'random-path/to/something/other.svg', regexs.target, globs.target);
+
+    // --- Modules
+    testRuleProperty(
+      true,
+      '/node_modules/jimpex/fonts/file.svg',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      true,
+      '/node_modules/jimpex/assets/fonts/my.svg',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      false,
+      '/node_modules/wootils/fonts/file.ttf',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      false,
+      '/node_modules/wootils/other/file.svg',
+      regexs.modules,
+      globs.modules
+    );
+  });
+
+  it('should generate the images rules for a target', () => {
+    // Given
+    const events = {
+      emit: jest.fn(),
+    };
+    const pathUtils = 'pathUtils';
+    const targets = 'targets';
+    const source = 'target-source';
+    const target = {
+      name: 'my-target',
+      paths: {
+        source,
+      },
+    };
+    let sut = null;
+    let rule = null;
+    let fn = null;
+    let result = null;
+    const extension = {
+      regex: null,
+      glob: null,
+    };
+    const paths = {
+      target: null,
+      modules: null,
+      fonts: null,
+      favicon: null,
+      modulesFonts: null,
+    };
+    const regexs = {
+      target: null,
+      modules: null,
+      fonts: null,
+      favicon: null,
+      modulesFonts: null,
+    };
+    const globs = {
+      target: null,
+      modules: null,
+      fonts: null,
+      favicon: null,
+      modulesFonts: null,
+    };
+    // When
+    sut = new TargetsFileRules(events, pathUtils, targets);
+    rule = sut.getRulesForTarget(target).images;
+    [,,,,, [,, fn]] = TargetFileRule.mock.calls;
+    result = fn(target);
+    extension.regex = result.extension;
+    extension.glob = result.glob;
+    [
+      paths.target,
+      paths.modules,
+    ] = result.paths.include;
+    [
+      paths.fonts,
+      paths.favicon,
+      paths.modulesFonts,
+    ] = result.paths.exclude;
+    [
+      regexs.target,
+      regexs.modules,
+    ] = result.files.include;
+    [
+      regexs.fonts,
+      regexs.favicon,
+      regexs.modulesFonts,
+    ] = result.files.exclude;
+    [
+      globs.target,
+      globs.modules,
+    ] = result.files.glob.include;
+    [
+      globs.fonts,
+      globs.favicon,
+      globs.modulesFonts,
+    ] = result.files.glob.exclude;
+    // Then
+    expect(rule.addTarget).toHaveBeenCalledTimes(1);
+    expect(rule.addTarget).toHaveBeenCalledWith(target);
+    expect(result).toEqual({
+      extension: expect.any(RegExp),
+      glob: expect.any(String),
+      paths: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+      },
+      files: {
+        include: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        exclude: [
+          expect.any(RegExp),
+          expect.any(RegExp),
+          expect.any(RegExp),
+        ],
+        glob: {
+          include: [
+            expect.any(String),
+            expect.any(String),
+          ],
+          exclude: [
+            expect.any(String),
+            expect.any(String),
+            expect.any(String),
+          ],
+        },
+      },
+    });
+
+    // Extension
+    testRuleProperty(true, 'file.jpg', extension.regex, extension.glob);
+    testRuleProperty(true, 'file.jpeg', extension.regex, extension.glob);
+    testRuleProperty(true, 'file.png', extension.regex, extension.glob);
+    testRuleProperty(true, 'file.gif', extension.regex, extension.glob);
+    testRuleProperty(true, 'file.svg', extension.regex, extension.glob);
+    testRuleProperty(false, 'file.ttf', extension.regex, extension.glob);
+
+    // Paths
+    // -- Include
+    // --- Target
+    testRuleProperty(true, `${source}/something`, paths.target);
+    testRuleProperty(true, `${source}/something/else`, paths.target);
+    testRuleProperty(false, 'random-path/to/something', paths.target);
+
+    // --- Modules
+    testRuleProperty(true, '/node_modules/jimpex/something', paths.modules);
+    testRuleProperty(true, '/node_modules/jimpex/something/else', paths.modules);
+    testRuleProperty(false, 'random-path/to/something', paths.modules);
+
+    // -- Exclude
+    // --- Fonts
+    testRuleProperty(true, `${source}/something/fonts/robot.svg`, paths.fonts);
+    testRuleProperty(true, `${source}/something/else/fonts/my.svg`, paths.fonts);
+    testRuleProperty(false, 'random-path/to/something/else.svg', paths.fonts);
+    testRuleProperty(false, 'random-path/to/something', paths.fonts);
+
+    // --- Favicon
+    testRuleProperty(true, `${source}/something/fonts/favicon.png`, paths.favicon);
+    testRuleProperty(true, `${source}/something/else/favicon.ico`, paths.favicon);
+    testRuleProperty(false, 'random-path/to/something/favicon.gif', paths.favicon);
+    testRuleProperty(false, 'random-path/to/something', paths.favicon);
+
+    // -- Modules Fonts
+    testRuleProperty(true, '/node_modules/jimpex/something/fonts/file.svg', paths.modulesFonts);
+    testRuleProperty(false, '/node_modules/jimpex/file.svg', paths.modulesFonts);
+    testRuleProperty(false, '/node_modules/jimpex/something/else', paths.modulesFonts);
+
+    // Files
+    // -- Include
+    // --- Target
+    testRuleProperty(true, `${source}/modules/file.jpg`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/file.jpeg`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/file.png`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/file.gif`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/file.svg`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.jpg`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.jpeg`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.png`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.gif`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/other/file.svg`, regexs.target, globs.target);
+    testRuleProperty(false, `${source}/modules/other.scss`, regexs.target, globs.target);
+    testRuleProperty(false, 'random-path/to/something/other.png', regexs.target, globs.target);
+
+    // --- Modules
+    testRuleProperty(
+      true,
+      '/node_modules/jimpex/file.jpg',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      true,
+      '/node_modules/jimpex/file.jpeg',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      true,
+      '/node_modules/wootils/other/file.png',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      true,
+      '/node_modules/wootils/other/file.gif',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      true,
+      '/node_modules/wootils/other/file.svg',
+      regexs.modules,
+      globs.modules
+    );
+    testRuleProperty(
+      false,
+      '/node_modules/jimpex/other.tsx',
+      regexs.modules,
+      globs.module
+    );
+
+    // -- Exclude
+    // --- Fonts
+    testRuleProperty(true, `${source}/something/fonts/robot.svg`, regexs.fonts, globs.fonts);
+    testRuleProperty(true, `${source}/something/else/fonts/my.svg`, regexs.fonts, globs.fonts);
+    testRuleProperty(false, 'random-path/to/something/else.svg', regexs.fonts, globs.fonts);
+
+    // --- Favicon
+    testRuleProperty(true, `${source}/something/fonts/favicon.png`, regexs.favicon, globs.favicon);
+    testRuleProperty(true, `${source}/something/else/favicon.ico`, regexs.favicon, globs.favicon);
+    testRuleProperty(false, 'random-path/to/something/favicon.gif', regexs.favicon, globs.favicon);
+    testRuleProperty(false, 'random-path/to/something.svg', regexs.favicon, globs.favicon);
+
+    // -- Modules Fonts
+    testRuleProperty(
+      true,
+      '/node_modules/jimpex/something/fonts/file.svg',
+      regexs.modulesFonts,
+      globs.modulesFonts
+    );
+    testRuleProperty(
+      false,
+      '/node_modules/jimpex/file.svg',
+      regexs.modulesFonts,
+      globs.modulesFonts
+    );
+    testRuleProperty(
+      false,
+      '/node_modules/jimpex/something/else.svg',
+      regexs.modulesFonts,
+      globs.modulesFonts
+    );
+  });
+
+  it('should generate the favicon rules for a target', () => {
+    // Given
+    const events = {
+      emit: jest.fn(),
+    };
+    const pathUtils = 'pathUtils';
+    const targets = 'targets';
+    const source = 'source';
+    const target = {
+      name: 'my-target',
+      paths: {
+        source,
+      },
+    };
+    let sut = null;
+    let rule = null;
+    let fn = null;
+    let result = null;
+    const extension = {
+      regex: null,
+      glob: null,
+    };
+    const paths = {
+      target: null,
+    };
+    const regexs = {
+      target: null,
+    };
+    const globs = {
+      target: null,
+    };
+    // When
+    sut = new TargetsFileRules(events, pathUtils, targets);
+    rule = sut.getRulesForTarget(target).favicon;
+    [,,,,,, [,, fn]] = TargetFileRule.mock.calls;
+    result = fn(target);
+    extension.regex = result.extension;
+    extension.glob = result.glob;
+    [paths.target] = result.paths.include;
+    [regexs.target] = result.files.include;
+    [globs.target] = result.files.glob.include;
+    // Then
+    expect(rule.addTarget).toHaveBeenCalledTimes(1);
+    expect(rule.addTarget).toHaveBeenCalledWith(target);
+    expect(result).toEqual({
+      extension: expect.any(RegExp),
+      glob: expect.any(String),
+      paths: {
+        include: [
+          expect.any(RegExp),
+        ],
+        exclude: [],
+      },
+      files: {
+        include: [
+          expect.any(RegExp),
+        ],
+        exclude: [],
+        glob: {
+          include: [
+            expect.any(String),
+          ],
+          exclude: [],
+        },
+      },
+    });
+
+    // Extension
+    testRuleProperty(true, 'file.png', extension.regex, extension.glob);
+    testRuleProperty(true, 'file.ico', extension.regex, extension.glob);
+    testRuleProperty(false, 'file.gif', extension.regex, extension.glob);
+
+    // Paths
+    // -- Target
+    testRuleProperty(true, `${source}/something`, paths.target);
+    testRuleProperty(true, `${source}/something/else`, paths.target);
+    testRuleProperty(false, 'random-path/to/something', paths.target);
+
+    // Files
+    // -- Target
+    testRuleProperty(true, `${source}/favicon.png`, regexs.target, globs.target);
+    testRuleProperty(true, `${source}/modules/assets/favicon.ico`, regexs.target, globs.target);
+    testRuleProperty(false, `${source}/modules/favicon.ttf`, regexs.target, globs.target);
+    testRuleProperty(false, `${source}/modules/icon.png`, regexs.target, globs.target);
+    testRuleProperty(false, 'random-path/to/something/favicon.ico', regexs.target, globs.target);
+  });
+
+  it('should include a provider for the DIC', () => {
+    // Given
+    let sut = null;
+    const container = {
+      set: jest.fn(),
+      get: jest.fn((service) => service),
+    };
+    let serviceName = null;
+    let serviceFn = null;
+    // When
+    targetsFileRules(container);
+    [[serviceName, serviceFn]] = container.set.mock.calls;
+    sut = serviceFn();
+    // Then
+    expect(serviceName).toBe('targetsFileRules');
+    expect(serviceFn).toBeFunction();
+    expect(sut).toBeInstanceOf(TargetsFileRules);
+    expect(sut.events).toBe('events');
+    expect(sut.pathUtils).toBe('pathUtils');
+    expect(sut.targets).toBe('targets');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3619,7 +3619,7 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
-minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:


### PR DESCRIPTION
### What does this PR do?

While building/updating plugins I started to notice a lot of services creating paths and rules for targets files, so I created a new way to handle that: The `targetsFileRules` service.

The new service can give you a dictionary with rules and paths so you can use to find specific files for a target:

```js
const myTarget = targets.getTarget('something');
const rules = targetsFileRules.getRulesForTarget(myTarget);
```

Done, you now have rules to find JS files, SCSS stylesheets, CSS stylesheets, images, fonts, etc; for an specific target.

The rules format is fully documented on the `typedef.js` file, so you can get more description there.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
