### PR TITLE
Add the devServer.open option

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -583,6 +583,7 @@ This is different from the main `copy` feature as this is specific to targets an
 > {
 >   port: 2509,
 >   reload: true,
+>   open: true,
 >   host: 'localhost',
 >   ssl: {
 >     key: null,
@@ -602,7 +603,11 @@ The server port.
 
 **`devServer.reload`**
 
-Whether or not to reload the server when the code changes.
+Whether or not to reload the browser when the code changes.
+
+**`devServer.open`**
+
+Whether or not to open the browser when server is ready.
 
 **`devServer.host`**
 

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -166,6 +166,7 @@ class ProjectConfiguration extends ConfigurationFile {
           copy: [],
           devServer: {
             port: 2509,
+            open: true,
             reload: true,
             host: 'localhost',
             ssl: {

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -300,7 +300,9 @@
  * @property {number} [port=2509]
  * The server port.
  * @property {boolean} [reload=true]
- * Whether or not to reload the server when the code changes.
+ * Whether or not to reload the browser when the code changes.
+ * @property {boolean} [open=true]
+ * Whether or not to open the browser when server is ready.
  * @property {string} [host='localhost']
  * The dev server hostname.
  * @property {ProjectConfigurationBrowserTargetTemplateDevServerSSLSettings} [ssl]


### PR DESCRIPTION
### What does this PR do?

Adds a new option for the dev server settings: `open`. You can now decide whether you want projext to open the browser or not.

### How should it be tested manually?

The real functionality will be added by the engines PRs so...

```bash
yarn test
# or
npm test
```
