### PR TITLE
Remove leading / on node_modules path

### DIFF
--- a/src/services/targets/targetsFileRules/targetsFileRules.js
+++ b/src/services/targets/targetsFileRules/targetsFileRules.js
@@ -90,7 +90,7 @@ class TargetsFileRules {
         new RegExp(ruleTarget.paths.source, 'i'),
         // The paths for modules that have been explicity included on the target settings.
         ...ruleTarget.includeModules.map((modName) => (
-          new RegExp(`/node_modules/${modName}`)
+          new RegExp(`node_modules/${modName}`)
         )),
       ]);
       // Define the allowed file paths.
@@ -99,7 +99,7 @@ class TargetsFileRules {
         new RegExp(`${ruleTarget.paths.source}/.*?\\.jsx?$`, 'i'),
         // Files of modules that have been explicity included on the target settings.
         ...ruleTarget.includeModules.map((modName) => (
-          new RegExp(`/node_modules/${modName}/.*?\\.jsx?$`, 'i')
+          new RegExp(`node_modules/${modName}/.*?\\.jsx?$`, 'i')
         )),
       ]);
       // Define the allowed file paths, on glob format.
@@ -108,7 +108,7 @@ class TargetsFileRules {
         `${ruleTarget.paths.source}/**/*.{js,jsx}`,
         // Files of modules that have been explicity included on the target settings.
         ...ruleTarget.includeModules.map((modName) => (
-          `/node_modules/${modName}/**/*.{js,jsx}`
+          `node_modules/${modName}/**/*.{js,jsx}`
         )),
       ]);
       // Return the rule settings.
@@ -154,7 +154,7 @@ class TargetsFileRules {
           new RegExp(ruleTarget.paths.source, 'i'),
           // The paths for modules that have been explicity included on the target settings.
           ...ruleTarget.includeModules.map((modName) => (
-            new RegExp(`/node_modules/${modName}`)
+            new RegExp(`node_modules/${modName}`)
           )),
         ],
         exclude: [],
@@ -166,7 +166,7 @@ class TargetsFileRules {
           new RegExp(`${ruleTarget.paths.source}/.*?\\.scss$`, 'i'),
           // Files of modules that have been explicity included on the target settings.
           ...ruleTarget.includeModules.map((modName) => (
-            new RegExp(`/node_modules/${modName}/.*?\\.scss$`, 'i')
+            new RegExp(`node_modules/${modName}/.*?\\.scss$`, 'i')
           )),
         ],
         exclude: [],
@@ -177,7 +177,7 @@ class TargetsFileRules {
             `${ruleTarget.paths.source}/**/*.scss`,
             // Files of modules that have been explicity included on the target settings.
             ...ruleTarget.includeModules.map((modName) => (
-              `/node_modules/${modName}/**/*.scss`
+              `node_modules/${modName}/**/*.scss`
             )),
           ],
           exclude: [],
@@ -208,7 +208,7 @@ class TargetsFileRules {
           // The target path.
           new RegExp(ruleTarget.paths.source, 'i'),
           // Any path inside the `node_modules` directory.
-          /\/node_modules\//i,
+          /node_modules\//i,
         ],
         exclude: [],
       },
@@ -218,7 +218,7 @@ class TargetsFileRules {
           // Target files.
           new RegExp(`${ruleTarget.paths.source}/.*?\\.css$`, 'i'),
           // Any file inside the `node_modules` directory.
-          /\/node_modules\/.*?\.css$/i,
+          /node_modules\/.*?\.css$/i,
         ],
         exclude: [],
         glob: {
@@ -227,7 +227,7 @@ class TargetsFileRules {
             // Target files.
             `${ruleTarget.paths.source}/**/*.css`,
             // Any file inside the `node_modules` directory.
-            '/node_modules/**/*.css',
+            'node_modules/**/*.css',
           ],
           exclude: [],
         },
@@ -259,7 +259,7 @@ class TargetsFileRules {
           // The target path.
           new RegExp(ruleTarget.paths.source, 'i'),
           // Any path inside the `node_modules` directory.
-          /\/node_modules\//i,
+          /node_modules\//i,
         ],
         exclude: [],
       },
@@ -269,7 +269,7 @@ class TargetsFileRules {
           // Target files.
           new RegExp(`${ruleTarget.paths.source}/.*?\\.(?:woff2?|ttf|eot)`, 'i'),
           // Any file inside the `node_modules` directory.
-          /\/node_modules\/.*?\.(?:woff2?|ttf|eot)$/i,
+          /node_modules\/.*?\.(?:woff2?|ttf|eot)$/i,
         ],
         exclude: [],
         glob: {
@@ -278,7 +278,7 @@ class TargetsFileRules {
             // Target files.
             `${ruleTarget.paths.source}/**/*.{woff,woff2,ttf,eot}`,
             // Any file inside the `node_modules` directory.
-            '/node_modules/**/*.{woff,woff2,ttf,eot}',
+            'node_modules/**/*.{woff,woff2,ttf,eot}',
           ],
           exclude: [],
         },
@@ -310,7 +310,7 @@ class TargetsFileRules {
           // Any path inside the target directory that contains a `fonts` component.
           new RegExp(`${ruleTarget.paths.source}/(?:.*?/)?fonts(?:/.*?)?$`, 'i'),
           // Any path on the `node_modules` that contains a `fonts` component.
-          /\/node_modules\/(?:.*?\/)?fonts(?:\/.*?)?$/i,
+          /node_modules\/(?:.*?\/)?fonts(?:\/.*?)?$/i,
         ],
         exclude: [],
       },
@@ -319,7 +319,7 @@ class TargetsFileRules {
         include: [
           // Any `.svg` inside a `fonts` directory, on the target directory or the `node_modules`.
           new RegExp(`${ruleTarget.paths.source}/(?:.*?/)?fonts/.*?\\.svg$`, 'i'),
-          /\/node_modules\/(?:.*?\/)?fonts\/.*?\.svg$/i,
+          /node_modules\/(?:.*?\/)?fonts\/.*?\.svg$/i,
         ],
         exclude: [],
         glob: {
@@ -330,7 +330,7 @@ class TargetsFileRules {
              * `node_modules`.
              */
             `${ruleTarget.paths.source}/**/fonts/**/*.svg`,
-            '/node_modules/**/fonts/**/*.svg',
+            'node_modules/**/fonts/**/*.svg',
           ],
           exclude: [],
         },
@@ -365,7 +365,7 @@ class TargetsFileRules {
         // Any path for a `favicon` file with extension `png` or `ico`.
         new RegExp(`${ruleTarget.paths.source}/.*?favicon\\.(png|ico)$`, 'i'),
         // Any path for an `.svg` file with a `fonts` component inside the `node_modules`.
-        /\/node_modules\/(?:.*?\/)?fonts\/.*?\.svg$/i,
+        /node_modules\/(?:.*?\/)?fonts\/.*?\.svg$/i,
       ];
 
       return {
@@ -377,7 +377,7 @@ class TargetsFileRules {
             // The target path.
             new RegExp(ruleTarget.paths.source, 'i'),
             // Any path inside the `node_modules` directory.
-            /\/node_modules\//i,
+            /node_modules\//i,
           ],
           // Exclude anything related to fonts.
           exclude,
@@ -388,7 +388,7 @@ class TargetsFileRules {
             // Target files.
             new RegExp(`${ruleTarget.paths.source}/.*?\\.(?:jpe?g|png|gif|svg)`, 'i'),
             // Any file inside the `node_modules` directory.
-            /\/node_modules\/.*?\.(?:jpe?g|png|gif|svg)$/i,
+            /node_modules\/.*?\.(?:jpe?g|png|gif|svg)$/i,
           ],
           // Exclude anything related to fonts.
           exclude,
@@ -398,7 +398,7 @@ class TargetsFileRules {
               // Target files.
               `${ruleTarget.paths.source}/**/*.{jpg,jpeg,png,gif,svg}`,
               // Any file inside the `node_modules` directory.
-              '/node_modules/**/*.{jpg,jpeg,png,gif,svg}',
+              'node_modules/**/*.{jpg,jpeg,png,gif,svg}',
             ],
             // Exclude anything related to fonts.
             exclude: [
@@ -407,7 +407,7 @@ class TargetsFileRules {
               // Any path for a `favicon` file with extension `png` or `ico`.
               `${ruleTarget.paths.source}/**/favicon.{png,ico}`,
               // Any path for an `.svg` file with a `fonts` component inside the `node_modules`.
-              '/node_modules/**/fonts/**/*.svg',
+              'node_modules/**/fonts/**/*.svg',
             ],
           },
         },

--- a/tests/services/targets/targetsFileRules/targetsFileRules.test.js
+++ b/tests/services/targets/targetsFileRules/targetsFileRules.test.js
@@ -312,9 +312,9 @@ describe('services/targets:targetsFileRules', () => {
     testRuleProperty(false, 'random-path/to/something', paths.target);
 
     // -- Module
-    testRuleProperty(true, `/node_modules/${moduleToInclude}/something`, paths.module);
-    testRuleProperty(true, `/node_modules/${moduleToInclude}/something/else`, paths.module);
-    testRuleProperty(false, '/node_modules/wootils/something/else', paths.module);
+    testRuleProperty(true, `node_modules/${moduleToInclude}/something`, paths.module);
+    testRuleProperty(true, `node_modules/${moduleToInclude}/something/else`, paths.module);
+    testRuleProperty(false, 'node_modules/wootils/something/else', paths.module);
 
     // Files
     // -- Config
@@ -331,25 +331,25 @@ describe('services/targets:targetsFileRules', () => {
     // --- Module
     testRuleProperty(
       true,
-      `/node_modules/${moduleToInclude}/file.js`,
+      `node_modules/${moduleToInclude}/file.js`,
       regexs.module,
       globs.module
     );
     testRuleProperty(
       true,
-      `/node_modules/${moduleToInclude}/other/file.jsx`,
+      `node_modules/${moduleToInclude}/other/file.jsx`,
       regexs.module,
       globs.module
     );
     testRuleProperty(
       false,
-      '/node_modules/wootils/other.js',
+      'node_modules/wootils/other.js',
       regexs.module,
       globs.module
     );
     testRuleProperty(
       false,
-      `/node_modules/${moduleToInclude}/other.tsx`,
+      `node_modules/${moduleToInclude}/other.tsx`,
       regexs.module,
       globs.module
     );
@@ -506,9 +506,9 @@ describe('services/targets:targetsFileRules', () => {
     testRuleProperty(false, 'random-path/to/something', paths.target);
 
     // -- Module
-    testRuleProperty(true, `/node_modules/${moduleToInclude}/something`, paths.module);
-    testRuleProperty(true, `/node_modules/${moduleToInclude}/something/else`, paths.module);
-    testRuleProperty(false, '/node_modules/wootils/something/else', paths.module);
+    testRuleProperty(true, `node_modules/${moduleToInclude}/something`, paths.module);
+    testRuleProperty(true, `node_modules/${moduleToInclude}/something/else`, paths.module);
+    testRuleProperty(false, 'node_modules/wootils/something/else', paths.module);
 
     // Files
     // -- Target
@@ -519,25 +519,25 @@ describe('services/targets:targetsFileRules', () => {
     // --- Module
     testRuleProperty(
       true,
-      `/node_modules/${moduleToInclude}/file.scss`,
+      `node_modules/${moduleToInclude}/file.scss`,
       regexs.module,
       globs.module
     );
     testRuleProperty(
       true,
-      `/node_modules/${moduleToInclude}/other/file.scss`,
+      `node_modules/${moduleToInclude}/other/file.scss`,
       regexs.module,
       globs.module
     );
     testRuleProperty(
       false,
-      '/node_modules/wootils/other.scss',
+      'node_modules/wootils/other.scss',
       regexs.module,
       globs.module
     );
     testRuleProperty(
       false,
-      `/node_modules/${moduleToInclude}/other.tsx`,
+      `node_modules/${moduleToInclude}/other.tsx`,
       regexs.module,
       globs.module
     );
@@ -636,8 +636,8 @@ describe('services/targets:targetsFileRules', () => {
     testRuleProperty(false, 'random-path/to/something', paths.target);
 
     // -- Modules
-    testRuleProperty(true, '/node_modules/jimpex/something', paths.modules);
-    testRuleProperty(true, '/node_modules/jimpex/something/else', paths.modules);
+    testRuleProperty(true, 'node_modules/jimpex/something', paths.modules);
+    testRuleProperty(true, 'node_modules/jimpex/something/else', paths.modules);
 
     // Files
     // -- Target
@@ -649,19 +649,19 @@ describe('services/targets:targetsFileRules', () => {
     // --- Modules
     testRuleProperty(
       true,
-      '/node_modules/jimpex/file.css',
+      'node_modules/jimpex/file.css',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       true,
-      '/node_modules/wootils/other/file.css',
+      'node_modules/wootils/other/file.css',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       false,
-      '/node_modules/jimpex/other.tsx',
+      'node_modules/jimpex/other.tsx',
       regexs.modules,
       globs.module
     );
@@ -763,8 +763,8 @@ describe('services/targets:targetsFileRules', () => {
     testRuleProperty(false, 'random-path/to/something', paths.target);
 
     // -- Modules
-    testRuleProperty(true, '/node_modules/jimpex/something', paths.modules);
-    testRuleProperty(true, '/node_modules/jimpex/something/else', paths.modules);
+    testRuleProperty(true, 'node_modules/jimpex/something', paths.modules);
+    testRuleProperty(true, 'node_modules/jimpex/something/else', paths.modules);
 
     // Files
     // -- Target
@@ -782,31 +782,31 @@ describe('services/targets:targetsFileRules', () => {
     // -- Modules
     testRuleProperty(
       true,
-      '/node_modules/jimpex/file.woff',
+      'node_modules/jimpex/file.woff',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       true,
-      '/node_modules/jimpex/file.woff2',
+      'node_modules/jimpex/file.woff2',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       true,
-      '/node_modules/wootils/other/file.ttf',
+      'node_modules/wootils/other/file.ttf',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       true,
-      '/node_modules/wootils/other/file.eot',
+      'node_modules/wootils/other/file.eot',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       false,
-      '/node_modules/jimpex/other.tsx',
+      'node_modules/jimpex/other.tsx',
       regexs.modules,
       globs.module
     );
@@ -908,11 +908,11 @@ describe('services/targets:targetsFileRules', () => {
     testRuleProperty(false, 'random-path/to/fonts', paths.target);
 
     // -- Modules
-    testRuleProperty(true, '/node_modules/jimpex/something/fonts', paths.modules);
-    testRuleProperty(true, '/node_modules/jimpex/fonts', paths.modules);
-    testRuleProperty(true, '/node_modules/jimpex/assets/fonts/', paths.modules);
-    testRuleProperty(false, '/node_modules/jimpex/fonts-something/else', paths.modules);
-    testRuleProperty(false, '/node_modules/jimpex/something/else', paths.modules);
+    testRuleProperty(true, 'node_modules/jimpex/something/fonts', paths.modules);
+    testRuleProperty(true, 'node_modules/jimpex/fonts', paths.modules);
+    testRuleProperty(true, 'node_modules/jimpex/assets/fonts/', paths.modules);
+    testRuleProperty(false, 'node_modules/jimpex/fonts-something/else', paths.modules);
+    testRuleProperty(false, 'node_modules/jimpex/something/else', paths.modules);
 
     // Files
     // -- Target
@@ -925,25 +925,25 @@ describe('services/targets:targetsFileRules', () => {
     // --- Modules
     testRuleProperty(
       true,
-      '/node_modules/jimpex/fonts/file.svg',
+      'node_modules/jimpex/fonts/file.svg',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       true,
-      '/node_modules/jimpex/assets/fonts/my.svg',
+      'node_modules/jimpex/assets/fonts/my.svg',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       false,
-      '/node_modules/wootils/fonts/file.ttf',
+      'node_modules/wootils/fonts/file.ttf',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       false,
-      '/node_modules/wootils/other/file.svg',
+      'node_modules/wootils/other/file.svg',
       regexs.modules,
       globs.modules
     );
@@ -1083,8 +1083,8 @@ describe('services/targets:targetsFileRules', () => {
     testRuleProperty(false, 'random-path/to/something', paths.target);
 
     // --- Modules
-    testRuleProperty(true, '/node_modules/jimpex/something', paths.modules);
-    testRuleProperty(true, '/node_modules/jimpex/something/else', paths.modules);
+    testRuleProperty(true, 'node_modules/jimpex/something', paths.modules);
+    testRuleProperty(true, 'node_modules/jimpex/something/else', paths.modules);
     testRuleProperty(false, 'random-path/to/something', paths.modules);
 
     // -- Exclude
@@ -1101,9 +1101,9 @@ describe('services/targets:targetsFileRules', () => {
     testRuleProperty(false, 'random-path/to/something', paths.favicon);
 
     // -- Modules Fonts
-    testRuleProperty(true, '/node_modules/jimpex/something/fonts/file.svg', paths.modulesFonts);
-    testRuleProperty(false, '/node_modules/jimpex/file.svg', paths.modulesFonts);
-    testRuleProperty(false, '/node_modules/jimpex/something/else', paths.modulesFonts);
+    testRuleProperty(true, 'node_modules/jimpex/something/fonts/file.svg', paths.modulesFonts);
+    testRuleProperty(false, 'node_modules/jimpex/file.svg', paths.modulesFonts);
+    testRuleProperty(false, 'node_modules/jimpex/something/else', paths.modulesFonts);
 
     // Files
     // -- Include
@@ -1124,37 +1124,37 @@ describe('services/targets:targetsFileRules', () => {
     // --- Modules
     testRuleProperty(
       true,
-      '/node_modules/jimpex/file.jpg',
+      'node_modules/jimpex/file.jpg',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       true,
-      '/node_modules/jimpex/file.jpeg',
+      'node_modules/jimpex/file.jpeg',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       true,
-      '/node_modules/wootils/other/file.png',
+      'node_modules/wootils/other/file.png',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       true,
-      '/node_modules/wootils/other/file.gif',
+      'node_modules/wootils/other/file.gif',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       true,
-      '/node_modules/wootils/other/file.svg',
+      'node_modules/wootils/other/file.svg',
       regexs.modules,
       globs.modules
     );
     testRuleProperty(
       false,
-      '/node_modules/jimpex/other.tsx',
+      'node_modules/jimpex/other.tsx',
       regexs.modules,
       globs.module
     );
@@ -1174,19 +1174,19 @@ describe('services/targets:targetsFileRules', () => {
     // -- Modules Fonts
     testRuleProperty(
       true,
-      '/node_modules/jimpex/something/fonts/file.svg',
+      'node_modules/jimpex/something/fonts/file.svg',
       regexs.modulesFonts,
       globs.modulesFonts
     );
     testRuleProperty(
       false,
-      '/node_modules/jimpex/file.svg',
+      'node_modules/jimpex/file.svg',
       regexs.modulesFonts,
       globs.modulesFonts
     );
     testRuleProperty(
       false,
-      '/node_modules/jimpex/something/else.svg',
+      'node_modules/jimpex/something/else.svg',
       regexs.modulesFonts,
       globs.modulesFonts
     );


### PR DESCRIPTION
### What does this PR do?

Hot fix for file rules that use `node_modules` path. If they start with `/`, some webpack and Rollup plugins fail to match.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
