### PR TITLE
Custom plugins

### DIFF
--- a/.jestrc.json
+++ b/.jestrc.json
@@ -2,5 +2,6 @@
   "automock": true,
   "unmockedModulePathPatterns": ["/node_modules/", "/mocks/"],
   "coveragePathIgnorePatterns": ["/node_modules/", "/mocks/"],
-  "collectCoverage": true
+  "collectCoverage": true,
+  "testEnvironment": "node"
 }

--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -28,6 +28,9 @@ There's no _"top level"_ setting, everything is separated in different scopes re
 
   // The settings of the feature the manages your project version.
   version: ...,
+  
+  // The path to custom plugins projext should load
+  plugins: ...,
 
   // Miscellaneous settings.
   others: ...,
@@ -657,7 +660,7 @@ Whether or not to redirect the browser back to the root whenever a path can't be
 
 These are the settings for the feature that allows a browser target to have a dynamic configuration file.
 
-> For more precise information, check the document about Browser configuration
+> For more precise information, check the document about Browser configuration.
 
 **`configuration.enabled`**
 
@@ -839,6 +842,29 @@ This tells projext if the file should be created only when building for producti
 > Default value: `[]`
 
 This can be used to specify the targets that will trigger the feature when builded. If no target is specified, the feature will be triggered by all the targets.
+
+## `plugins`
+
+To load custom plugins.
+
+```js
+{
+  enabled: true,
+  list: [],
+}
+```
+
+### `enabled`
+> Default value: `true`
+
+Whether or not custom plugins should be loaded.
+
+### `list`
+> Default value: `[]`
+
+A list of plugin paths relative to the project root directory. Those files can export a single function or a function called `plugin` in order to be loaded.
+
+> For more precise information, check the document about creating plugins.
 
 ## `others`
 

--- a/src/services/common/plugins.js
+++ b/src/services/common/plugins.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { provider } = require('jimple');
 /**
  * This service is in charge of looking for, loading and registering plugins for the app.
@@ -47,7 +48,7 @@ class Plugins {
     this._loadedPlugins = [];
   }
   /**
-   * Load all the plugins.
+   * Search for plugins on the `package.json` and loads them.
    * @param  {boolean} [dependencies=true]    Whether or not to look for plugins on the
    *                                          `dependencies`.
    * @param  {boolean} [devDependencies=true] Whether or not to look for plugins on the
@@ -68,6 +69,17 @@ class Plugins {
     .forEach((name) => this._loadPlugin(name));
   }
   /**
+   * Loads a plugin from a file relative to the project root directory.
+   * @param {string} filePath The path to the file.
+   */
+  loadFromFile(filePath) {
+    this._loadPluginFile(
+      filePath,
+      path.basename(filePath),
+      this.pathUtils.join(filePath)
+    );
+  }
+  /**
    * Gets the names of the loaded plugins.
    * @return {string}
    */
@@ -83,28 +95,44 @@ class Plugins {
     return this.getLoadedPlugins().includes(name);
   }
   /**
-   * Load a plugin by its package name.
-   * @param  {string} packageName The name of the plugin.
-   * @throws {Error} If the plugin can't be loaded or registered.
+   * Loads a plugin by its package name.
+   * @param {string} packageName The name of the plugin.
    * @ignore
    * @access protected
    */
   _loadPlugin(packageName) {
+    this._loadPluginFile(
+      packageName,
+      packageName.substr(this.prefix.length),
+      this.pathUtils.join('node_modules', packageName)
+    );
+  }
+  /**
+   * Loads a plugin form an specific file.
+   * @param {string} reference A name for the plugin to show in case the plugin can't be loaded.
+   *                           In the case of a plugin from the `node_modules`, it should be the
+   *                           package name; on any other case, it should be the file path.
+   * @param {string} name      The name the service will use to save it on the list of loaded
+   *                           plugins.
+   * @param {string} filepath  The path to the file to `require`.
+   * @throws {Error} If the plugin can't be loaded or registered.
+   * @ignore
+   * @access protected
+   */
+  _loadPluginFile(reference, name, filepath) {
     try {
-      const packagePath = this.pathUtils.join('node_modules', packageName);
       // eslint-disable-next-line global-require,import/no-dynamic-require
-      const plugin = require(packagePath);
+      const plugin = require(filepath);
       if (plugin.plugin && typeof plugin.plugin === 'function') {
         plugin.plugin(this.app);
       } else {
         plugin(this.app);
       }
     } catch (error) {
-      this.appLogger.error(`The plugin ${packageName} couldn't be loaded`);
+      this.appLogger.error(`The plugin ${reference} couldn't be loaded`);
       throw error;
     }
 
-    const name = packageName.substr(this.prefix.length);
     this._loadedPlugins.push(name);
   }
 }

--- a/tests/mocks/configurationFile.mock.js
+++ b/tests/mocks/configurationFile.mock.js
@@ -23,9 +23,10 @@ class ConfigurationFileMock {
     overwrites = changes;
   }
 
-  constructor(...args) {
+  constructor(pathUtils, ...args) {
     this.constructorMock = mocks.constructor;
-    this.constructorMock(...args);
+    this.constructorMock(pathUtils, ...args);
+    this.pathUtils = pathUtils;
     this._config = {};
   }
 

--- a/tests/mocks/mockPluginWithError.js
+++ b/tests/mocks/mockPluginWithError.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  throw new Error('Unknown');
+};

--- a/tests/services/common/plugins.test.js
+++ b/tests/services/common/plugins.test.js
@@ -91,6 +91,29 @@ describe('services/common:plugins', () => {
     expect(app.register).toHaveBeenCalledWith('pluginWithFunction');
   });
 
+  it('should load a plugin using a file path', () => {
+    // Given
+    const app = {
+      register: jest.fn(),
+    };
+    const prefix = 'plugin-';
+    const appLogger = 'appLogger';
+    const packageInfo = 'packageInfo';
+    const pluginFile = `${mocksRelativePath}/mockPlugin.js`;
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    let sut = null;
+    // When
+    sut = new Plugins(prefix, app, appLogger, packageInfo, pathUtils);
+    sut.loadFromFile(pluginFile);
+    // Then
+    expect(pathUtils.join).toHaveBeenCalledTimes(1);
+    expect(pathUtils.join).toHaveBeenCalledWith(pluginFile);
+    expect(app.register).toHaveBeenCalledTimes(1);
+    expect(app.register).toHaveBeenCalledWith('plugin');
+  });
+
   it('should fail to load a plugin', () => {
     // Given
     const prefix = 'plugin-';
@@ -108,17 +131,14 @@ describe('services/common:plugins', () => {
         [pluginName]: 'latest',
       },
     };
-    const error = new Error('Unknown error');
     const pathUtils = {
-      join: jest.fn(() => {
-        throw error;
-      }),
+      join: jest.fn(() => `${mocksRelativePath}/mockPluginWithError.js`),
     };
     let sut = null;
     // When
     sut = new Plugins(prefix, app, appLogger, packageInfo, pathUtils);
     // Then
-    expect(() => sut.load()).toThrow(error);
+    expect(() => sut.load()).toThrow(/Unknown/i);
     expect(pathUtils.join).toHaveBeenCalledTimes(1);
     expect(pathUtils.join).toHaveBeenCalledWith('node_modules', pluginName);
     expect(appLogger.error).toHaveBeenCalledTimes(1);

--- a/tests/services/configurations/projectConfiguration.test.js
+++ b/tests/services/configurations/projectConfiguration.test.js
@@ -3,8 +3,10 @@ const ConfigurationFileMock = require('/tests/mocks/configurationFile.mock');
 
 jest.mock('jimple', () => JimpleMock);
 jest.mock('/src/abstracts/configurationFile', () => ConfigurationFileMock);
+jest.mock('fs-extra');
 jest.unmock('/src/services/configurations/projectConfiguration');
 
+const fs = require('fs-extra');
 require('jasmine-expect');
 const {
   ProjectConfiguration,
@@ -14,6 +16,7 @@ const {
 describe('services/configurations:projectConfiguration', () => {
   beforeEach(() => {
     ConfigurationFileMock.reset();
+    fs.pathExistsSync.mockReset();
   });
 
   it('should be instantiated', () => {
@@ -41,7 +44,9 @@ describe('services/configurations:projectConfiguration', () => {
 
   it('should return the project configuration', () => {
     // Given
-    const pathUtils = 'pathUtils';
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
     const plugins = {
       loaded: jest.fn(() => false),
     };
@@ -52,6 +57,7 @@ describe('services/configurations:projectConfiguration', () => {
       'targets',
       'copy',
       'version',
+      'plugins',
       'others',
     ];
     let sut = null;
@@ -74,11 +80,19 @@ describe('services/configurations:projectConfiguration', () => {
     expect(Object.keys(result)).toEqual(expectedKeys);
     expect(targetsFinder).toHaveBeenCalledTimes(1);
     expect(targetsFinder).toHaveBeenCalledWith(result.paths.source);
+    expect(fs.pathExistsSync).toHaveBeenCalledTimes(2);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith('projext.plugin.js');
+    expect(fs.pathExistsSync).toHaveBeenCalledWith('config/projext.plugin.js');
+    expect(pathUtils.join).toHaveBeenCalledTimes(2);
+    expect(pathUtils.join).toHaveBeenCalledWith('projext.plugin.js');
+    expect(pathUtils.join).toHaveBeenCalledWith('config/projext.plugin.js');
   });
 
   it('should return the project configuration and use `webpack` as build engine', () => {
     // Given
-    const pathUtils = 'pathUtils';
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
     const plugin = 'webpack';
     const plugins = {
       loaded: jest.fn((name) => (name === plugin)),
@@ -96,7 +110,9 @@ describe('services/configurations:projectConfiguration', () => {
 
   it('should return the project configuration and use `Rollup` as build engine', () => {
     // Given
-    const pathUtils = 'pathUtils';
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
     const plugin = 'rollup';
     const plugins = {
       loaded: jest.fn((name) => (name === plugin)),
@@ -114,7 +130,9 @@ describe('services/configurations:projectConfiguration', () => {
 
   it('should return the project configuration with targets found on the source directory', () => {
     // Given
-    const pathUtils = 'pathUtils';
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
     const plugins = {
       loaded: jest.fn(() => false),
     };
@@ -134,6 +152,7 @@ describe('services/configurations:projectConfiguration', () => {
       'targets',
       'copy',
       'version',
+      'plugins',
       'others',
     ];
     let sut = null;
@@ -165,7 +184,9 @@ describe('services/configurations:projectConfiguration', () => {
 
   it('should overwrite any found target information', () => {
     // Given
-    const pathUtils = 'pathUtils';
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
     const plugins = {
       loaded: jest.fn(() => false),
     };
@@ -189,6 +210,7 @@ describe('services/configurations:projectConfiguration', () => {
       'targets',
       'copy',
       'version',
+      'plugins',
       'others',
     ];
     let sut = null;
@@ -219,7 +241,9 @@ describe('services/configurations:projectConfiguration', () => {
 
   it('should rename a target if it only found one and the configuration also has only one', () => {
     // Given
-    const pathUtils = 'pathUtils';
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
     const plugins = {
       loaded: jest.fn(() => false),
     };
@@ -244,6 +268,7 @@ describe('services/configurations:projectConfiguration', () => {
       'targets',
       'copy',
       'version',
+      'plugins',
       'others',
     ];
     let sut = null;
@@ -281,7 +306,9 @@ describe('services/configurations:projectConfiguration', () => {
         },
       },
     });
-    const pathUtils = 'pathUtils';
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
     const plugins = {
       loaded: jest.fn(() => false),
     };
@@ -292,6 +319,7 @@ describe('services/configurations:projectConfiguration', () => {
       'targets',
       'copy',
       'version',
+      'plugins',
       'others',
     ];
     let sut = null;
@@ -314,6 +342,146 @@ describe('services/configurations:projectConfiguration', () => {
     expect(Object.keys(result)).toEqual(expectedKeys);
     expect(result.targets).toEqual({});
     expect(targetsFinder).toHaveBeenCalledTimes(0);
+  });
+
+  it('should load a plugin which file was specified on the configuration', () => {
+    // Given
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    const plugins = {
+      loaded: jest.fn(() => false),
+      loadFromFile: jest.fn(),
+    };
+    const pluginFile = 'my-plugin.js';
+    ConfigurationFileMock.overwrite({
+      plugins: {
+        list: [pluginFile],
+      },
+    });
+    const targetsFinder = jest.fn(() => []);
+    const expectedKeys = [
+      'paths',
+      'targetsTemplates',
+      'targets',
+      'copy',
+      'version',
+      'plugins',
+      'others',
+    ];
+    let sut = null;
+    let result = null;
+    // When
+    sut = new ProjectConfiguration(pathUtils, plugins, targetsFinder);
+    result = sut.getConfig();
+    // Then
+    expect(sut).toBeInstanceOf(ProjectConfiguration);
+    expect(sut.constructorMock).toHaveBeenCalledTimes(1);
+    expect(sut.constructorMock).toHaveBeenCalledWith(
+      pathUtils,
+      [
+        'projext.config.js',
+        'config/projext.config.js',
+        'config/project.config.js',
+      ]
+    );
+    expect(result).toBeObject();
+    expect(Object.keys(result)).toEqual(expectedKeys);
+    expect(plugins.loadFromFile).toHaveBeenCalledTimes(1);
+    expect(plugins.loadFromFile).toHaveBeenCalledWith(pluginFile);
+  });
+
+  it('shouldn\'t load custom plugins if the feature is disabled', () => {
+    // Given
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    const plugins = {
+      loaded: jest.fn(() => false),
+      loadFromFile: jest.fn(),
+    };
+    const pluginFile = 'my-plugin.js';
+    ConfigurationFileMock.overwrite({
+      plugins: {
+        enabled: false,
+        list: [pluginFile],
+      },
+    });
+    const targetsFinder = jest.fn(() => []);
+    const expectedKeys = [
+      'paths',
+      'targetsTemplates',
+      'targets',
+      'copy',
+      'version',
+      'plugins',
+      'others',
+    ];
+    let sut = null;
+    let result = null;
+    // When
+    sut = new ProjectConfiguration(pathUtils, plugins, targetsFinder);
+    result = sut.getConfig();
+    // Then
+    expect(sut).toBeInstanceOf(ProjectConfiguration);
+    expect(sut.constructorMock).toHaveBeenCalledTimes(1);
+    expect(sut.constructorMock).toHaveBeenCalledWith(
+      pathUtils,
+      [
+        'projext.config.js',
+        'config/projext.config.js',
+        'config/project.config.js',
+      ]
+    );
+    expect(result).toBeObject();
+    expect(Object.keys(result)).toEqual(expectedKeys);
+    expect(pathUtils.join).toHaveBeenCalledTimes(0);
+    expect(fs.pathExistsSync).toHaveBeenCalledTimes(0);
+    expect(plugins.loadFromFile).toHaveBeenCalledTimes(0);
+  });
+
+  it('should load the "known plugins"', () => {
+    // Given
+    fs.pathExistsSync.mockImplementationOnce(() => true);
+    fs.pathExistsSync.mockImplementationOnce(() => true);
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    const plugins = {
+      loaded: jest.fn(() => false),
+      loadFromFile: jest.fn(),
+    };
+    const targetsFinder = jest.fn(() => []);
+    const expectedKeys = [
+      'paths',
+      'targetsTemplates',
+      'targets',
+      'copy',
+      'version',
+      'plugins',
+      'others',
+    ];
+    let sut = null;
+    let result = null;
+    // When
+    sut = new ProjectConfiguration(pathUtils, plugins, targetsFinder);
+    result = sut.getConfig();
+    // Then
+    expect(sut).toBeInstanceOf(ProjectConfiguration);
+    expect(sut.constructorMock).toHaveBeenCalledTimes(1);
+    expect(sut.constructorMock).toHaveBeenCalledWith(
+      pathUtils,
+      [
+        'projext.config.js',
+        'config/projext.config.js',
+        'config/project.config.js',
+      ]
+    );
+    expect(result).toBeObject();
+    expect(Object.keys(result)).toEqual(expectedKeys);
+    expect(plugins.loadFromFile).toHaveBeenCalledTimes(2);
+    expect(plugins.loadFromFile).toHaveBeenCalledWith('projext.plugin.js');
+    expect(plugins.loadFromFile).toHaveBeenCalledWith('config/projext.plugin.js');
   });
 
   it('should include a provider for the DIC', () => {


### PR DESCRIPTION
### What does this PR do?

It adds support for custom plugins, which are files on your project that you want for projext to load as plugins. They'll have access to the projext dependency injection container and thus all the services and events projext handles.

There's 2 ways of implementing this:

#### The "zero configuration way"

You can create a file called `projext.plugin.js` on either your project root directory or on `/config`. The file will be detected and automatically loaded by projext.

#### Project setting

This PR adds a new setting scope to the project configuration:

```js
...
plugins: {
  enabled: true,
  list: [],
},
...
```

- `enabled`: Whether custom plugins should be loaded or not. If `false`, this will also disabled the load of the `projext.plugin.js` file.
- `list`: A list of files, with paths relative to the project root directory, that will be loaded as plugins.

--

This PR also changes the `testEnvironment` of Jest in order to make it a little bit faster.

### How should it be tested manually?

Create a custom plugin:

```js
// /projext.plugin.js

module.exports = (app) => {
  app.get('events').on('build-target-commands-list', (commands) => [
    'echo "HELLO"',
    ...commands,
  ]);
}
```

That plugin will listen for the reducer event for the list of commands projext and the build engine use for bundling/running a target. The listener will add a `echo "HELLO"` on front of all the other commands, so if you run `projext build` or `projext run`, you'll see `HELLO` logged before it starts building the target.

And of course...

```bash
yarn test
# or
npm test
```
