### PR TITLE
New target setting: copy

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -98,6 +98,7 @@ Since there are a lot of settings for the templates, will divide them by type an
   library: false,
   libraryOptions: { ... },
   cleanBeforeBuild: true,
+  copy: [],
 }
 ```
 
@@ -289,6 +290,20 @@ How the library will be exposed: `commonjs2` or `umd`.
 
 Whether or not to remove all code from previous builds from the distribution directory when making a new build.
 
+#### `copy`
+> Default value: `[]`
+
+A list of files to be copied during the bundling process. It can be a list of file paths relative to the target source directory, in which case they'll be copied to the target distribution directory root; or a list of objects with the following format:
+
+```js
+{
+  from: 'path/relative/to/the/source/directory.txt',
+  to: 'path/relative/to/the/distribution/directory.txt',
+}
+```
+
+This is different from the main `copy` feature as this is specific to targets and you may require it for your app to work. For example: You may use this setting to copy a `manifest.json` for your PWA while you can use the main `copy` feature for the `package.json` or an `.nvmrc`, things you need for distribution.
+
 ### `browser`
 
 ```js
@@ -311,6 +326,7 @@ Whether or not to remove all code from previous builds from the distribution dir
   library: false,
   libraryOptions: { ... },
   cleanBeforeBuild: true,
+  copy: [],
   devServer: { ... },
   configuration: { ... },
 }
@@ -542,6 +558,20 @@ Whether or not to use gzip compression on the generated library file.
 > Default value: `true`
 
 Whether or not to remove all code from previous builds from the distribution directory when making a new build.
+
+#### `copy`
+> Default value: `[]`
+
+A list of files to be copied during the bundling process. It can be a list of file paths relative to the target source directory, in which case they'll be copied to the target distribution directory root; or a list of objects with the following format:
+
+```js
+{
+  from: 'path/relative/to/the/source/directory.txt',
+  to: 'path/relative/to/the/distribution/directory.txt',
+}
+```
+
+This is different from the main `copy` feature as this is specific to targets and you may require it for your app to work. For example: You may use this setting to copy a `manifest.json` for your PWA while you can use the main `copy` feature for the `package.json` or an `.nvmrc`, things you need for distribution.
 
 #### `devServer`
 > Default value:

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -103,6 +103,7 @@ class ProjectConfiguration extends ConfigurationFile {
             libraryTarget: 'commonjs2',
           },
           cleanBeforeBuild: true,
+          copy: [],
         },
         browser: {
           type: 'browser',
@@ -161,6 +162,7 @@ class ProjectConfiguration extends ConfigurationFile {
             compress: false,
           },
           cleanBeforeBuild: true,
+          copy: [],
           devServer: {
             port: 2509,
             reload: true,

--- a/src/services/targets/targets.js
+++ b/src/services/targets/targets.js
@@ -338,9 +338,10 @@ class Targets {
    * bundling process.
    * This method uses the `target-copy-files` reducer event, which receives the list of files to
    * copy, the target information and the build type; it expects an updated list on return.
+   * The reducer event can be used on inject a {@link TargetExtraFileTransform} function.
    * @param {Target} target                    The target information.
    * @param {string} [buildType='development'] The type of bundle projext is generating.
-   * @return {Array}
+   * @return {Array} A list of {@link TargetExtraFile}s.
    * @throws {Error} If the target type is `node` but bundling is disabled. There's no need to copy
    *                 files on a target that doesn't require bundling.
    * @throws {Error} If one of the files to copy doesn't exist.

--- a/src/services/targets/targets.js
+++ b/src/services/targets/targets.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const fs = require('fs-extra');
 const extend = require('extend');
 const { AppConfiguration } = require('wootils/node/appConfiguration');
 const { provider } = require('jimple');
@@ -87,7 +88,7 @@ class Targets {
   }
   /**
    * Loads and build the target information.
-   * This method emits the event reducer `target-load` with the information of a loaded target and
+   * This method emits the reducer event `target-load` with the information of a loaded target and
    * expects an object with a target information on return.
    * @throws {Error} If a target has a type but it doesn't match `this.typesValidationRegex`.
    */
@@ -331,6 +332,62 @@ class Targets {
     }
 
     return result;
+  }
+  /**
+   * Gets a list with the information for the files the target needs to copy during the
+   * bundling process.
+   * This method uses the `target-copy-files` reducer event, which receives the list of files to
+   * copy, the target information and expects an update list on return.
+   * @param {Target} target The target information.
+   * @return {Array}
+   * @throws {Error} If the target type is `node` but bundling is disabled. There's no need to copy
+   *                 files on a target that doesn't require bundling.
+   * @throws {Error} If one of the files to copy doesn't exist.
+   */
+  getFilesToCopy(target) {
+    // Validate the target settings
+    if (target.is.node && !target.bundle) {
+      throw new Error('Only targets that require bundling can copy files');
+    }
+    // Get the target paths.
+    const {
+      paths: {
+        build,
+        source,
+      },
+    } = target;
+    // Format the list.
+    let newList = target.copy.map((item) => {
+      // Define an item structure.
+      const newItem = {
+        from: '',
+        to: '',
+      };
+      /**
+       * If the item is a string, use its name and copy it to the target distribution directory
+       * root; but if the target is an object, just prefix its paths with the target directories.
+       */
+      if (typeof item === 'string') {
+        const filename = path.basename(item);
+        newItem.from = path.join(source, item);
+        newItem.to = path.join(build, filename);
+      } else {
+        newItem.from = path.join(source, item.from);
+        newItem.to = path.join(build, item.to);
+      }
+
+      return newItem;
+    });
+
+    // Reduce the list.
+    newList = this.events.reduce('target-copy-files', newList, target);
+
+    const invalid = newList.find((item) => !fs.pathExistsSync(item.from));
+    if (invalid) {
+      throw new Error(`The file to copy doesn't exist: ${invalid.from}`);
+    }
+
+    return newList;
   }
   /**
    * Checks if there are missing entries that need to be replaced with the default fallback, and in

--- a/src/services/targets/targets.js
+++ b/src/services/targets/targets.js
@@ -337,14 +337,15 @@ class Targets {
    * Gets a list with the information for the files the target needs to copy during the
    * bundling process.
    * This method uses the `target-copy-files` reducer event, which receives the list of files to
-   * copy, the target information and expects an update list on return.
-   * @param {Target} target The target information.
+   * copy, the target information and the build type; it expects an updated list on return.
+   * @param {Target} target                    The target information.
+   * @param {string} [buildType='development'] The type of bundle projext is generating.
    * @return {Array}
    * @throws {Error} If the target type is `node` but bundling is disabled. There's no need to copy
    *                 files on a target that doesn't require bundling.
    * @throws {Error} If one of the files to copy doesn't exist.
    */
-  getFilesToCopy(target) {
+  getFilesToCopy(target, buildType = 'development') {
     // Validate the target settings
     if (target.is.node && !target.bundle) {
       throw new Error('Only targets that require bundling can copy files');
@@ -380,7 +381,7 @@ class Targets {
     });
 
     // Reduce the list.
-    newList = this.events.reduce('target-copy-files', newList, target);
+    newList = this.events.reduce('target-copy-files', newList, target, buildType);
 
     const invalid = newList.find((item) => !fs.pathExistsSync(item.from));
     if (invalid) {

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -172,6 +172,14 @@
  */
 
 /**
+ * @typedef {Object} ProjectConfigurationTargetTemplateCopyItem
+ * @property {string}  from The path to the file, relative to the target source directory.
+ * @property {?string} to   The path where the file will be copied, relative to the target
+ *                          distribution directory. If not specified, the file will be copied to
+ *                          the root of the target distribution directory.
+ */
+
+/**
  * ================================================================================================
  * Project configuration > Targets templates > Sub properties > Node
  * ================================================================================================
@@ -395,6 +403,10 @@
  * @property {boolean} [cleanBeforeBuild=true]
  * Whether or not to remove all code from previous builds from the distribution directory when
  * making a new build.
+ * @property {Array} [copy=[]]
+ * A list of files to copy during the bundling process. It can be a list of file paths relative to
+ * the target source directory, in which case they'll be copied to the target distribution
+ * directory root; or a list of {@link ProjectConfigurationTargetTemplateCopyItem}.
  */
 
 /**
@@ -456,6 +468,10 @@
  * @property {boolean} cleanBeforeBuild
  * Whether or not to remove all code from previous builds from the distribution directory when
  * making a new build.
+ * @property {Array} copy
+ * A list of files to copy during the bundling process. It can be a list of file paths relative to
+ * the target source directory, in which case they'll be copied to the target distribution
+ * directory root; or a list of {@link ProjectConfigurationTargetTemplateCopyItem}.
  * @property {TargetTypeCheck} is
  * To check whether the target type is `node` or `browser`
  * @property {TargetPaths} paths
@@ -519,6 +535,10 @@
  * @property {boolean} [cleanBeforeBuild=true]
  * Whether or not to remove all code from previous builds from the distribution directory when
  * making a new build.
+ * @property {Array} [copy=[]]
+ * A list of files to copy during the bundling process. It can be a list of file paths relative to
+ * the target source directory, in which case they'll be copied to the target distribution
+ * directory root; or a list of {@link ProjectConfigurationTargetTemplateCopyItem}.
  * @property {ProjectConfigurationBrowserTargetTemplateDevServerSettings} [devServer]
  * These are the options for the `http` server projext will use when running the target on a
  * development environment.
@@ -568,8 +588,6 @@
  * @property {boolean} flow
  * Whether or not your target uses [flow](https://flow.org/). This will update the Babel
  * configuration in order to add support for it.
- * @property {boolean} CSSModules
- * Whether or not your application uses CSS Modules.
  * @property {boolean} library
  * This will tell the build engine that it needs to be builded as a library to be `require`d.
  * @property {ProjectConfigurationBrowserTargetTemplateLibraryOptions} libraryOptions
@@ -578,6 +596,10 @@
  * @property {boolean} cleanBeforeBuild
  * Whether or not to remove all code from previous builds from the distribution directory when
  * making a new build.
+ * @property {Array} copy
+ * A list of files to copy during the bundling process. It can be a list of file paths relative to
+ * the target source directory, in which case they'll be copied to the target distribution
+ * directory root; or a list of {@link ProjectConfigurationTargetTemplateCopyItem}.
  * @property {ProjectConfigurationBrowserTargetTemplateDevServerSettings} devServer
  * These are the options for the `http` server projext will use when running the target on a
  * development environment.

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -833,6 +833,20 @@
  */
 
 /**
+ * @typedef {function} TargetExtraFileTransform
+ * @param {string} contents The original contents of the file.
+ * @return {Promise<string,Error>} The updated contents.
+ */
+
+/**
+ * @typedef {Object} TargetExtraFile
+ * @property {string}                    from      The file origin path.
+ * @property {string}                    to        The file destination path.
+ * @property {?TargetExtraFileTransform} transform A custom function to modify the contents of
+ *                                                 the file to copy.
+ */
+
+/**
  * ================================================================================================
  * "Interfaces"
  * ================================================================================================

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -60,6 +60,11 @@
  */
 
 /**
+ * @external {Buffer}
+ * https://nodejs.org/api/buffer.html
+ */
+
+/**
  * ================================================================================================
  * Project configuration > Targets > sub properties > Shared
  * ================================================================================================
@@ -834,7 +839,7 @@
 
 /**
  * @typedef {function} TargetExtraFileTransform
- * @param {string} contents The original contents of the file.
+ * @param {Buffer} contents The original contents of the file.
  * @return {Promise<string,Error>} The updated contents.
  */
 

--- a/tests/services/targets/targets.test.js
+++ b/tests/services/targets/targets.test.js
@@ -1858,6 +1858,7 @@ describe('services/targets:targets', () => {
       },
       copy: [file],
     };
+    const buildType = 'production';
     let sut = null;
     const expectedItem = {
       from: path.join(source, file),
@@ -1876,13 +1877,14 @@ describe('services/targets:targets', () => {
       utils
     );
     // Then
-    expect(() => sut.getFilesToCopy(target))
+    expect(() => sut.getFilesToCopy(target, buildType))
     .toThrow(new RegExp(`The file to copy doesn't exist: ${expectedErrorPath}`, 'i'));
     expect(events.reduce).toHaveBeenCalledTimes(1);
     expect(events.reduce).toHaveBeenCalledWith(
       'target-copy-files',
       expectedList,
-      target
+      target,
+      buildType
     );
   });
 
@@ -1958,7 +1960,8 @@ describe('services/targets:targets', () => {
     expect(events.reduce).toHaveBeenCalledWith(
       'target-copy-files',
       expectedList,
-      target
+      target,
+      'development'
     );
   });
 


### PR DESCRIPTION
### What does this PR do?

As the title says, it adds a new target setting: `copy`. Here's an extract of the documentation with more information about how it works:

> It can be a list of file paths relative to the target source directory, in which case they'll be copied to the target distribution directory root; or a list of objects with the following format:
>
> ```js
> {
>   from: 'path/relative/to/the/source/directory.txt',
>   to: 'path/relative/to/the/distribution/directory.txt',
> }
> ```
>
> This is different from the main `copy` feature as this is specific to targets and you may require it for your app to work. For example: You may use this setting to copy a `manifest.json` for your PWA while you can use the main `copy` feature for the `package.json` or an `.nvmrc`, things you need for distribution.

This feature has itself a _"sub feature"_: When the list of files for a target is formatted and generated, projext runs a reducer event for it and this is where plugins can add a custom `tranform` function: It receives the current contents of the file and expects new contents on return.

Now, two things about this:

1. There's an example of this on the upcoming update of the [`projext-samples`](https://github.com/homer0/projext-samples) repository.
2. Don't think that if you don't create your own plugins you can't get access to the _"sub feature"_; just wait for the upcoming "Custom plugins" PR.

### How should it be tested manually?

There's nothing to actually test as the only thing this PR adds is support for the setting and a way to retrieve the list, the real functionality will be added on the engines PRs, so...

```bash
yarn test
# or
npm test
```
