### PR TITLE
Add devServer.historyAPIFallback as an 'official' setting

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -557,6 +557,7 @@ Whether or not to remove all code from previous builds from the distribution dir
 >     ca: null,
 >   },
 >   proxied: { ... },
+>   historyApiFallback: true,
 > }
 > ```
 
@@ -602,6 +603,11 @@ When the dev server is being proxied (using `nginx` for example), there are cert
 - `enabled`: Whether the server is being proxied or not.
 - `hostname`: The hostname used. If `null`, it will use the same as `devServer.hostname`.
 - `https`: Whether or not the server is being proxied over `https`. This settings has a boolean value, but if you let it as `null` it will set its value based on `devServer.ssl`, if you added the certificates it will be `true`, otherwise `false`.
+
+**`devServer.historyApiFallback`**
+> Default value: true
+
+Whether or not to redirect the browser back to the root whenever a path can't be found.
 
 #### `configuration`
 > Default value:

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -175,6 +175,7 @@ class ProjectConfiguration extends ConfigurationFile {
               host: null,
               https: null,
             },
+            historyApiFallback: true,
           },
           configuration: {
             enabled: false,


### PR DESCRIPTION
### What does this PR do?

The `devServer.historyAPIFallback` setting was only for the webpack plugin, but since it was also implemented on the upcoming Rollup plugin, I decided to make it an _"official setting"_ on the project configuration.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
