### PR TITLE
New target setting: includeTargets

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -91,6 +91,7 @@ Since there are a lot of settings for the templates, will divide them by type an
   css: { ... },
   includeModules: [],
   excludeModules: [],
+  includeTargets: [],
   runOnDevelopment: false,
   babel: { ... },
   flow: false,
@@ -213,6 +214,15 @@ For example, let's say you are using a library that exports a native `Class` tha
 
 This setting can be used to specify a list of modules that should never be bundled. By default, projext will exclude all the dependencies from the `package.json`, but if you import modules using a sub path (like `colors/safe` instead of `colors`), you need to specify it on this list so the build engine won't try to put it inside the bundle it.
 
+#### `includeTargets`
+> Default value: `[]`
+
+This setting can be used to specify a list of other targets you want to process on your bundle.
+
+For example, you have two targets, let's call them `frontend` and `backend`, that share some functionality and which code needs to be transpiled/processed. Since projext define the paths for transpilation/processing to match each target's directory, the wouldn't be able to use shared code between each other.
+
+You have two possible solutions now, thanks to `includeTargets`: You can either add the other target name on each `includeTargets` setting, or define a third `shared` target that both have on the setting.
+
 #### `runOnDevelopment`
 > Default value: `false`
 
@@ -294,6 +304,7 @@ Whether or not to remove all code from previous builds from the distribution dir
   html: { ... },
   css: { ... },
   includeModules: [],
+  includeTargets: [],
   runOnDevelopment: false,
   babel: { ... },
   flow: false,
@@ -440,6 +451,15 @@ This setting can be used to specify a list of node modules you want to process o
 For example, let's say you are using a library that exports a native `Class` that you are `extend`ing, but you are transpiling for a browser that doesn't support native `Class`es; you can add the name of the module on this setting and projext will include it on its bundling process and transpile it if needed.
 
 > At the end of the process, those names are converted to regular expressions, so you can also make the name a expression, while escaping especial characters of course.
+
+#### `includeTargets`
+> Default value: `[]`
+
+This setting can be used to specify a list of other targets you want to process on your bundle.
+
+For example, you have two targets, let's call them `frontend` and `backend`, that share some functionality and which code needs to be transpiled/processed. Since projext define the paths for transpilation/processing to match each target's directory, the wouldn't be able to use shared code between each other.
+
+You have two possible solutions now, thanks to `includeTargets`: You can either add the other target name on each `includeTargets` setting, or define a third `shared` target that both have on the setting.
 
 #### `runOnDevelopment`
 > Default value: `false`

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -90,6 +90,7 @@ class ProjectConfiguration extends ConfigurationFile {
           },
           includeModules: [],
           excludeModules: [],
+          includeTargets: [],
           runOnDevelopment: false,
           babel: {
             features: [],
@@ -143,6 +144,7 @@ class ProjectConfiguration extends ConfigurationFile {
             inject: false,
           },
           includeModules: [],
+          includeTargets: [],
           runOnDevelopment: false,
           babel: {
             features: [],

--- a/src/services/targets/targetsFileRules/targetFileRule.js
+++ b/src/services/targets/targetsFileRules/targetFileRule.js
@@ -6,6 +6,8 @@ const extend = require('extend');
 class TargetFileRule {
   /**
    * @param {Events}                events                   To reduce the rule settings updated.
+   * @param {Targets}               targets                  To get the information of other targets
+   *                                                         from the `includeTargets` setting.
    * @param {string}                ruleType                 A reference identifier that tells for
    *                                                         which kind file type the rule is
    *                                                         being used for.
@@ -13,12 +15,17 @@ class TargetFileRule {
    *                                                         a new target is added.
    * @throws {Error} If `getSettingsForTargetRule` is not a function.
    */
-  constructor(events, ruleType, getSettingsForTargetRule) {
+  constructor(events, targets, ruleType, getSettingsForTargetRule) {
     /**
      * A local reference for the `events` service.
      * @type {Events}
      */
     this.events = events;
+    /**
+     * A local reference for the `targets` service.
+     * @type {Targets}
+     */
+    this.targets = targets;
     // Validate the handler function.
     if (typeof getSettingsForTargetRule !== 'function') {
       throw new Error('You need to specify a handler function for when a new target is added');
@@ -45,7 +52,7 @@ class TargetFileRule {
      */
     this._rule = {
       extension: /\.\w+$/i,
-      glob: '**/*.css',
+      glob: '**/*.*',
       paths: {
         include: [],
         exclude: [],
@@ -98,6 +105,10 @@ class TargetFileRule {
 
     this._hasTarget = true;
     this._rule = this.events.reduce(events, finalRule, this._rule);
+    target.includeTargets.forEach((targetName) => {
+      const targetInfo = this.targets.getTarget(targetName);
+      this.addTarget(targetInfo);
+    });
   }
   /**
    * Merge two sets of rule settings. This is also used recursively to merge nested settings.

--- a/src/services/targets/targetsFileRules/targetsFileRules.js
+++ b/src/services/targets/targetsFileRules/targetsFileRules.js
@@ -67,7 +67,7 @@ class TargetsFileRules {
    * @ignore
    */
   _getJSRule(target) {
-    const rule = new TargetFileRule(this.events, 'js', (ruleTarget, hasTarget) => {
+    const rule = new TargetFileRule(this.events, this.targets, 'js', (ruleTarget, hasTarget) => {
       const pathsInclude = [];
       const filesInclude = [];
       const filesGlobInclude = [];
@@ -144,7 +144,7 @@ class TargetsFileRules {
    * @ignore
    */
   _getSCSSRule(target) {
-    const rule = new TargetFileRule(this.events, 'scss', (ruleTarget) => ({
+    const rule = new TargetFileRule(this.events, this.targets, 'scss', (ruleTarget) => ({
       extension: /\.scss$/i,
       glob: '**/*.scss',
       paths: {
@@ -199,7 +199,7 @@ class TargetsFileRules {
    * @ignore
    */
   _getCSSRule(target) {
-    const rule = new TargetFileRule(this.events, 'css', (ruleTarget) => ({
+    const rule = new TargetFileRule(this.events, this.targets, 'css', (ruleTarget) => ({
       extension: /\.css$/i,
       glob: '**/*.css',
       paths: {
@@ -250,7 +250,7 @@ class TargetsFileRules {
    * @ignore
    */
   _getCommonFontsRule(target) {
-    const rule = new TargetFileRule(this.events, 'fonts.common', (ruleTarget) => ({
+    const rule = new TargetFileRule(this.events, this.targets, 'fonts.common', (ruleTarget) => ({
       extension: /\.(?:woff2?|ttf|eot)$/i,
       glob: '**/*.{woff,woff2,ttf,eot}',
       paths: {
@@ -301,7 +301,7 @@ class TargetsFileRules {
    * @ignore
    */
   _getSVGFontsRule(target) {
-    const rule = new TargetFileRule(this.events, 'fonts.svg', (ruleTarget) => ({
+    const rule = new TargetFileRule(this.events, this.targets, 'fonts.svg', (ruleTarget) => ({
       extension: /\.svg$/i,
       glob: '**/*.svg',
       paths: {
@@ -351,7 +351,7 @@ class TargetsFileRules {
    * @ignore
    */
   _getImagesRule(target) {
-    const rule = new TargetFileRule(this.events, 'images', (ruleTarget) => {
+    const rule = new TargetFileRule(this.events, this.targets, 'images', (ruleTarget) => {
       /**
        * Define the excluded paths.
        * The issue here is that the rule should pick `.svg` files as images, but not if they
@@ -428,7 +428,7 @@ class TargetsFileRules {
    * @ignore
    */
   _getFaviconRule(target) {
-    const rule = new TargetFileRule(this.events, 'favicon', (ruleTarget) => ({
+    const rule = new TargetFileRule(this.events, this.targets, 'favicon', (ruleTarget) => ({
       extension: /\.(png|ico)$/i,
       glob: '**/*.{png,ico}',
       paths: {

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -370,12 +370,14 @@
  * These options help you customize the way the bundling process handles your CSS code.
  * @property {Array} [includeModules=[]]
  * This setting can be used to specify a list of node modules you want to process on your bundle.
- * This means that JS files from modules on this list will be transpiled.
  * @property {Array} [excludeModules=[]]
  * This setting can be used to specify a list of modules that should never be bundled. By default,
  * projext will exclude all the dependencies from the `package.json`, but if you import modules
  * using a sub path (like `colors/safe` instead of `colors`), you need to specify it on this list
  * so the build engine won't try to put it inside the bundle it.
+ * @property {Array} [includeTargets=[]]
+ * This setting can be used to specify a list of other targets you want to process on your bundle.
+ * This means that JS and SCSS files from these targets will be transpiled/processed.
  * @property {boolean} [runOnDevelopment=false]
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
@@ -434,6 +436,9 @@
  * projext will exclude all the dependencies from the `package.json`, but if you import modules
  * using a sub path (like `colors/safe` instead of `colors`), you need to specify it on this list
  * so the build engine won't try to put it inside the bundle it.
+ * @property {Array} includeTargets
+ * This setting can be used to specify a list of other targets you want to process on your bundle.
+ * This means that JS and SCSS files from these targets will be transpiled/processed.
  * @property {boolean} runOnDevelopment
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
@@ -495,6 +500,9 @@
  * @property {Array} [includeModules=[]]
  * This setting can be used to specify a list of node modules you want to process on your bundle.
  * This means that JS files from modules on this list will be transpiled.
+ * @property {Array} [includeTargets=[]]
+ * This setting can be used to specify a list of other targets you want to process on your bundle.
+ * This means that JS and SCSS files from these targets will be transpiled/processed.
  * @property {boolean} [runOnDevelopment=false]
  * This will tell the build engine that when you build the target for a development environment,
  * it should bring up an `http` server to _"run"_ your target.
@@ -549,6 +557,9 @@
  * @property {Array} includeModules
  * This setting can be used to specify a list of node modules you want to process on your bundle.
  * This means that JS files from modules on this list will be transpiled.
+ * @property {Array} includeTargets
+ * This setting can be used to specify a list of other targets you want to process on your bundle.
+ * This means that JS and SCSS files from these targets will be transpiled/processed.
  * @property {boolean} runOnDevelopment
  * This will tell the build engine that when you build the target for a development environment,
  * it should bring up an `http` server to _"run"_ your target.

--- a/tests/services/targets/targetsFileRules/targetsFileRules.test.js
+++ b/tests/services/targets/targetsFileRules/targetsFileRules.test.js
@@ -95,7 +95,7 @@ describe('services/targets:targetsFileRules', () => {
     expect(result).toEqual(expectedRules);
     expect(TargetFileRule).toHaveBeenCalledTimes(expectedRuleTypes.length);
     expectedRuleTypes.forEach((ruleType) => {
-      expect(TargetFileRule).toHaveBeenCalledWith(events, ruleType, expect.any(Function));
+      expect(TargetFileRule).toHaveBeenCalledWith(events, targets, ruleType, expect.any(Function));
     });
     expect(events.emit).toHaveBeenCalledTimes(expectedRuleTypeEvents.length + 1);
     expectedRuleTypeEvents.forEach((eventName) => {
@@ -170,7 +170,7 @@ describe('services/targets:targetsFileRules', () => {
     expect(result).toEqual(expectedRules);
     expect(TargetFileRule).toHaveBeenCalledTimes(expectedRuleTypes.length);
     expectedRuleTypes.forEach((ruleType) => {
-      expect(TargetFileRule).toHaveBeenCalledWith(events, ruleType, expect.any(Function));
+      expect(TargetFileRule).toHaveBeenCalledWith(events, targets, ruleType, expect.any(Function));
     });
     expect(targets.getTarget).toHaveBeenCalledTimes(1);
     expect(targets.getTarget).toHaveBeenCalledWith(target);
@@ -240,7 +240,7 @@ describe('services/targets:targetsFileRules', () => {
     // When
     sut = new TargetsFileRules(events, pathUtils, targets);
     rule = sut.getRulesForTarget(target).js;
-    [[,, fn]] = TargetFileRule.mock.calls;
+    [[,,, fn]] = TargetFileRule.mock.calls;
     result = fn(target);
     extension.regex = result.extension;
     extension.glob = result.glob;
@@ -379,7 +379,7 @@ describe('services/targets:targetsFileRules', () => {
     // When
     sut = new TargetsFileRules(events, pathUtils, targets);
     sut.getRulesForTarget(target);
-    [[,, fn]] = TargetFileRule.mock.calls;
+    [[,,, fn]] = TargetFileRule.mock.calls;
     result = fn(target, true);
     // Then
     expect(result).toEqual({
@@ -450,7 +450,7 @@ describe('services/targets:targetsFileRules', () => {
     // When
     sut = new TargetsFileRules(events, pathUtils, targets);
     rule = sut.getRulesForTarget(target).scss;
-    [, [,, fn]] = TargetFileRule.mock.calls;
+    [, [,,, fn]] = TargetFileRule.mock.calls;
     result = fn(target);
     extension.regex = result.extension;
     extension.glob = result.glob;
@@ -580,7 +580,7 @@ describe('services/targets:targetsFileRules', () => {
     // When
     sut = new TargetsFileRules(events, pathUtils, targets);
     rule = sut.getRulesForTarget(target).css;
-    [,, [,, fn]] = TargetFileRule.mock.calls;
+    [,, [,,, fn]] = TargetFileRule.mock.calls;
     result = fn(target);
     extension.regex = result.extension;
     extension.glob = result.glob;
@@ -704,7 +704,7 @@ describe('services/targets:targetsFileRules', () => {
     // When
     sut = new TargetsFileRules(events, pathUtils, targets);
     rule = sut.getRulesForTarget(target).fonts.common;
-    [,,, [,, fn]] = TargetFileRule.mock.calls;
+    [,,, [,,, fn]] = TargetFileRule.mock.calls;
     result = fn(target);
     extension.regex = result.extension;
     extension.glob = result.glob;
@@ -849,7 +849,7 @@ describe('services/targets:targetsFileRules', () => {
     // When
     sut = new TargetsFileRules(events, pathUtils, targets);
     rule = sut.getRulesForTarget(target).fonts.svg;
-    [,,,, [,, fn]] = TargetFileRule.mock.calls;
+    [,,,, [,,, fn]] = TargetFileRule.mock.calls;
     result = fn(target);
     extension.regex = result.extension;
     extension.glob = result.glob;
@@ -995,7 +995,7 @@ describe('services/targets:targetsFileRules', () => {
     // When
     sut = new TargetsFileRules(events, pathUtils, targets);
     rule = sut.getRulesForTarget(target).images;
-    [,,,,, [,, fn]] = TargetFileRule.mock.calls;
+    [,,,,, [,,, fn]] = TargetFileRule.mock.calls;
     result = fn(target);
     extension.regex = result.extension;
     extension.glob = result.glob;
@@ -1226,7 +1226,7 @@ describe('services/targets:targetsFileRules', () => {
     // When
     sut = new TargetsFileRules(events, pathUtils, targets);
     rule = sut.getRulesForTarget(target).favicon;
-    [,,,,,, [,, fn]] = TargetFileRule.mock.calls;
+    [,,,,,, [,,, fn]] = TargetFileRule.mock.calls;
     result = fn(target);
     extension.regex = result.extension;
     extension.glob = result.glob;


### PR DESCRIPTION
### What does this PR do?

From the documentation:

> This setting can be used to specify a list of other targets you want to process on your bundle.
>
>For example, you have two targets, let's call them `frontend` and `backend`, that share some functionality and which code needs to be transpiled/processed. Since projext define the paths for transpilation/processing to match each target's directory, the wouldn't be able to use shared code between each other.
>
> You have two possible solutions now, thanks to `includeTargets`: You can either add the other target name on each `includeTargets` setting, or define a third `shared` target that both have on the setting.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```