### PR TITLE
Send the current settings to a file that overwrites a configuration

### DIFF
--- a/src/abstracts/cliSubCommand.js
+++ b/src/abstracts/cliSubCommand.js
@@ -2,6 +2,7 @@
  * A helper class for creating sub commands for the CLI. A sub command works like a
  * {@link CLICommand} inside a regular {@link CLICommand}.
  * @abstract
+ * @version 1.0
  */
 class CLISubCommand {
   /**

--- a/src/abstracts/configurationFile.js
+++ b/src/abstracts/configurationFile.js
@@ -5,6 +5,7 @@ const path = require('path');
  * A helper class for creating configuration files that can be overwritten on
  * implementation.
  * @abstract
+ * @version 1.0
  */
 class ConfigurationFile {
   /**
@@ -139,20 +140,16 @@ class ConfigurationFile {
        */
       parentConfig = this.parentConfig.getConfig(...args);
     }
-    /**
-     * Generate the final configuration, which is a merge of the following things:
-     * - The parent configuration `getConfig` method result; or an empty object if no parent
-     * configuration was received.
-     * - The result of this instance `createConfig` method.
-     * - The contents of the overwrite file.
-     */
-    this._config = extend(
-      true,
-      {},
-      parentConfig,
-      this.createConfig(...args),
-      this._fileConfig(...args)
-    );
+    // Define the current configuration using the parent one.
+    let currentConfig = extend(true, {}, parentConfig);
+    // Create a new set of arguments by adding the current configuration at the end.
+    let currentArgs = [...args, currentConfig];
+    // Update the current configuration by calling `createConfig` with the new arguments.
+    currentConfig = extend(true, {}, currentConfig, this.createConfig(...currentArgs));
+    // Update the arguments with the "new current configuration".
+    currentArgs = [...args, currentConfig];
+    // Finally, call the method for the overwrite file and merge everything together.
+    this._config = extend(true, {}, currentConfig, this._fileConfig(...currentArgs));
   }
   /**
    * Load the configuration from an overwrite file.

--- a/tests/mocks/mockFunction.config.js
+++ b/tests/mocks/mockFunction.config.js
@@ -1,1 +1,1 @@
-module.exports = (...args) => ({ args });
+module.exports = jest.fn((...args) => ({ args }));


### PR DESCRIPTION
### What does this PR do?

Configuration services that `extends` the class `ConfigurationFile` can have their settings overwritten by a file on an specific path, the most basic example of that is `projectConfiguration`, which can be overwritten by `projext.config.js`.

Now, `projectConfiguration` is a good example, but you always export an `Object` and something you probably didn't know is that you can export a function that returns an `Object` too.

Exporting the function allows for more dynamic changes during the overwrite process, but it lacks something very important: context. You are creating a new configuration on the fly but you don't know the current settings, you only now that the object that you are returning will be merged with whatever was already there.

This PR refactors the process of overwriting a configuration by removing a _"big merge block"_ and replacing it with a step by step process:

1. The initial value is a parent configuration or an empty object.
2. The service calls `createConfig` and adds the initial value as last parameter.
3. It then calls the function from the overwrite file and adds whatever `createConfig` returned as the last parameter.

As you can see, the two possible overwrites now receive the current state of the configuration as last parameter.

### How should it be tested manually?

Try overwriting the project configuration with a function.

And of course...

```bash
npm test
# or
yarn test
```
