### PR TITLE
Watch mode

### DIFF
--- a/documents/cli.md
+++ b/documents/cli.md
@@ -11,12 +11,24 @@ You can run this commands with either [yarn](https://yarnpkg.com), [npx](https:/
 It builds a target and moves it bundle to the distribution directory.
 
 ```bash
-projext build [target] [--type [type]] [--run]
+projext build [target] [--type [type]] [--watch] [--run]
 ```
 
 - **target:** The name of the target you intend to build. If no target is specified, projext will try to use the default target (the one with the project's name or the first on an alphabetical list).
 - **type:** Which build type: `development` (default) or `production`.
+- **watch:** Watch the target files and update the build. If the target type is Node and it doesn't require bundling nor transpiling, it won't do anything.
 - **run:** Run the target after the build is completed. It only works when the build type is `development`.
+
+### Watching a target
+
+It tells projext to watch your target files and update the build if they change.
+
+```bash
+projext run [target]
+```
+- **target:** The name of the target you intend to build and watch. If no target is specified, projext will try to use the default target (the one with the project's name or the first on an alphabetical list).
+
+> This is basically an alias of `projext build` that uses the `--watch` flag by default.
 
 ### Running a target
 

--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -96,6 +96,7 @@ Since there are a lot of settings for the templates, will divide them by type an
   excludeModules: [],
   includeTargets: [],
   runOnDevelopment: false,
+  watch: { ... },
   babel: { ... },
   flow: false,
   library: false,
@@ -234,6 +235,18 @@ This tells projext that when the target is builded (bundled/copied) on a develop
 
 When the target needs to be bundled, it will relay on the build engined to do it, otherwise, projext will use its custom implementation of [`nodemon`](https://yarnpkg.com/en/package/nodemon) for watching and, if needed, transpile your target code.
 
+#### `watch`
+> Default value:
+>
+> ```js
+> {
+>   development: false,
+>   production: false,
+> }
+> ```
+
+Using this flags, you can tell projext to always watch your files when building for an specific environment.
+
 #### `babel`
 > Default value:
 >
@@ -324,6 +337,7 @@ This is different from the main `copy` feature as this is specific to targets an
   includeModules: [],
   includeTargets: [],
   runOnDevelopment: false,
+  watch: { ... },
   babel: { ... },
   flow: false,
   library: false,
@@ -484,6 +498,18 @@ You have two possible solutions now, thanks to `includeTargets`: You can either 
 > Default value: `false`
 
 This will tell the build engine that when you build the target for a development environment, it should bring up an `http` server to _"run"_ your target.
+
+#### `watch`
+> Default value:
+>
+> ```js
+> {
+>   development: false,
+>   production: false,
+> }
+> ```
+
+Using this flags, you can tell projext to always watch your files when building for an specific environment.
 
 #### `babel`
 > Default value:

--- a/src/abstracts/nodeWatcher.js
+++ b/src/abstracts/nodeWatcher.js
@@ -1,0 +1,232 @@
+const path = require('path');
+const Watchpack = require('watchpack');
+/**
+ * A helper class for creating services that rely on watching directories and copying and/or
+ * transpiling files.
+ * @abstract
+ * @version 1.0
+ */
+class NodeWatcher {
+  /**
+   * @param {WatchpackOptions} [watchpackOptions={}] Custom options for `watchpack`, the library
+   *                                                 being used to watch directories.
+   */
+  constructor(watchpackOptions = {}) {
+    if (new.target === NodeWatcher) {
+      throw new TypeError(
+        'NodeWatcher is an abstract class, it can\'t be instantiated directly'
+      );
+    }
+    /**
+     * Whether or not the service is watching.
+     * @type {boolean}
+     */
+    this.watching = false;
+    /**
+     * The custom options for `watchpack`. They're stored because the instance will be created
+     * when {@link NodeWatcher#watch} is called.
+     * @type {WatchpackOptions}
+     * @access protected
+     * @ignore
+     */
+    this._watchpackOptions = watchpackOptions;
+    /**
+     * This will be the instance of `watchpack` when the service starts watching the files.
+     * @type {?Watchpack}
+     */
+    this._watcher = null;
+    /**
+     * This will be the list of paths the service will be watching.
+     * @type {Array}
+     * @access protected
+     * @ignore
+     */
+    this._paths = [];
+    /**
+     * A list of dictionaries with `from` and `to` paths for transpilation. When a file change is
+     * detected by `watchpack`, the service will try to match the file path with the `from`
+     * property of one of the items, and if one is found, it will call the method to transpile
+     * that file using item's paths.
+     * @type {Array}
+     * @access protected
+     * @ignore
+     */
+    this._transpilationPaths = [];
+    /**
+     * A list of dictionaries with `from` and `to` paths for copying files. When a file change is
+     * detected by `watchpack`, and if the file path doesn't match any of the transpilation paths,
+     * the service will try to match the `from` of an item from this list. If one is found, it will
+     * then call the method to copy that file using item's paths.
+     * @type {Array}
+     * @access protected
+     * @ignore
+     */
+    this._copyPaths = [];
+    /**
+     * Bind the method in case is sent as reference.
+     * @ignore
+     */
+    this.watch = this.watch.bind(this);
+    /**
+     * Bind the method as it will be sent to `watchpack` as reference.
+     * @ignore
+     */
+    this._onChange = this._onChange.bind(this);
+  }
+  /**
+   * Starts watching the directories.
+   * @param {Array} paths                   The list of directories the service will watch.
+   * @param {Array} [transpilationPaths=[]] A list of dictionaries with `from` and `to` paths for
+   *                                        transpilation. When a file change is detected by the
+   *                                        service, it will try to match the file path with the
+   *                                        `from` property of one of the items, and if one is
+   *                                        found, it will call the method to transpile that file
+   *                                        using item's paths.
+   * @param {Array} [copyPaths=[]]          A list of dictionaries with `from` and `to` paths for
+   *                                        copying files. When a file change is detected by the
+   *                                        service, and if the file path doesn't match any of
+   *                                        the transpilation paths, it will try to match the
+   *                                        `from` of an item from this list. If one is found, it
+   *                                        will then call the method to copy that file using
+   *                                        item's paths.
+   * @return {Watchpack}
+   */
+  watch(paths, transpilationPaths = [], copyPaths = []) {
+    if (this.watching) {
+      throw new Error('The service is already watching, you can\'t call it more than once');
+    } else if (!paths.length) {
+      throw new Error('You need to specify at least one path to watch');
+    } else if (!transpilationPaths.length && !copyPaths.length) {
+      throw new Error('You need to provide at least one transpilation or copy path');
+    }
+
+    this.watching = true;
+    this._paths = paths;
+    this._transpilationPaths = transpilationPaths;
+    this._copyPaths = copyPaths;
+
+    this._onStart();
+
+    this._watcher = new Watchpack(this._watchpackOptions);
+    this._watcher.watch([], this._paths);
+    this._watcher.on('change', this._onChange);
+    return this._watcher;
+  }
+  /**
+   * Stops watching the directories.
+   */
+  stop() {
+    if (this._watcher) {
+      this._watcher.close();
+      this.watching = false;
+    }
+  }
+  /**
+   * Gets the list of paths the service is watching.
+   * @return {Array}
+   */
+  getPaths() {
+    return this._paths;
+  }
+  /**
+   * This is called when the service is about to start watching the directories.
+   * @access protected
+   * @ignore
+   */
+  _onStart() {
+
+  }
+  /**
+   * This method is called when `watchpack` detects a source file has changed. It checks if the
+   * file path matches one of the transpilation paths or the copy paths in order to either
+   * transpile or copy the file in to the _"build directory"_.
+   * @param {string} file The path to the modified file.
+   * @access protected
+   * @ignore
+   */
+  _onChange(file) {
+    // Try to find a matching item on the transpilation paths.
+    const transpilationPath = this._transpilationPaths
+    .find(({ from }) => file.startsWith(from));
+    if (transpilationPath) {
+      // If there's an item which `from` matched the file path, transpile the file.
+      this._transpileFile(
+        file,
+        this._getFileNewPath(file, transpilationPath.from, transpilationPath.to)
+      );
+    } else {
+      // If no item matched the file, try to find a copy path.
+      const copyPath = this._copyPaths
+      .find(({ from }) => file.startsWith(from));
+      if (copyPath) {
+        // If there's an item which `from` matched the file path, copy the file.
+        this._copyFile(
+          file,
+          this._getFileNewPath(file, copyPath.from, copyPath.to)
+        );
+      } else {
+        this._onInvalidPathForChange(file);
+      }
+    }
+  }
+  /**
+   * This is called when a source file changes and the service can't find a matching path on neither
+   * the transpilation paths nor the copy paths.
+   * @param {string} file The path to the modified file.
+   * @access protected
+   * @ignore
+   */
+  _onInvalidPathForChange(file) {
+    // To avoid a ESLint vs ESDoc issues.
+    // eslint-disable-next-line no-unused-vars
+    const ignore = file;
+  }
+  /**
+   * Transpiles a file from a source directory into a build directory.
+   * @param {string} source The path to the source file.
+   * @param {string} output The path for the source file once transpiled.
+   * @abstract
+   * @access protected
+   * @ignore
+   */
+  _transpileFile(source, output) {
+    // To avoid a ESLint vs ESDoc issues.
+    // eslint-disable-next-line no-unused-vars
+    const ignore = { source, output };
+
+    throw new Error('_transpileFile must be overwritten');
+  }
+  /**
+   * Copies a file from a source directory into a build directory.
+   * @param {string} from The original path of the file.
+   * @param {string} to   The new path for the file.
+   * @abstract
+   * @access protected
+   * @ignore
+   */
+  _copyFile(from, to) {
+    // To avoid a ESLint vs ESDoc issues.
+    // eslint-disable-next-line no-unused-vars
+    const ignore = { from, to };
+
+    throw new Error('_copyFile must be overwritten');
+  }
+  /**
+   * Builds the path for a file that will be copied/transpiled fro its source directory into the
+   * build directory.
+   * @param {string} file The original path of the file.
+   * @param {string} from The path to the source directory.
+   * @param {string} to   The path to the build directory.
+   * @return {string}
+   * @access protected
+   * @ignore
+   */
+  _getFileNewPath(file, from, to) {
+    // Remove the _"source directory"_ of the file path in order to have just the relative part.
+    const relative = file.substr(from.length);
+    // Create the new path the file will have once copied/transpiled.
+    return path.join(to, relative);
+  }
+}
+
+module.exports = NodeWatcher;

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -29,6 +29,8 @@ const {
   buildEngines,
   buildNodeRunner,
   buildNodeRunnerProcess,
+  buildNodeWatcher,
+  buildNodeWatcherProcess,
   buildTranspiler,
   buildVersion,
   builder,
@@ -46,6 +48,7 @@ const {
   cliSHBuildCommand,
   cliSHCopyCommand,
   cliSHNodeRunCommand,
+  cliSHNodeWatchCommand,
   cliSHRunCommand,
   cliSHTranspileCommand,
   cliSHValidateBuildCommand,
@@ -105,6 +108,8 @@ class Projext extends Jimple {
     this.register(buildEngines);
     this.register(buildNodeRunner);
     this.register(buildNodeRunnerProcess);
+    this.register(buildNodeWatcher);
+    this.register(buildNodeWatcherProcess);
     this.register(buildTranspiler);
     this.register(buildVersion);
     this.register(builder);
@@ -120,6 +125,7 @@ class Projext extends Jimple {
     this.register(cliSHBuildCommand);
     this.register(cliSHCopyCommand);
     this.register(cliSHNodeRunCommand);
+    this.register(cliSHNodeWatchCommand);
     this.register(cliSHRunCommand);
     this.register(cliSHTranspileCommand);
     this.register(cliSHValidateBuildCommand);
@@ -165,6 +171,7 @@ class Projext extends Jimple {
       this.get('cliSHBuildCommand'),
       this.get('cliSHCopyCommand'),
       this.get('cliSHNodeRunCommand'),
+      this.get('cliSHNodeWatchCommand'),
       this.get('cliSHRunCommand'),
       this.get('cliSHTranspileCommand'),
       this.get('cliSHValidateBuildCommand'),

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -51,6 +51,9 @@ const {
   cliSHValidateBuildCommand,
   cliSHValidateRunCommand,
   cliGenerators,
+  cliSHValidateWatchCommand,
+  cliSHWatchCommand,
+  cliWatchCommand,
 } = require('../services/cli');
 
 const {
@@ -121,6 +124,10 @@ class Projext extends Jimple {
     this.register(cliSHTranspileCommand);
     this.register(cliSHValidateBuildCommand);
     this.register(cliSHValidateRunCommand);
+    this.register(cliSHValidateWatchCommand);
+    this.register(cliSHWatchCommand);
+    this.register(cliWatchCommand);
+
     this.register(cliGenerators.targetHTMLGenerator);
     this.register(cliGenerators.projectConfigurationFileGenerator);
 
@@ -162,6 +169,9 @@ class Projext extends Jimple {
       this.get('cliSHTranspileCommand'),
       this.get('cliSHValidateBuildCommand'),
       this.get('cliSHValidateRunCommand'),
+      this.get('cliSHValidateWatchCommand'),
+      this.get('cliSHWatchCommand'),
+      this.get('cliWatchCommand'),
     ]);
   }
   /**

--- a/src/bin/projext
+++ b/src/bin/projext
@@ -5,6 +5,11 @@ task=$1
 disableSHTasks=false
 # Determine whether the task is a private helper task or not
 isSHTask=false
+# Whether or not the real bash command will be shown
+showSHCommand=false
+if echo "$*" | grep -q "\(\s\-\-\(projextdebug\)\(\s\|$\)\)"; then
+  showSHCommand=true
+fi
 
 # If no task was specified...
 if [ "$task" = "" ]; then
@@ -12,7 +17,7 @@ if [ "$task" = "" ]; then
   projext-cli --help
 else
   # ...otherwise, check if the task is a shell task that needs commands
-  if echo "$task" | grep -q "^\(build\|run\)$"; then
+  if echo "$task" | grep -q "^\(build\|run\|watch\)$"; then
     isSHTask=true
   fi
 
@@ -25,13 +30,22 @@ else
   if [ "$isSHTask" = true ] && [ "$disableSHTasks" = false ]; then
       # ...execute a validation command to avoid any error being thrown on the
       # command that returns the list.
+      if [ "$showSHCommand" = true ]; then
+        echo "> projext-cli sh-validate-$*"
+      fi
       eval "projext-cli sh-validate-$*"
       # Capture the commands that need to run
+      if [ "$showSHCommand" = true ]; then
+        echo "> projext-cli sh-$*"
+      fi
       command=$(eval "projext-cli sh-$*")
       # If there are commands to run...
       if [ "$command" != "" ]; then
-        # ...execute them
-        # echo "> $command"
+        # Show the real command(s) if the debug flag was used.
+        if [ "$showSHCommand" = true ]; then
+          echo "> $command"
+        fi
+        # ...and execute the commands
         eval "$command"
       fi
   else

--- a/src/services/building/buildNodeRunner.js
+++ b/src/services/building/buildNodeRunner.js
@@ -27,7 +27,7 @@ class BuildNodeRunner {
   }
   /**
    * Run a target with Nodemon.
-   * @param  {Target} target The target information.
+   * @param {Target} target The target information.
    * @return {Nodemon}
    * @throws {Error} If the target needs to be bundled.
    */
@@ -43,9 +43,11 @@ class BuildNodeRunner {
   /**
    * Runs a target that requires transpilation. It executes the file from the distribution
    * directory while it watches the source directory.
-   * @param  {Target} target The target information.
+   * @param {Target} target The target information.
    * @return {Nodemon}
    * @throws {Error} If one of the included targets requires bundling.
+   * @access protected
+   * @ignore
    */
   _runWithTranspilation(target) {
     const { paths: { source, build }, includeTargets } = target;
@@ -86,10 +88,12 @@ class BuildNodeRunner {
   }
   /**
    * Runs a target that doesn't require transpilation. It executes and watches the source directory.
-   * @param  {Target} target The target information.
+   * @param {Target} target The target information.
    * @return {Nodemon}
    * @throws {Error} If one of the included targets requires bundling.
    * @throws {Error} If one of the included targets requires transpiling.
+   * @access protected
+   * @ignore
    */
   _run(target) {
     const { paths: { source }, includeTargets } = target;

--- a/src/services/building/buildNodeRunnerProcess.js
+++ b/src/services/building/buildNodeRunnerProcess.js
@@ -2,21 +2,24 @@ const path = require('path');
 const fs = require('fs-extra');
 const extend = require('extend');
 const nodemon = require('nodemon');
-const Watchpack = require('watchpack');
 const { provider } = require('jimple');
+const NodeWatcher = require('../../abstracts/nodeWatcher');
 /**
- * This service implements both `nodemon` and `watchpack` in order to run Node apps while watching
- * and transpiling if necessary.
+ * This service implements `nodemon` and {@link NodeWatcher} in order to run Node apps while
+ * watching, transpiling and copying files.
+ * @extends {NodeWatcher}
  */
-class BuildNodeRunnerProcess {
+class BuildNodeRunnerProcess extends NodeWatcher {
   /**
-   * Class constructor.
    * @param {Logger}                       appLogger            The inform on the CLI of the events
    *                                                            of the runner.
-   * @param {BuildTranspiler}              buildTranspiler      To transpile files if required.
-   * @param {ProjectConfigurationSettings} projectConfiguration To read the project paths.
+   * @param {BuildTranspiler}              buildTranspiler      To transpile files if needed.
+   * @param {ProjectConfigurationSettings} projectConfiguration To read the watch settings.
    */
   constructor(appLogger, buildTranspiler, projectConfiguration) {
+    super({
+      poll: projectConfiguration.others.watch.poll,
+    });
     /**
      * A local reference for the `appLogger` service.
      * @type {Logger}
@@ -28,38 +31,24 @@ class BuildNodeRunnerProcess {
      */
     this.buildTranspiler = buildTranspiler;
     /**
-     * The watcher that will check of changes on the target source directory.
-     * @type {Watchpack}
-     */
-    this.watcher = new Watchpack({
-      poll: projectConfiguration.others.watch.poll,
-    });
-    /**
      * A simple flag to check whether the process is running or not.
      * @type {boolean}
      */
     this.running = false;
     /**
-     * The default options for when the service runs a target. These will be overwritten by the
-     * parameters sent to the `run` method.
-     * @type {Object}
-     * @property {string}  executable            The path to the executable file.
-     * @property {Array}   watch                 A list of directories to watch.
-     * @property {Array}   ignore                A list of patterns to ignore.
-     * @property {string}  sourcePath            The path to the source files.
-     * @property {string}  executionPath         The path to the files being executed.
-     * @property {Object}  envVars               A dictionary of environment variables to send to
-     *                                           the process.
-     * @property {boolean} requiresTranspilation Whether or not the target requires transpilation.
+     * @property {string} executable The path to the file `nodemon` will execute.
+     * @property {Array}  watch      The list of directories `nodemon` will watch in orderto reset
+     *                               the execution.
+     * @property {Array}  ignore     A list of patterns `nodemon` will ignore whilewatching
+     *                               directories.
+     * @property {Object} envVars    A dictionary of environment variables to send to theexecution
+     *                               process.
      */
     this.defaultOptions = {
       executable: '',
       watch: [],
-      ignore: [],
-      sourcePath: '',
-      executionPath: '',
       envVars: {},
-      requiresTranspilation: false,
+      ignore: [],
     };
     /**
      * This dictionary is where the parameters sent to the `run` method and the `defaultOptions`
@@ -82,7 +71,7 @@ class BuildNodeRunnerProcess {
      */
     this._restaring = false;
     /**
-     * Bind the method to export it as the main service.
+     * Bind the method that will be exported as the service.
      * @ignore
      */
     this.run = this.run.bind(this);
@@ -106,34 +95,33 @@ class BuildNodeRunnerProcess {
      * @ignore
      */
     this._onNodemonQuit = this._onNodemonQuit.bind(this);
-    /**
-     * Bind the method to send it to the `watchpack` events listener.
-     * @ignore
-     */
-    this._onFileChange = this._onFileChange.bind(this);
   }
   /**
-   * Run a Node app.
-   * @param {string} executable             The app executable.
-   * @param {Array}  watchOn                A list of directories to watch.
-   * @param {string} sourcePath             The path to the source code of the app. If it doesn't
-   *                                        match with `executionPath`, then the code needs
-   *                                        transpilation.
-   * @param {string} executionPath          The path to where the app is being executed. If it
-   *                                        doesn't match with `sourcePath`, then the code needs
-   *                                        transpilation.
-   * @param {Object} [envVars={}]           A dictionary with extra environment variables to send to
-   *                                        the process.
-   * @param {Array}  [ignore=['*.test.js']] A list of patterns to ignore on the watch.
+   * Run a Node application.
+   * @param {string} executable              The path to the file to execute.
+   * @param {Array}  watch                   The list of directories to watch in order to restart
+   *                                         the application.
+   * @param {Array}  [transpilationPaths=[]] A list of dictionaries with `from` and `to` paths the
+   *                                         service will use for transpilation when files change
+   *                                         during the execution, in order to restart the
+   *                                         application.
+   * @param {Array}  [copyPaths=[]]          A list of dictionaries with `from` and `to` paths the
+   *                                         service will use for copying files when they change
+   *                                         during the execution, in order to restart the
+   *                                         application.
+   * @param {Object} [envVars={}]            A dictionary with extra environment variables to send
+   *                                         to the execution process.
+   * @param {Array}  [ignore=['.test.js']]   A list of file name patterns the service that will be
+   *                                         ignored by the `nodemon` watcher.
    * @return {Nodemon}
    * @throws {Error} if the process is already running.
    * @throws {Error} if the executable doesn't exist.
    */
   run(
     executable,
-    watchOn,
-    sourcePath,
-    executionPath,
+    watch,
+    transpilationPaths = [],
+    copyPaths = [],
     envVars = {},
     ignore = ['*.test.js']
   ) {
@@ -147,26 +135,37 @@ class BuildNodeRunnerProcess {
     }
     // Turn on the flag that tells the service the process is running.
     this.running = true;
-    // Define the options.
+    // Merge the default options with the parameters.
     this.options = extend(true, {}, this.defaultOptions, {
       executable,
-      watchOn,
-      ignore,
-      sourcePath,
-      executionPath,
+      watch,
       envVars,
-      requiresTranspilation: (sourcePath !== executionPath),
+      ignore,
     });
-    // If the code requires transpilation...
-    if (this.options.requiresTranspilation) {
-      // ...turn on `watchpack`.
-      this.watcher.watch([], [this.options.sourcePath]);
-      this.watcher.on('change', this._onFileChange);
+    /**
+     * This part is tricky...
+     * First, make sure there's at least one item on the transpilation paths list, because that
+     * means that the files are being executed from a different path than its source directory.
+     * If the files change location, and the application depends on files outside its directory,
+     * then the service will watch the transpilation paths, for files that need to be moved and
+     * transpiled, and the copy files, for files that just need to be moved.
+     * The reason this is _"tricky"_ is because the copy paths are only added if there's
+     * transpilation, because there's no need to copy files if the code doesn't change locations.
+     */
+    if (transpilationPaths.length) {
+      this.watch(
+        [
+          ...transpilationPaths.map(({ from }) => from),
+          ...copyPaths.map(({ from }) => from),
+        ],
+        transpilationPaths,
+        copyPaths
+      );
     }
-    // Execute `nodemon`.
+    // Start `nodemon`.
     nodemon({
       script: this.options.executable,
-      watch: this.options.watchOn,
+      watch: this.options.watch,
       ignore: this.options.ignore,
       env: Object.assign({}, process.env, this.options.envVars),
     });
@@ -177,6 +176,71 @@ class BuildNodeRunnerProcess {
     nodemon.on('quit', this._onNodemonQuit);
 
     return nodemon;
+  }
+  /**
+   * This is called when a source file changes and it's detected by the service, not `nodemon`.
+   * The overwrite is just to show a log message saying that the process will be restarted, as the
+   * parent class will end up transpiling or copying a file into one the directories `nodemon`
+   * watches.
+   * @param {string} file The path to the file that changed.
+   * @access protected
+   * @ignore
+   */
+  _onChange(file) {
+    this.appLogger.warning(`Restarting because a file was modified: ${file}`);
+    super._onChange(file);
+  }
+  /**
+   * This is called when a source file changes and the service can't find a matching path on neither
+   * the transpilation paths nor the copy paths.
+   * The method will just show an error message explaning the problem and call the method that shows
+   * the error when `nodemon` crashes.
+   * @access protected
+   * @ignore
+   */
+  _onInvalidPathForChange() {
+    this.appLogger.error('Error: The file directory is not on the list of allowed paths');
+    this._onNodemonCrash();
+  }
+  /**
+   * Transpiles a file from a source directory into a build directory, which `nodemon` watches.
+   * @param {string} source The path to the source file.
+   * @param {string} output The path for the source file once transpiled.
+   * @access protected
+   * @ignore
+   */
+  _transpileFile(source, output) {
+    try {
+      // Make sure the path to the directory exists.
+      fs.ensureDirSync(path.dirname(output));
+      // Transpile the file.
+      this.buildTranspiler.transpileFileSync({ source, output });
+      this.appLogger.success('The file was successfully copied and transpiled');
+    } catch (error) {
+      this.appLogger.error('Error: The file couldn\'t be updated');
+      this.appLogger.error(error);
+      this._onNodemonCrash();
+    }
+  }
+  /**
+   * Copies a file from a source directory into a build directory, which `nodemon` watches.
+   * @param {string} from The original path of the file.
+   * @param {string} to   The new path for the file.
+   * @access protected
+   * @ignore
+   */
+  _copyFile(from, to) {
+    try {
+      // Make sure the path to the directory exists.
+      fs.ensureDirSync(path.dirname(to));
+      // Copy the file.
+      fs.copySync(from, to);
+      this.appLogger.success('The file was successfully copied');
+    } catch (error) {
+      this.appLogger.error('Error: The file couldn\'t be copied');
+      this.appLogger.error(error);
+      this._onNodemonCrash();
+    }
   }
   /**
    * This is called when `nodemon` starts the process and after each time it restarts it. The
@@ -194,7 +258,7 @@ class BuildNodeRunnerProcess {
       this.appLogger.success(`Starting ${this.options.executable}`);
       this.appLogger.info([
         'to restart at any time, enter \'rs\'',
-        ...this.options.watchOn.map((directory) => `watching: ${directory}`),
+        ...this.options.watch.map((directory) => `watching: ${directory}`),
       ]);
       // Turn on the flag that informs the service this method was executed at least once.
       this._started = true;
@@ -209,10 +273,11 @@ class BuildNodeRunnerProcess {
    */
   _onNodemonRestart(files) {
     /**
-     * If the code requires transpilation and this was triggered by file changes, the restart
-     * message was already printed by the `watchpack` listener, so no need to print anything else.
+     * If the code requires transpilation (which means that the service is watching directories)
+     * and this was triggered by file changes, the restart message was already printed by the
+     * `_onChange` method, so no need to print anything else.
      */
-    if (!this.options.requiresTranspilation) {
+    if (!this.watching) {
       if (files && files.length) {
         const [file] = files;
         this.appLogger.warning(`Restarting because file was modified: ${file}`);
@@ -245,58 +310,19 @@ class BuildNodeRunnerProcess {
   }
   /**
    * This is called when the `nodemon` process is stopeed. It first checks if it needs to turn off
-   * the `watchpack` listener and then exists the current process.
+   * the watcher and then exits the current process.
    * @ignore
    * @access protected
    */
   _onNodemonQuit() {
-    // If the code needs transpilation...
-    if (this.options.requiresTranspilation) {
-      // ...then `watchpack` is listening and should be stopped.
-      this.watcher.close();
+    // If the service is watching directories...
+    if (this.watching) {
+      // ...then it should be stopped.
+      this.stop();
     }
 
     // eslint-disable-next-line no-process-exit
     process.exit();
-  }
-  /**
-   * This is the `watchpack` listener and it gets called every time a source file changes. When this
-   * happens, the service transpiles the file, thus triggering `nodemon` restart.
-   * @param {string} file The path to the modified file.
-   * @ignore
-   * @access protected
-   */
-  _onFileChange(file) {
-    this.appLogger.warning(`Restarting because file was modified: ${file}`);
-    this._transpileFile(file);
-  }
-  /**
-   * Transpile a file from the source directory into the execution directory (the one `nodemon` is
-   * watching).
-   * @param {string} file The path to the file.
-   * @ignore
-   * @access protected
-   */
-  _transpileFile(file) {
-    const { sourcePath, executionPath } = this.options;
-    const relative = file.substr(sourcePath.length);
-
-    try {
-      this.buildTranspiler.transpileFileSync({
-        source: path.join(sourcePath, relative),
-        output: path.join(executionPath, relative),
-      });
-
-      this.appLogger.success('The file was successfully copied and transpiled');
-    } catch (error) {
-      /**
-       * By no throwing the error, we allow `nodemon` to keep listening so we can try making other
-       * changes to the file in order transpile it correctly.
-       */
-      this.appLogger.error('Error: The file couldn\'t be updated');
-      this.appLogger.error(error);
-      this._onNodemonCrash();
-    }
   }
 }
 /**

--- a/src/services/building/buildNodeWatcher.js
+++ b/src/services/building/buildNodeWatcher.js
@@ -1,0 +1,104 @@
+const { provider } = require('jimple');
+/**
+ * This service provides a simple interface for watching targets using `watchpack`.
+ * The actual service that does the _'watching'_ is `buildNodeWatcherProcess`, but this
+ * one takes care of reading and processing a target settings before telling the other service
+ * to start watching.
+ */
+class BuildNodeWatcher {
+  /**
+   * @param {BuildNodeWatcherProcess#run} buildNodeWatcherProcess To actually watch a target files.
+   * @param {Targets}                     targets                 To get the information of the
+   *                                                              included targets.
+   */
+  constructor(buildNodeWatcherProcess, targets) {
+    /**
+     * A local reference for the `buildNodeWatcherProcess` service.
+     * @type {BuildNodeWatcherProcess#run}
+     */
+    this.buildNodeWatcherProcess = buildNodeWatcherProcess;
+    /**
+     * A local reference for the `targets` service.
+     * @type {Targets}
+     */
+    this.targets = targets;
+  }
+  /**
+   * Watch a target.
+   * @param  {Target} target The target information.
+   * @return {Watchpack}
+   * @throws {Error} If the target needs to be bundled.
+   * @throws {Error} If one of the included targets requires bundling.
+   */
+  watchTarget(target) {
+    if (target.bundle) {
+      throw new Error(`${target.name} needs to be bundled`);
+    }
+
+    const {
+      includeTargets,
+      transpile,
+      paths: { source, build },
+    } = target;
+    const watch = [source];
+    const transpilationPaths = [];
+    const copyPaths = [];
+    const targetPathSettings = {
+      from: source,
+      to: build,
+    };
+
+    if (transpile) {
+      transpilationPaths.push(targetPathSettings);
+    } else {
+      copyPaths.push(targetPathSettings);
+    }
+
+    includeTargets.forEach((name) => {
+      const subTarget = this.targets.getTarget(name);
+      if (subTarget.bundle) {
+        const errorMessage = `The target ${name} requires bundling so it can't be ` +
+          `included by ${target.name}`;
+        throw new Error(errorMessage);
+      } else {
+        const pathSettings = {
+          from: subTarget.paths.source,
+          to: subTarget.paths.build,
+        };
+        watch.push(pathSettings.from);
+        if (subTarget.transpile) {
+          transpilationPaths.push(pathSettings);
+        } else {
+          copyPaths.push(pathSettings);
+        }
+      }
+    });
+
+    return this.buildNodeWatcherProcess(
+      watch,
+      transpilationPaths,
+      copyPaths
+    );
+  }
+}
+/**
+ * The service provider that once registered on the app container will set an instance of
+ * `BuildNodeWatcher` as the `buildNodeWatcher` service.
+ * @example
+ * // Register it on the container
+ * container.register(buildNodeWatcher);
+ * // Getting access to the service instance
+ * const buildNodeWatcher = container.get('buildNodeWatcher');
+ * @type {Provider}
+ */
+const buildNodeWatcher = provider((app) => {
+  app.set('buildNodeWatcher', () => new BuildNodeWatcher(
+    app.get('buildNodeWatcherProcess'),
+    app.get('targets')
+  ));
+});
+
+module.exports = {
+  BuildNodeWatcher,
+  buildNodeWatcher,
+};

--- a/src/services/building/buildNodeWatcherProcess.js
+++ b/src/services/building/buildNodeWatcherProcess.js
@@ -1,0 +1,124 @@
+const path = require('path');
+const fs = require('fs-extra');
+const { provider } = require('jimple');
+const NodeWatcher = require('../../abstracts/nodeWatcher');
+/**
+ * This service watches directories in order to copy and/or transpile files into their
+ * build/distribution directories when they change.
+ * @extends {NodeWatcher}
+ */
+class BuildNodeWatcherProcess extends NodeWatcher {
+  /**
+   * @param {Logger}                       appLogger            The inform on the CLI of the events
+   *                                                            of the watcher.
+   * @param {BuildTranspiler}              buildTranspiler      To transpile files if needed.
+   * @param {ProjectConfigurationSettings} projectConfiguration To read the watch settings.
+   */
+  constructor(appLogger, buildTranspiler, projectConfiguration) {
+    super({
+      poll: projectConfiguration.others.watch.poll,
+    });
+    /**
+     * A local reference for the `appLogger` service.
+     * @type {Logger}
+     */
+    this.appLogger = appLogger;
+    /**
+     * A local reference for the `buildTranspiler` service.
+     * @type {BuildTranspiler}
+     */
+    this.buildTranspiler = buildTranspiler;
+  }
+  /**
+   * This is called when the service is about to start watching the directories.
+   * The overwrite is just for logging some information messages.
+   * @access protected
+   * @ignore
+   */
+  _onStart() {
+    this.appLogger.success('Starting watch mode');
+    this.appLogger.info(this.getPaths().map((directory) => `watching: ${directory}`));
+  }
+
+  /**
+   * This is called when a source file changes and it's detected by the service.
+   * The overwrite is just to show an information message.
+   * @param {string} file The path to the file that changed.
+   * @access protected
+   * @ignore
+   */
+  _onChange(file) {
+    this.appLogger.warning(`Change detected on ${file}`);
+    super._onChange(file);
+  }
+  /**
+   * This is called when a source file changes and the service can't find a matching path on neither
+   * the transpilation paths nor the copy paths.
+   * The method will just show an error message explaning the problem.
+   * @access protected
+   * @ignore
+   */
+  _onInvalidPathForChange() {
+    this.appLogger.error('Error: The file directory is not on the list of allowed paths');
+  }
+  /**
+   * Transpiles a file from a source directory into a build directory.
+   * @param {string} source The path to the source file.
+   * @param {string} output The path for the source file once transpiled.
+   * @access protected
+   * @ignore
+   */
+  _transpileFile(source, output) {
+    try {
+      // Make sure the path to the directory exists.
+      fs.ensureDirSync(path.dirname(output));
+      // Transpile the file.
+      this.buildTranspiler.transpileFileSync({ source, output });
+      this.appLogger.success('The file was successfully copied and transpiled');
+    } catch (error) {
+      this.appLogger.error('Error: The file couldn\'t be updated');
+      this.appLogger.error(error);
+    }
+  }
+  /**
+   * Copies a file from a source directory into a build directory.
+   * @param {string} from The original path of the file.
+   * @param {string} to   The new path for the file.
+   * @access protected
+   * @ignore
+   */
+  _copyFile(from, to) {
+    try {
+      // Make sure the path to the directory exists.
+      fs.ensureDirSync(path.dirname(to));
+      // Copy the file.
+      fs.copySync(from, to);
+      this.appLogger.success('The file was successfully copied');
+    } catch (error) {
+      this.appLogger.error('Error: The file couldn\'t be copied');
+      this.appLogger.error(error);
+    }
+  }
+}
+/**
+ * The service provider that once registered on the app container will set an instance of
+ * `BuildNodeWatcherProcess` as the `buildNodeWatcherProcess` service.
+ * @example
+ * // Register it on the container
+ * container.register(buildNodeWatcherProcess);
+ * // Getting access to the service instance
+ * const buildNodeWatcherProcess = container.get('buildNodeWatcherProcess');
+ * @type {Provider}
+ */
+const buildNodeWatcherProcess = provider((app) => {
+  app.set('buildNodeWatcherProcess', () => new BuildNodeWatcherProcess(
+    app.get('appLogger'),
+    app.get('buildTranspiler'),
+    app.get('projectConfiguration').getConfig()
+  ).watch);
+});
+
+module.exports = {
+  BuildNodeWatcherProcess,
+  buildNodeWatcherProcess,
+};

--- a/src/services/building/builder.js
+++ b/src/services/building/builder.js
@@ -52,16 +52,20 @@ class Builder {
    * Get a build command for a target. If the target doesn't require bundling, it will return an
    * empty string, otherwise, it will ask the build engine the target uses for the required shell
    * command.
-   * @param {Target}  target           The target information.
-   * @param {string}  buildType        The type of build intended: `production` or `development`.
-   * @param {boolean} [forceRun=false] Whether or not the build command should also run the target.
+   * @param {Target}  target            The target information.
+   * @param {string}  buildType         The type of build intended: `production` or `development`.
+   * @param {boolean} [forceRun=false]  Whether or not the build command should also run the
+   *                                    target. It's _"forced"_ because it overwrites the
+   *                                    `runOnDevelopment` setting.
+   * @param {boolean} [forceWatch=false] Whether or not the target files should be watched and the
+   *                                     build recreated when they changed.
    * @return {string}
    */
-  getTargetBuildCommand(target, buildType, forceRun = false) {
+  getTargetBuildCommand(target, buildType, forceRun = false, forceWatch = false) {
     let command = '';
     if (target.bundle !== false) {
       const engine = this.buildEngines.getEngine(target.engine);
-      command = engine.getBuildCommand(target, buildType, forceRun);
+      command = engine.getBuildCommand(target, buildType, forceRun, forceWatch);
     }
 
     return command;

--- a/src/services/building/index.js
+++ b/src/services/building/index.js
@@ -3,6 +3,8 @@ const { buildCopier } = require('./buildCopier');
 const { buildEngines } = require('./buildEngines');
 const { buildNodeRunner } = require('./buildNodeRunner');
 const { buildNodeRunnerProcess } = require('./buildNodeRunnerProcess');
+const { buildNodeWatcher } = require('./buildNodeWatcher');
+const { buildNodeWatcherProcess } = require('./buildNodeWatcherProcess');
 const { buildTranspiler } = require('./buildTranspiler');
 const { buildVersion } = require('./buildVersion');
 const { builder } = require('./builder');
@@ -13,6 +15,8 @@ module.exports = {
   buildEngines,
   buildNodeRunner,
   buildNodeRunnerProcess,
+  buildNodeWatcher,
+  buildNodeWatcherProcess,
   buildTranspiler,
   buildVersion,
   builder,

--- a/src/services/cli/cliBuild.js
+++ b/src/services/cli/cliBuild.js
@@ -34,6 +34,13 @@ class CLIBuildCommand extends CLICommand {
         'build type is development',
       false
     );
+    this.addOption(
+      'watch',
+      '-w, --watch',
+      'Rebuild the target every time one of its files changes. It only works ' +
+        'when the build type is development',
+      false
+    );
     /**
      * Enable unknown options so other services can customize the build command.
      * @type {Boolean}

--- a/src/services/cli/cliSHNodeRun.js
+++ b/src/services/cli/cliSHNodeRun.js
@@ -47,7 +47,7 @@ class CLISHNodeRunCommand extends CLICommand {
   /**
    * Handle the execution of the command and runs a Node target.
    * @param {string} name The name of the target.
-   * @return {`nodemon`}
+   * @return {Nodemon}
    */
   handle(name) {
     const target = this.targets.getTarget(name);

--- a/src/services/cli/cliSHNodeWatch.js
+++ b/src/services/cli/cliSHNodeWatch.js
@@ -1,0 +1,78 @@
+const { provider } = require('jimple');
+const CLICommand = require('../../abstracts/cliCommand');
+/**
+ * This is a private command the shell script executes in order to watch a Node target with
+ * `watchpack`.
+ * @extends {CLICommand}
+ */
+class CLISHNodeWatchCommand extends CLICommand {
+  /**
+   * Class constructor.
+   * @param {BuildNodeWatcher} buildNodeWatcher To actually run a target.
+   * @param {Targets}          targets         To get a target information.
+   */
+  constructor(buildNodeWatcher, targets) {
+    super();
+    /**
+     * A local reference for the `buildNodeWatcher` service.
+     * @type {BuildNodeRunner}
+     */
+    this.buildNodeWatcher = buildNodeWatcher;
+    /**
+     * A local reference for the `targets` service.
+     * @type {Targets}
+     */
+    this.targets = targets;
+    /**
+     * The instruction needed to trigger the command.
+     * @type {string}
+     */
+    this.command = 'sh-node-watch [target]';
+    /**
+     * A description of the command, just to follow the interface as the command won't show up on
+     * the help interface.
+     * @type {string}
+     */
+    this.description = 'Watch a Node target that wasn\'t bundled';
+    /**
+     * Hide the command from the help interface.
+     * @type {boolean}
+     */
+    this.hidden = true;
+    /**
+     * Enable unknown options so other services can customize the run command.
+     * @type {Boolean}
+     */
+    this.allowUnknownOptions = true;
+  }
+  /**
+   * Handle the execution of the command and runs a Node target.
+   * @param {string} name The name of the target.
+   * @return {Watchpack}
+   */
+  handle(name) {
+    const target = this.targets.getTarget(name);
+    return this.buildNodeWatcher.watchTarget(target);
+  }
+}
+/**
+ * The service provider that once registered on the app container will set an instance of
+ * `CLISHNodeWatchCommand` as the `cliSHNodeWatchCommand` service.
+ * @example
+ * // Register it on the container
+ * container.register(cliSHNodeWatchCommand);
+ * // Getting access to the service instance
+ * const cliSHNodeWatchCommand = container.get('cliSHNodeWatchCommand');
+ * @type {Provider}
+ */
+const cliSHNodeWatchCommand = provider((app) => {
+  app.set('cliSHNodeWatchCommand', () => new CLISHNodeWatchCommand(
+    app.get('buildNodeWatcher'),
+    app.get('targets')
+  ));
+});
+
+module.exports = {
+  CLISHNodeWatchCommand,
+  cliSHNodeWatchCommand,
+};

--- a/src/services/cli/cliSHValidateBuild.js
+++ b/src/services/cli/cliSHValidateBuild.js
@@ -48,6 +48,16 @@ class CLISHValidateBuildCommand extends CLICommand {
      * @type {string}
      */
     this.description = 'Validate the arguments before the shell executes the task';
+    /**
+     * Hide the command from the help interface.
+     * @type {boolean}
+     */
+    this.hidden = true;
+    /**
+     * Enable unknown options so other services can customize the build command.
+     * @type {Boolean}
+     */
+    this.allowUnknownOptions = true;
     this.addOption(
       'type',
       '-t, --type [type]',
@@ -61,16 +71,6 @@ class CLISHValidateBuildCommand extends CLICommand {
         'build type is development',
       false
     );
-    /**
-     * Hide the command from the help interface.
-     * @type {boolean}
-     */
-    this.hidden = true;
-    /**
-     * Enable unknown options so other services can customize the build command.
-     * @type {Boolean}
-     */
-    this.allowUnknownOptions = true;
   }
   /**
    * Handle the execution of the command and validate all the arguments.

--- a/src/services/cli/cliSHValidateWatch.js
+++ b/src/services/cli/cliSHValidateWatch.js
@@ -1,15 +1,14 @@
 const { provider } = require('jimple');
 const CLICommand = require('../../abstracts/cliCommand');
 /**
- * This is a private command the shell script executes before running the run command in order to
+ * This is a private command the shell script executes before running the watch command in order to
  * validate the arguments and throw any necessary error. The reason we do this in two separated
  * commands is that the shell script takes all the output of the run command and tries to execute
  * it, so we can't include execptions in there.
  * @extends {CLICommand}
  */
-class CLISHValidateRunCommand extends CLICommand {
+class CLISHValidateWatchCommand extends CLICommand {
   /**
-   * Class constructor.
    * @param {Targets} targets To validate a target existence.
    */
   constructor(targets) {
@@ -23,7 +22,7 @@ class CLISHValidateRunCommand extends CLICommand {
      * The instruction needed to trigger the command.
      * @type {string}
      */
-    this.command = 'sh-validate-run [target]';
+    this.command = 'sh-validate-watch [target]';
     /**
      * A description of the command, just to follow the interface as the command won't show up on
      * the help interface.
@@ -36,10 +35,16 @@ class CLISHValidateRunCommand extends CLICommand {
      */
     this.hidden = true;
     /**
-     * Enable unknown options so other services can customize the run command.
+     * Enable unknown options so other services can customize the watch command.
      * @type {Boolean}
      */
     this.allowUnknownOptions = true;
+    this.addOption(
+      'type',
+      '-t, --type [type]',
+      'Which build type: development (default) or production',
+      'development'
+    );
   }
   /**
    * Handle the execution of the command and validate the target existence.
@@ -55,21 +60,21 @@ class CLISHValidateRunCommand extends CLICommand {
 }
 /**
  * The service provider that once registered on the app container will set an instance of
- * `CLISHValidateRunCommand` as the `cliSHValidateRunCommand` service.
+ * `CLISHValidateWatchCommand` as the `cliSHValidateWatchCommand` service.
  * @example
  * // Register it on the container
- * container.register(cliSHValidateRunCommand);
+ * container.register(cliSHValidateWatchCommand);
  * // Getting access to the service instance
- * const cliSHValidateRunCommand = container.get('cliSHValidateRunCommand');
+ * const cliSHValidateWatchCommand = container.get('cliSHValidateWatchCommand');
  * @type {Provider}
  */
-const cliSHValidateRunCommand = provider((app) => {
-  app.set('cliSHValidateRunCommand', () => new CLISHValidateRunCommand(
+const cliSHValidateWatchCommand = provider((app) => {
+  app.set('cliSHValidateWatchCommand', () => new CLISHValidateWatchCommand(
     app.get('targets')
   ));
 });
 
 module.exports = {
-  CLISHValidateRunCommand,
-  cliSHValidateRunCommand,
+  CLISHValidateWatchCommand,
+  cliSHValidateWatchCommand,
 };

--- a/src/services/cli/cliSHWatch.js
+++ b/src/services/cli/cliSHWatch.js
@@ -1,0 +1,102 @@
+const { provider } = require('jimple');
+const CLICommand = require('../../abstracts/cliCommand');
+/**
+ * This is the _'real watch command'_. This is a private command the shell script executes in order
+ * to get a list of commands it should execute.
+ * @extends {CLICommand}
+ */
+class CLISHWatchCommand extends CLICommand {
+  /**
+   * Class constructor.
+   * @param {CLIBuildCommand} cliBuildCommand The run command is actually an alias for the build
+   *                                          command with the `--watch` option flag set to true.
+   * @param {Targets}         targets         To get the name of the default target if no other is
+   *                                          specified.
+   */
+  constructor(cliBuildCommand, targets) {
+    super();
+    /**
+     * A local reference for the `cliBuildCommand` service.
+     * @type {CLIBuildCommand}
+     */
+    this.cliBuildCommand = cliBuildCommand;
+    /**
+     * A local reference for the `targets` service.
+     * @type {Targets}
+     */
+    this.targets = targets;
+    /**
+     * The instruction needed to trigger the command.
+     * @type {string}
+     */
+    this.command = 'sh-watch [target]';
+    /**
+     * A description of the command, just to follow the interface as the command won't show up on
+     * the help interface.
+     * @type {string}
+     */
+    this.description = 'Get the build commands for the shell program to execute';
+    /**
+     * Hide the command from the help interface.
+     * @type {boolean}
+     */
+    this.hidden = true;
+    /**
+     * Enable unknown options so other services can customize the watch command.
+     * @type {Boolean}
+     */
+    this.allowUnknownOptions = true;
+    this.addOption(
+      'type',
+      '-t, --type [type]',
+      'Which build type: development (default) or production',
+      'development'
+    );
+  }
+  /**
+   * Handle the execution of the command and outputs the list of commands to run.
+   * @param {?string} name           The name of the target.
+   * @param {Command} command        The executed command (sent by `commander`).
+   * @param {Object}  options        The command options.
+   * @param {Object}  unknownOptions A dictionary of extra options that command may have received.
+   */
+  handle(name, command, options, unknownOptions) {
+    const { type } = options;
+    const target = name ?
+      // If the target doesn't exist, this will throw an error.
+      this.targets.getTarget(name) :
+      // Get the default target or throw an error if the project doesn't have targets.
+      this.targets.getDefaultTarget();
+
+    this.output(this.cliBuildCommand.generate(Object.assign(
+      {},
+      unknownOptions,
+      {
+        target: target.name,
+        type,
+        watch: true,
+      }
+    )));
+  }
+}
+/**
+ * The service provider that once registered on the app container will set an instance of
+ * `CLISHWatchCommand` as the `cliSHWatchCommand` service.
+ * @example
+ * // Register it on the container
+ * container.register(cliSHWatchCommand);
+ * // Getting access to the service instance
+ * const cliSHWatchCommand = container.get('cliSHWatchCommand');
+ * @type {Provider}
+ */
+const cliSHWatchCommand = provider((app) => {
+  app.set('cliSHWatchCommand', () => new CLISHWatchCommand(
+    app.get('cliBuildCommand'),
+    app.get('targets')
+  ));
+});
+
+module.exports = {
+  CLISHWatchCommand,
+  cliSHWatchCommand,
+};

--- a/src/services/cli/cliWatch.js
+++ b/src/services/cli/cliWatch.js
@@ -1,0 +1,55 @@
+const { provider } = require('jimple');
+const CLICommand = require('../../abstracts/cliCommand');
+/**
+ * This is a fake command the app uses to show the information of the watch task. In reality, this
+ * command is handled by a shell script.
+ * @extends {CLICommand}
+ */
+class CLIWatchCommand extends CLICommand {
+  /**
+   * Class constructor.
+   * @ignore
+   */
+  constructor() {
+    super();
+    /**
+     * The instruction needed to trigger the command.
+     * @type {string}
+     */
+    this.command = 'watch [target]';
+    /**
+     * A description of the command for the help interface.
+     * @type {string}
+     */
+    this.description = 'Run a target on a development build type';
+    /**
+     * Enable unknown options so other services can customize the watch command.
+     * @type {Boolean}
+     */
+    this.allowUnknownOptions = true;
+    this.addOption(
+      'type',
+      '-t, --type [type]',
+      'Which build type: development (default) or production',
+      'development'
+    );
+  }
+}
+/**
+ * The service provider that once registered on the app container will set an instance of
+ * `CLIWatchCommand` as the `cliWatchCommand` service.
+ * @example
+ * // Register it on the container
+ * container.register(cliWatchCommand);
+ * // Getting access to the service instance
+ * const cliWatchCommand = container.get('cliWatchCommand');
+ * @type {Provider}
+ */
+const cliWatchCommand = provider((app) => {
+  app.set('cliWatchCommand', () => new CLIWatchCommand());
+});
+
+module.exports = {
+  CLIWatchCommand,
+  cliWatchCommand,
+};

--- a/src/services/cli/index.js
+++ b/src/services/cli/index.js
@@ -13,6 +13,9 @@ const { cliSHRunCommand } = require('./cliSHRun');
 const { cliSHTranspileCommand } = require('./cliSHTranspile');
 const { cliSHValidateBuildCommand } = require('./cliSHValidateBuild');
 const { cliSHValidateRunCommand } = require('./cliSHValidateRun');
+const { cliSHValidateWatchCommand } = require('./cliSHValidateWatch');
+const { cliSHWatchCommand } = require('./cliSHWatch');
+const { cliWatchCommand } = require('./cliWatch');
 const cliGenerators = require('./generators');
 
 module.exports = {
@@ -33,4 +36,7 @@ module.exports = {
   cliSHValidateBuildCommand,
   cliSHValidateRunCommand,
   cliGenerators,
+  cliSHValidateWatchCommand,
+  cliSHWatchCommand,
+  cliWatchCommand,
 };

--- a/src/services/cli/index.js
+++ b/src/services/cli/index.js
@@ -9,6 +9,7 @@ const { cliRunCommand } = require('./cliRun');
 const { cliSHBuildCommand } = require('./cliSHBuild');
 const { cliSHCopyCommand } = require('./cliSHCopy');
 const { cliSHNodeRunCommand } = require('./cliSHNodeRun');
+const { cliSHNodeWatchCommand } = require('./cliSHNodeWatch');
 const { cliSHRunCommand } = require('./cliSHRun');
 const { cliSHTranspileCommand } = require('./cliSHTranspile');
 const { cliSHValidateBuildCommand } = require('./cliSHValidateBuild');
@@ -31,6 +32,7 @@ module.exports = {
   cliSHBuildCommand,
   cliSHCopyCommand,
   cliSHNodeRunCommand,
+  cliSHNodeWatchCommand,
   cliSHRunCommand,
   cliSHTranspileCommand,
   cliSHValidateBuildCommand,

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -93,6 +93,10 @@ class ProjectConfiguration extends ConfigurationFile {
           excludeModules: [],
           includeTargets: [],
           runOnDevelopment: false,
+          watch: {
+            development: false,
+            production: false,
+          },
           babel: {
             features: [],
             nodeVersion: 'current',
@@ -148,6 +152,10 @@ class ProjectConfiguration extends ConfigurationFile {
           includeModules: [],
           includeTargets: [],
           runOnDevelopment: false,
+          watch: {
+            development: false,
+            production: false,
+          },
           babel: {
             features: [],
             browserVersions: 2,

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -25,6 +25,11 @@
  */
 
 /**
+ * @external {WatchpackOptions}
+ * https://github.com/webpack/watchpack#api
+ */
+
+/**
  * @external {AppConfiguration}
  * https://homer0.github.io/wootils/class/wootils/node/appConfiguration.js~AppConfiguration.html
  */

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -764,18 +764,6 @@
  */
 
 /**
- * @typedef {function} BuildEngineGetCommand
- * @param {Target} target
- * The target information.
- * @param {string} buildType
- * The intended build type: `development` or `production`.
- * @param {boolean} [forceRun=false]
- * Force the target to run even if the `runOnDevelopment` setting is `false`.
- * @return {string}
- * The command the shell script will use to build the target.
- */
-
-/**
  * @typedef {Object} TargetFileRulePathSettings
  * @property {Array} include The list of expressions that match the allowed paths for a rule.
  * @property {Array} exclude The list of expressions that match the paths that should be excluded
@@ -860,9 +848,41 @@
  */
 
 /**
+ * @typedef {function} BuildEngineGetCommand
+ * @param {Target} target
+ * The target information.
+ * @param {string} buildType
+ * The intended build type: `development` or `production`.
+ * @param {boolean} [forceRun=false]
+ * Force the target to run even if the `runOnDevelopment` setting is `false`.
+ * @param {boolean} [forceWatch=false]
+ * Force the build engine to watch the target files even if the `watch` setting for the required
+ * build type is set to `false`.
+ * @return {string}
+ * The command the shell script will use to build the target.
+ */
+
+/**
  * @typedef {Object} BuildEngine
  * @property {BuildEngineGetCommand} getBuildCommand
  * The method used by projext in order to get the shell comands to build and/or run a target.
+ */
+
+/**
+ * ================================================================================================
+ * Building
+ * ================================================================================================
+ */
+
+/**
+ * @typedef {Object} CLIBuildCommandParams
+ * @property {Target}  target The target information.
+ * @property {string}  type   The intended build type: `development` or `production`.
+ * @property {boolean} run    Whether or not the target needs to be executed.
+ * @property {boolean} build  Whether or not a build will be created. This is always `true` for
+ *                            browser targets but it may be false for Node targets if bundling and
+ *                            transpiling is disabled.
+ * @property {boolean} watch  Whether or not the target files will be watched.
  */
 
 /**

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -190,6 +190,16 @@
  */
 
 /**
+ * @typedef {Object} ProjectConfigurationTargetWatchOptions
+ * @property {boolean} [development=false] Whether or not to watch the target files when it gets
+ *                                         build for development. If the target type is Node and it
+ *                                         doesn't require bundling nor transpiling, it won't do
+ *                                         anything.
+ * @property {boolean} [production=false]  Whether or not to watch the target files when it gets
+ *                                         build for production.
+ */
+
+/**
  * ================================================================================================
  * Project configuration > Targets templates > Sub properties > Node
  * ================================================================================================
@@ -401,6 +411,9 @@
  * @property {boolean} [runOnDevelopment=false]
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
+ * @property {ProjectConfigurationTargetWatchOptions} [watch]
+ * The settings for the projext watch mode, which watches the target files for changes and updates
+ * the build without executing it.
  * @property {ProjectConfigurationNodeTargetTemplateBabelSettings} [babel]
  * The target transpilation options.
  * @property {boolean} [flow=false]
@@ -466,6 +479,9 @@
  * @property {boolean} runOnDevelopment
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
+ * @property {ProjectConfigurationTargetWatchOptions} watch
+ * The settings for the projext watch mode, which watches the target files for changes and updates
+ * the build without executing it.
  * @property {ProjectConfigurationNodeTargetTemplateBabelSettings} babel
  * The target transpilation options.
  * @property {boolean} flow
@@ -534,6 +550,9 @@
  * @property {boolean} [runOnDevelopment=false]
  * This will tell the build engine that when you build the target for a development environment,
  * it should bring up an `http` server to _"run"_ your target.
+ * @property {ProjectConfigurationTargetWatchOptions} [watch]
+ * The settings for the projext watch mode, which watches the target files for changes and updates
+ * the build without executing it.
  * @property {ProjectConfigurationBrowserTargetTemplateBabelSettings} [babel]
  * These options are used by the build engine to configure [Babel](https://babeljs.io):
  * @property {boolean} [flow=false]
@@ -595,6 +614,9 @@
  * @property {boolean} runOnDevelopment
  * This will tell the build engine that when you build the target for a development environment,
  * it should bring up an `http` server to _"run"_ your target.
+ * @property {ProjectConfigurationTargetWatchOptions} watch
+ * The settings for the projext watch mode, which watches the target files for changes and updates
+ * the build without executing it.
  * @property {ProjectConfigurationBrowserTargetTemplateBabelSettings} babel
  * These options are used by the build engine to configure [Babel](https://babeljs.io):
  * @property {boolean} flow

--- a/tests/abstracts/nodeWatcher.test.js
+++ b/tests/abstracts/nodeWatcher.test.js
@@ -1,0 +1,356 @@
+jest.mock('watchpack');
+jest.unmock('/src/abstracts/nodeWatcher');
+
+require('jasmine-expect');
+const Watchpack = require('watchpack');
+const NodeWatcher = require('/src/abstracts/nodeWatcher');
+
+describe('abstracts:NodeWatcher', () => {
+  beforeEach(() => {
+    Watchpack.mockReset();
+  });
+
+  it('should throw an error if used without subclassing it', () => {
+    // Given/When/Then
+    expect(() => new NodeWatcher())
+    .toThrow(/NodeWatcher is an abstract class/i);
+  });
+
+  it('should throw an error if `watch` is called when the service is already watching', () => {
+    // Given
+    class Sut extends NodeWatcher {
+      constructor() {
+        super();
+        this.watching = true;
+      }
+    }
+    let sut = null;
+    // When/Then
+    sut = new Sut();
+    expect(() => sut.watch()).toThrow(/The service is already watching/i);
+  });
+
+  it('should throw an error if `watch` is called without a list of paths', () => {
+    // Given
+    class Sut extends NodeWatcher {}
+    let sut = null;
+    // When/Then
+    sut = new Sut();
+    expect(() => sut.watch([]))
+    .toThrow(/You need to specify at least one path to watch/i);
+  });
+
+  it('should throw an error if `watch` is called without transpilation and copy paths', () => {
+    // Given
+    class Sut extends NodeWatcher {}
+    let sut = null;
+    // When/Then
+    sut = new Sut();
+    expect(() => sut.watch(['random']))
+    .toThrow(/You need to provide at least one transpilation or copy path/i);
+  });
+
+  it('should start watching a list of paths', () => {
+    // Given
+    const watchpackWatch = jest.fn();
+    const watchpackOn = jest.fn();
+    Watchpack.mockImplementationOnce(() => ({
+      watch: watchpackWatch,
+      on: watchpackOn,
+    }));
+    const onStart = jest.fn();
+    class Sut extends NodeWatcher {
+      _onStart() {
+        onStart();
+      }
+    }
+    const watchpackSettings = {
+      hello: 'Charito!',
+    };
+    const watchPaths = ['some/random/path'];
+    let sut = null;
+    // When
+    sut = new Sut(watchpackSettings);
+    sut.watch(watchPaths, ['random']);
+    // Then
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(Watchpack).toHaveBeenCalledTimes(1);
+    expect(Watchpack).toHaveBeenCalledWith(watchpackSettings);
+    expect(watchpackWatch).toHaveBeenCalledTimes(1);
+    expect(watchpackWatch).toHaveBeenCalledWith([], watchPaths);
+    expect(watchpackOn).toHaveBeenCalledTimes(1);
+    expect(watchpackOn).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('should start and stop watching a list of paths', () => {
+    // Given
+    const watchpackWatch = jest.fn();
+    const watchpackOn = jest.fn();
+    const watchpackClose = jest.fn();
+    Watchpack.mockImplementationOnce(() => ({
+      watch: watchpackWatch,
+      on: watchpackOn,
+      close: watchpackClose,
+    }));
+    const onStart = jest.fn();
+    class Sut extends NodeWatcher {
+      _onStart() {
+        onStart();
+      }
+    }
+    const watchpackSettings = {
+      hello: 'Charito!',
+    };
+    const watchPaths = ['some/random/path'];
+    let sut = null;
+    // When
+    sut = new Sut(watchpackSettings);
+    sut.watch(watchPaths, ['random']);
+    sut.stop();
+    // Then
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(Watchpack).toHaveBeenCalledTimes(1);
+    expect(Watchpack).toHaveBeenCalledWith(watchpackSettings);
+    expect(watchpackWatch).toHaveBeenCalledTimes(1);
+    expect(watchpackWatch).toHaveBeenCalledWith([], watchPaths);
+    expect(watchpackOn).toHaveBeenCalledTimes(1);
+    expect(watchpackOn).toHaveBeenCalledWith('change', expect.any(Function));
+    expect(watchpackClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shouldnt do anything when `stop` is called by the service is not watching', () => {
+    // Given
+    const watchpackClose = jest.fn();
+    Watchpack.mockImplementationOnce(() => ({
+      close: watchpackClose,
+    }));
+    class Sut extends NodeWatcher {}
+    let sut = null;
+    // When
+    sut = new Sut();
+    sut.stop();
+    // Then
+    expect(Watchpack).toHaveBeenCalledTimes(0);
+    expect(watchpackClose).toHaveBeenCalledTimes(0);
+  });
+
+  it('should return the list of watched directories', () => {
+    // Given
+    Watchpack.mockImplementationOnce(() => ({
+      watch: jest.fn(),
+      on: jest.fn(),
+    }));
+    class Sut extends NodeWatcher {}
+    const watchPaths = ['some/random/path'];
+    let sut = null;
+    let result = null;
+    // When
+    sut = new Sut();
+    sut.watch(watchPaths, ['random']);
+    result = sut.getPaths();
+    // Then
+    expect(result).toEqual(watchPaths);
+  });
+
+  it('should call `_onInvalidPathForChange` when a file path is not recognized', () => {
+    // Given
+    let onChange;
+    const watchpackWatch = jest.fn();
+    const watchpackOn = jest.fn((eventName, fn) => {
+      onChange = fn;
+    });
+    Watchpack.mockImplementationOnce(() => ({
+      watch: watchpackWatch,
+      on: watchpackOn,
+    }));
+    const onInvalidPathForChange = jest.fn();
+    class Sut extends NodeWatcher {
+      _onInvalidPathForChange(...args) {
+        onInvalidPathForChange(...args);
+      }
+    }
+    const watchPaths = ['some/random/path'];
+    const transpilationAndCopyPaths = [{
+      from: 'some/random/path',
+      to: 'some/random/path',
+    }];
+    const changedFile = 'some/file.js';
+    let sut = null;
+    // When
+    sut = new Sut();
+    sut.watch(watchPaths, transpilationAndCopyPaths, transpilationAndCopyPaths);
+    onChange(changedFile);
+    // Then
+    expect(onInvalidPathForChange).toHaveBeenCalledTimes(1);
+    expect(onInvalidPathForChange).toHaveBeenCalledWith(changedFile);
+  });
+
+  it('shouldn\'t do anything if `_onInvalidPathForChange` is not overwritten', () => {
+    // Given
+    let onChange;
+    const watchpackWatch = jest.fn();
+    const watchpackOn = jest.fn((eventName, fn) => {
+      onChange = fn;
+    });
+    Watchpack.mockImplementationOnce(() => ({
+      watch: watchpackWatch,
+      on: watchpackOn,
+    }));
+    class Sut extends NodeWatcher {}
+    const watchPaths = ['some/random/path'];
+    const transpilationAndCopyPaths = [{
+      from: 'some/random/path',
+      to: 'some/random/path',
+    }];
+    const changedFile = 'some/file.js';
+    let sut = null;
+    // When/Then
+    sut = new Sut();
+    sut.watch(watchPaths, transpilationAndCopyPaths, transpilationAndCopyPaths);
+    onChange(changedFile);
+  });
+
+  it('should call throw an error if `_transpileFile` is not overwritten', () => {
+    // Given
+    let onChange;
+    const watchpackWatch = jest.fn();
+    const watchpackOn = jest.fn((eventName, fn) => {
+      onChange = fn;
+    });
+    Watchpack.mockImplementationOnce(() => ({
+      watch: watchpackWatch,
+      on: watchpackOn,
+    }));
+    class Sut extends NodeWatcher {}
+    const watchPaths = ['some/random/path'];
+    const transpilationPath = {
+      from: 'some/source/path',
+      to: 'some/output/path',
+    };
+    const fileBasePath = '/some/inner/path.js';
+    const changedFile = `${transpilationPath.from}${fileBasePath}`;
+    const copyPaths = [{
+      from: 'some/random/path',
+      to: 'some/random/path',
+    }];
+    let sut = null;
+    // When/Then
+    sut = new Sut();
+    sut.watch(watchPaths, [transpilationPath], copyPaths);
+    expect(() => onChange(changedFile))
+    .toThrow(/_transpileFile must be overwritten/i);
+  });
+
+  it('should provide the old and new path when `_transpileFile` is overwritten', () => {
+    // Given
+    let onChange;
+    const watchpackWatch = jest.fn();
+    const watchpackOn = jest.fn((eventName, fn) => {
+      onChange = fn;
+    });
+    Watchpack.mockImplementationOnce(() => ({
+      watch: watchpackWatch,
+      on: watchpackOn,
+    }));
+    const transpileFile = jest.fn();
+    class Sut extends NodeWatcher {
+      _transpileFile(...args) {
+        transpileFile(...args);
+      }
+    }
+    const watchPaths = ['some/random/path'];
+    const transpilationPath = {
+      from: 'some/source/path',
+      to: 'some/output/path',
+    };
+    const fileBasePath = '/some/inner/path.js';
+    const changedFile = `${transpilationPath.from}${fileBasePath}`;
+    const copyPaths = [{
+      from: 'some/random/path',
+      to: 'some/random/path',
+    }];
+    let sut = null;
+    // When
+    sut = new Sut();
+    sut.watch(watchPaths, [transpilationPath], copyPaths);
+    onChange(changedFile);
+    // Then
+    expect(transpileFile).toHaveBeenCalledTimes(1);
+    expect(transpileFile).toHaveBeenCalledWith(
+      changedFile,
+      `${transpilationPath.to}${fileBasePath}`
+    );
+  });
+
+  it('should call throw an error if `_copyFile` is not overwritten', () => {
+    // Given
+    let onChange;
+    const watchpackWatch = jest.fn();
+    const watchpackOn = jest.fn((eventName, fn) => {
+      onChange = fn;
+    });
+    Watchpack.mockImplementationOnce(() => ({
+      watch: watchpackWatch,
+      on: watchpackOn,
+    }));
+    class Sut extends NodeWatcher {}
+    const watchPaths = ['some/random/path'];
+    const transpilationPaths = [{
+      from: 'some/random/path',
+      to: 'some/random/path',
+    }];
+    const copyPath = {
+      from: 'some/source/path',
+      to: 'some/output/path',
+    };
+    const fileBasePath = '/some/inner/path.js';
+    const changedFile = `${copyPath.from}${fileBasePath}`;
+    let sut = null;
+    // When/Then
+    sut = new Sut();
+    sut.watch(watchPaths, transpilationPaths, [copyPath]);
+    expect(() => onChange(changedFile))
+    .toThrow(/_copyFile must be overwritten/i);
+  });
+
+  it('should provide the old and new path when `_copyFile` is overwritten', () => {
+    // Given
+    let onChange;
+    const watchpackWatch = jest.fn();
+    const watchpackOn = jest.fn((eventName, fn) => {
+      onChange = fn;
+    });
+    Watchpack.mockImplementationOnce(() => ({
+      watch: watchpackWatch,
+      on: watchpackOn,
+    }));
+    const copyFile = jest.fn();
+    class Sut extends NodeWatcher {
+      _copyFile(...args) {
+        copyFile(...args);
+      }
+    }
+    const watchPaths = ['some/random/path'];
+    const transpilationPaths = [{
+      from: 'some/random/path',
+      to: 'some/random/path',
+    }];
+    const copyPath = {
+      from: 'some/source/path',
+      to: 'some/output/path',
+    };
+    const fileBasePath = '/some/inner/path.js';
+    const changedFile = `${copyPath.from}${fileBasePath}`;
+    let sut = null;
+    // When/Then
+    sut = new Sut();
+    sut.watch(watchPaths, transpilationPaths, [copyPath]);
+    onChange(changedFile);
+    // Then
+    expect(copyFile).toHaveBeenCalledTimes(1);
+    expect(copyFile).toHaveBeenCalledWith(
+      changedFile,
+      `${copyPath.to}${fileBasePath}`
+    );
+  });
+});

--- a/tests/mocks/nodeWatcher.mock.js
+++ b/tests/mocks/nodeWatcher.mock.js
@@ -1,0 +1,69 @@
+const mocks = {
+  constructor: jest.fn(),
+  watch: jest.fn(),
+  onChange: jest.fn(),
+  getPaths: jest.fn(),
+  stop: jest.fn(),
+};
+
+class NodeWatcherMock {
+  static get mocks() {
+    return mocks;
+  }
+
+  static reset() {
+    Object.keys(mocks).forEach((name) => {
+      mocks[name].mockReset();
+    });
+  }
+
+  constructor(...args) {
+    mocks.constructor(...args);
+    this._paths = [];
+    this.watching = false;
+  }
+
+  setPaths(paths) {
+    this._paths = paths;
+  }
+
+  getPaths() {
+    mocks.getPaths();
+    return this._paths;
+  }
+
+  watch(...args) {
+    this.watching = true;
+    mocks.watch(...args);
+  }
+
+  stop(...args) {
+    mocks.stop(...args);
+  }
+
+  callOnStart(...args) {
+    return this._onStart(...args);
+  }
+
+  callOnChange(...args) {
+    return this._onChange(...args);
+  }
+
+  callOnInvalidPathForChange(...args) {
+    return this._onInvalidPathForChange(...args);
+  }
+
+  callTranspileFile(...args) {
+    return this._transpileFile(...args);
+  }
+
+  callCopyFile(...args) {
+    return this._copyFile(...args);
+  }
+
+  _onChange(...args) {
+    return mocks.onChange(...args);
+  }
+}
+
+module.exports = NodeWatcherMock;

--- a/tests/services/building/buildCopier.test.js
+++ b/tests/services/building/buildCopier.test.js
@@ -24,9 +24,17 @@ describe('services/building:buildCopier', () => {
     const events = 'events';
     const pathUtils = 'pathUtils';
     const projectConfiguration = 'projectConfiguration';
+    const targets = 'targets';
     let sut = null;
     // When
-    sut = new BuildCopier(copier, appLogger, events, pathUtils, projectConfiguration);
+    sut = new BuildCopier(
+      copier,
+      appLogger,
+      events,
+      pathUtils,
+      projectConfiguration,
+      targets
+    );
     // Then
     expect(sut).toBeInstanceOf(BuildCopier);
     expect(sut.copier).toBe(copier);
@@ -34,6 +42,7 @@ describe('services/building:buildCopier', () => {
     expect(sut.events).toBe(events);
     expect(sut.pathUtils).toBe(pathUtils);
     expect(sut.projectConfiguration).toBe(projectConfiguration);
+    expect(sut.targets).toBe(targets);
   });
 
   it('should copy the project files', () => {
@@ -76,6 +85,7 @@ describe('services/building:buildCopier', () => {
         privateModules: 'private',
       },
     };
+    const targets = 'targets';
     const expectedItems = [
       ...projectConfiguration.copy.items,
       ...[projectConfiguration.version.revision.filename],
@@ -83,7 +93,14 @@ describe('services/building:buildCopier', () => {
     fs.pathExistsSync.mockImplementationOnce(() => true);
     let sut = null;
     // When
-    sut = new BuildCopier(copier, appLogger, events, pathUtils, projectConfiguration);
+    sut = new BuildCopier(
+      copier,
+      appLogger,
+      events,
+      pathUtils,
+      projectConfiguration,
+      targets
+    );
     return sut.copyFiles()
     .then(() => {
       // Then
@@ -106,8 +123,8 @@ describe('services/building:buildCopier', () => {
       expect(events.reduce).toHaveBeenCalledTimes(1);
       expect(events.reduce).toHaveBeenCalledWith('project-files-to-copy', expectedItems);
     })
-    .catch(() => {
-      expect(true).toBeFalse();
+    .catch((error) => {
+      throw error;
     });
   });
 
@@ -134,9 +151,17 @@ describe('services/building:buildCopier', () => {
         privateModules: 'private',
       },
     };
+    const targets = 'targets';
     let sut = null;
     // When
-    sut = new BuildCopier(copier, appLogger, events, pathUtils, projectConfiguration);
+    sut = new BuildCopier(
+      copier,
+      appLogger,
+      events,
+      pathUtils,
+      projectConfiguration,
+      targets
+    );
     return sut.copyFiles()
     .then(() => {
       expect(true).toBeFalse();
@@ -172,16 +197,24 @@ describe('services/building:buildCopier', () => {
         privateModules: 'private',
       },
     };
+    const targets = 'targets';
     let sut = null;
     // When
-    sut = new BuildCopier(copier, appLogger, events, pathUtils, projectConfiguration);
+    sut = new BuildCopier(
+      copier,
+      appLogger,
+      events,
+      pathUtils,
+      projectConfiguration,
+      targets
+    );
     return sut.copyFiles()
     .then(() => {
       // Then
       expect(copier).toHaveBeenCalledTimes(0);
     })
-    .catch(() => {
-      expect(true).toBeFalse();
+    .catch((error) => {
+      throw error;
     });
   });
 
@@ -210,9 +243,17 @@ describe('services/building:buildCopier', () => {
         privateModules: 'private',
       },
     };
+    const targets = 'targets';
     let sut = null;
     // When
-    sut = new BuildCopier(copier, appLogger, events, pathUtils, projectConfiguration);
+    sut = new BuildCopier(
+      copier,
+      appLogger,
+      events,
+      pathUtils,
+      projectConfiguration,
+      targets
+    );
     return sut.copyFiles()
     .then(() => {
       // Then
@@ -220,8 +261,8 @@ describe('services/building:buildCopier', () => {
       expect(events.reduce).toHaveBeenCalledWith('project-files-to-copy', []);
       expect(copier).toHaveBeenCalledTimes(0);
     })
-    .catch(() => {
-      expect(true).toBeFalse();
+    .catch((error) => {
+      throw error;
     });
   });
 
@@ -285,6 +326,7 @@ describe('services/building:buildCopier', () => {
         privateModules: privateModulesFolder,
       },
     };
+    const targets = 'targets';
     const expectedItems = [
       ...itemsToCopy,
       ...modulesToCopy.map((mod) => ({
@@ -314,7 +356,14 @@ describe('services/building:buildCopier', () => {
     fs.writeJson.mockImplementationOnce(() => Promise.resolve());
     let sut = null;
     // When
-    sut = new BuildCopier(copier, appLogger, events, pathUtils, projectConfiguration);
+    sut = new BuildCopier(
+      copier,
+      appLogger,
+      events,
+      pathUtils,
+      projectConfiguration,
+      targets
+    );
     return sut.copyFiles()
     .then(() => {
       // Then
@@ -341,8 +390,8 @@ describe('services/building:buildCopier', () => {
       expect(events.reduce).toHaveBeenCalledTimes(1);
       expect(events.reduce).toHaveBeenCalledWith('project-files-to-copy', expectedItems);
     })
-    .catch(() => {
-      expect(true).toBeFalse();
+    .catch((error) => {
+      throw error;
     });
   });
 
@@ -380,6 +429,7 @@ describe('services/building:buildCopier', () => {
         privateModules: 'private',
       },
     };
+    const targets = 'targets';
     const expectedItems = [
       ...projectConfiguration.copy.items,
       ...[projectConfiguration.version.revision.filename],
@@ -387,7 +437,14 @@ describe('services/building:buildCopier', () => {
     fs.pathExistsSync.mockImplementationOnce(() => true);
     let sut = null;
     // When
-    sut = new BuildCopier(copier, appLogger, events, pathUtils, projectConfiguration);
+    sut = new BuildCopier(
+      copier,
+      appLogger,
+      events,
+      pathUtils,
+      projectConfiguration,
+      targets
+    );
     return sut.copyFiles()
     .then(() => {
       expect(true).toBeFalse();
@@ -425,11 +482,13 @@ describe('services/building:buildCopier', () => {
     const pathUtils = 'pathUtils';
     const events = 'events';
     const projectConfiguration = 'projectConfiguration';
+    const targets = 'targets';
     const target = {
       paths: {
         build: 'target-build-path',
         source: 'target-source-path',
       },
+      includeTargets: [],
     };
     const targetFiles = [
       'index.js',
@@ -440,7 +499,14 @@ describe('services/building:buildCopier', () => {
     fs.readdir.mockImplementationOnce(() => Promise.resolve(targetFiles));
     let sut = null;
     // When
-    sut = new BuildCopier(copier, appLogger, events, pathUtils, projectConfiguration);
+    sut = new BuildCopier(
+      copier,
+      appLogger,
+      events,
+      pathUtils,
+      projectConfiguration,
+      targets
+    );
     return sut.copyTargetFiles(target)
     .then(() => {
       // Then
@@ -452,8 +518,78 @@ describe('services/building:buildCopier', () => {
       expect(copier).toHaveBeenCalledWith(target.paths.source, target.paths.build, targetFiles);
       expect(appLogger.success).toHaveBeenCalledTimes(1);
     })
-    .catch(() => {
-      expect(true).toBeFalse();
+    .catch((error) => {
+      throw error;
+    });
+  });
+
+  it('should copy a target and its `includeTargets` files', () => {
+    // Given
+    const copier = jest.fn(() => Promise.resolve());
+    const appLogger = {
+      success: jest.fn(),
+    };
+    const pathUtils = 'pathUtils';
+    const events = 'events';
+    const projectConfiguration = 'projectConfiguration';
+    const includedTarget = {
+      name: 'included-target',
+      paths: {
+        build: 'included-target-build-path',
+        source: 'included-target-source-path',
+      },
+      includeTargets: [],
+    };
+    const targets = {
+      getTarget: jest.fn(() => includedTarget),
+    };
+    const target = {
+      paths: {
+        build: 'target-build-path',
+        source: 'target-source-path',
+      },
+      includeTargets: [includedTarget.name],
+    };
+    const targetFiles = [
+      'index.js',
+      'start.js',
+      'lib',
+    ];
+    const includedTargetFiles = ['random.js'];
+    fs.ensureDir.mockImplementationOnce(() => Promise.resolve());
+    fs.ensureDir.mockImplementationOnce(() => Promise.resolve());
+    fs.readdir.mockImplementationOnce(() => Promise.resolve(targetFiles));
+    fs.readdir.mockImplementationOnce(() => Promise.resolve(includedTargetFiles));
+    let sut = null;
+    // When
+    sut = new BuildCopier(
+      copier,
+      appLogger,
+      events,
+      pathUtils,
+      projectConfiguration,
+      targets
+    );
+    return sut.copyTargetFiles(target)
+    .then(() => {
+      // Then
+      expect(fs.ensureDir).toHaveBeenCalledTimes(2);
+      expect(fs.ensureDir).toHaveBeenCalledWith(target.paths.build);
+      expect(fs.ensureDir).toHaveBeenCalledWith(includedTarget.paths.build);
+      expect(fs.readdir).toHaveBeenCalledTimes(2);
+      expect(fs.readdir).toHaveBeenCalledWith(target.paths.source);
+      expect(fs.readdir).toHaveBeenCalledWith(includedTarget.paths.source);
+      expect(copier).toHaveBeenCalledTimes(2);
+      expect(copier).toHaveBeenCalledWith(target.paths.source, target.paths.build, targetFiles);
+      expect(copier).toHaveBeenCalledWith(
+        includedTarget.paths.source,
+        includedTarget.paths.build,
+        includedTargetFiles
+      );
+      expect(appLogger.success).toHaveBeenCalledTimes(2);
+    })
+    .catch((error) => {
+      throw error;
     });
   });
 
@@ -464,13 +600,16 @@ describe('services/building:buildCopier', () => {
     const appLogger = {
       error: jest.fn(),
     };
+    const events = 'events';
     const pathUtils = 'pathUtils';
     const projectConfiguration = 'projectConfiguration';
+    const targets = 'targets';
     const target = {
       paths: {
         build: 'target-build-path',
         source: 'target-source-path',
       },
+      includeTargets: [],
     };
     const targetFiles = [
       'index.js',
@@ -481,7 +620,14 @@ describe('services/building:buildCopier', () => {
     fs.readdir.mockImplementationOnce(() => Promise.resolve(targetFiles));
     let sut = null;
     // When
-    sut = new BuildCopier(copier, appLogger, pathUtils, projectConfiguration);
+    sut = new BuildCopier(
+      copier,
+      appLogger,
+      events,
+      pathUtils,
+      projectConfiguration,
+      targets
+    );
     return sut.copyTargetFiles(target)
     .then(() => {
       expect(true).toBeFalse();
@@ -496,6 +642,59 @@ describe('services/building:buildCopier', () => {
       expect(copier).toHaveBeenCalledWith(target.paths.source, target.paths.build, targetFiles);
       expect(appLogger.error).toHaveBeenCalledTimes(1);
       expect(errorResult).toBe(error);
+    });
+  });
+
+  it('should fail to copy a target that includes one that requires bundling', () => {
+    // Given
+    const copier = jest.fn(() => Promise.resolve());
+    const appLogger = {
+      error: jest.fn(),
+    };
+    const pathUtils = 'pathUtils';
+    const events = 'events';
+    const projectConfiguration = 'projectConfiguration';
+    const includedTarget = {
+      bundle: true,
+      name: 'included-target',
+      paths: {
+        build: 'included-target-build-path',
+        source: 'included-target-source-path',
+      },
+      includeTargets: [],
+    };
+    const targets = {
+      getTarget: jest.fn(() => includedTarget),
+    };
+    const target = {
+      paths: {
+        build: 'target-build-path',
+        source: 'target-source-path',
+      },
+      includeTargets: [includedTarget.name],
+    };
+    fs.ensureDir.mockImplementationOnce(() => Promise.resolve());
+    fs.readdir.mockImplementationOnce(() => Promise.resolve());
+    let sut = null;
+    // When
+    sut = new BuildCopier(
+      copier,
+      appLogger,
+      events,
+      pathUtils,
+      projectConfiguration,
+      targets
+    );
+    return sut.copyTargetFiles(target)
+    .then(() => {
+      expect(true).toBeFalse();
+    })
+    .catch((errorResult) => {
+      // Then
+      expect(fs.ensureDir).toHaveBeenCalledTimes(0);
+      expect(fs.readdir).toHaveBeenCalledTimes(0);
+      expect(errorResult).toBeInstanceOf(Error);
+      expect(errorResult.message).toMatch(/requires bundling/i);
     });
   });
 
@@ -527,5 +726,6 @@ describe('services/building:buildCopier', () => {
     expect(sut.copier).toBe('copier');
     expect(sut.pathUtils).toBe('pathUtils');
     expect(sut.projectConfiguration).toBe('projectConfiguration');
+    expect(sut.targets).toBe('targets');
   });
 });

--- a/tests/services/building/buildNodeRunner.test.js
+++ b/tests/services/building/buildNodeRunner.test.js
@@ -13,82 +13,313 @@ describe('services/building:buildNodeRunner', () => {
   it('should be instantiated with all its dependencies', () => {
     // Given
     const buildNodeRunnerProcess = 'buildNodeRunnerProcess';
+    const targets = 'targets';
     let sut = null;
     // When
-    sut = new BuildNodeRunner(buildNodeRunnerProcess);
+    sut = new BuildNodeRunner(buildNodeRunnerProcess, targets);
     // Then
     expect(sut).toBeInstanceOf(BuildNodeRunner);
     expect(sut.buildNodeRunnerProcess).toBe(buildNodeRunnerProcess);
+    expect(sut.targets).toBe(targets);
   });
 
   it('should throw an error when called with a target that requires bundling', () => {
     // Given
     const buildNodeRunnerProcess = 'buildNodeRunnerProcess';
+    const targets = 'targets';
     const target = {
       bundle: true,
     };
     let sut = null;
     // When
-    sut = new BuildNodeRunner(buildNodeRunnerProcess);
+    sut = new BuildNodeRunner(buildNodeRunnerProcess, targets);
     // Then
     expect(() => sut.runTarget(target)).toThrow(/needs to be bundled/i);
   });
 
-  it('should run a target without transpilation', () => {
-    // Given
-    const buildNodeRunnerProcess = jest.fn();
-    const target = {
-      bundle: false,
-      transpile: false,
-      paths: {
-        source: 'target-source-path',
-      },
-      entry: {
-        development: 'index.development',
-      },
-    };
-    let sut = null;
-    // When
-    sut = new BuildNodeRunner(buildNodeRunnerProcess);
-    sut.runTarget(target);
-    // Then
-    expect(buildNodeRunnerProcess).toHaveBeenCalledTimes(1);
-    expect(buildNodeRunnerProcess).toHaveBeenCalledWith(
-      `${target.paths.source}/${target.entry.development}`,
-      [target.paths.source],
-      target.paths.source,
-      target.paths.source,
-      {}
-    );
+  describe('without transpilation', () => {
+    it('should run a target', () => {
+      // Given
+      const buildNodeRunnerProcess = jest.fn();
+      const targets = 'targets';
+      const target = {
+        bundle: false,
+        transpile: false,
+        paths: {
+          source: 'target-source-path',
+        },
+        entry: {
+          development: 'index.development',
+        },
+        includeTargets: [],
+      };
+      let sut = null;
+      // When
+      sut = new BuildNodeRunner(buildNodeRunnerProcess, targets);
+      sut.runTarget(target);
+      // Then
+      expect(buildNodeRunnerProcess).toHaveBeenCalledTimes(1);
+      expect(buildNodeRunnerProcess).toHaveBeenCalledWith(
+        `${target.paths.source}/${target.entry.development}`,
+        [target.paths.source]
+      );
+    });
+
+    it('should run a target and watch another target source directory', () => {
+      // Given
+      const buildNodeRunnerProcess = jest.fn();
+      const includedTarget = {
+        name: 'included-target',
+        paths: {
+          source: 'included-target-source-path',
+        },
+      };
+      const targets = {
+        getTarget: jest.fn(() => includedTarget),
+      };
+      const target = {
+        bundle: false,
+        transpile: false,
+        paths: {
+          source: 'target-source-path',
+        },
+        entry: {
+          development: 'index.development',
+        },
+        includeTargets: [includedTarget.name],
+      };
+      let sut = null;
+      // When
+      sut = new BuildNodeRunner(buildNodeRunnerProcess, targets);
+      sut.runTarget(target);
+      // Then
+      expect(buildNodeRunnerProcess).toHaveBeenCalledTimes(1);
+      expect(buildNodeRunnerProcess).toHaveBeenCalledWith(
+        `${target.paths.source}/${target.entry.development}`,
+        [
+          target.paths.source,
+          includedTarget.paths.source,
+        ]
+      );
+    });
+
+    it('should throw an error when an included target requires bundling', () => {
+      // Given
+      const buildNodeRunnerProcess = jest.fn();
+      const includedTarget = {
+        name: 'included-target',
+        bundle: true,
+      };
+      const targets = {
+        getTarget: jest.fn(() => includedTarget),
+      };
+      const target = {
+        bundle: false,
+        transpile: false,
+        paths: {
+          source: 'target-source-path',
+        },
+        entry: {
+          development: 'index.development',
+        },
+        includeTargets: [includedTarget.name],
+      };
+      let sut = null;
+      // When/Then
+      sut = new BuildNodeRunner(buildNodeRunnerProcess, targets);
+      expect(() => sut.runTarget(target)).toThrow(/requires bundling/i);
+    });
+
+    it('should throw an error when an included target requires transpilation', () => {
+      // Given
+      const buildNodeRunnerProcess = jest.fn();
+      const includedTarget = {
+        name: 'included-target',
+        transpile: true,
+      };
+      const targets = {
+        getTarget: jest.fn(() => includedTarget),
+      };
+      const target = {
+        bundle: false,
+        transpile: false,
+        paths: {
+          source: 'target-source-path',
+        },
+        entry: {
+          development: 'index.development',
+        },
+        includeTargets: [includedTarget.name],
+      };
+      let sut = null;
+      // When/Then
+      sut = new BuildNodeRunner(buildNodeRunnerProcess, targets);
+      expect(() => sut.runTarget(target)).toThrow(/requires transpilation/i);
+    });
   });
 
-  it('should run a target with transpilation', () => {
-    // Given
-    const buildNodeRunnerProcess = jest.fn();
-    const target = {
-      bundle: false,
-      transpile: true,
-      paths: {
-        source: 'target-source-path',
-        build: 'target-build-path',
-      },
-      entry: {
-        development: 'index.development',
-      },
-    };
-    let sut = null;
-    // When
-    sut = new BuildNodeRunner(buildNodeRunnerProcess);
-    sut.runTarget(target);
-    // Then
-    expect(buildNodeRunnerProcess).toHaveBeenCalledTimes(1);
-    expect(buildNodeRunnerProcess).toHaveBeenCalledWith(
-      `${target.paths.build}/${target.entry.development}`,
-      [target.paths.build],
-      target.paths.source,
-      target.paths.build,
-      {}
-    );
+  describe('with transpilation', () => {
+    it('should run a target', () => {
+      // Given
+      const buildNodeRunnerProcess = jest.fn();
+      const targets = 'targets';
+      const target = {
+        bundle: false,
+        transpile: true,
+        paths: {
+          source: 'target-source-path',
+          build: 'target-build-path',
+        },
+        entry: {
+          development: 'index.development',
+        },
+        includeTargets: [],
+      };
+      let sut = null;
+      // When
+      sut = new BuildNodeRunner(buildNodeRunnerProcess, targets);
+      sut.runTarget(target);
+      // Then
+      expect(buildNodeRunnerProcess).toHaveBeenCalledTimes(1);
+      expect(buildNodeRunnerProcess).toHaveBeenCalledWith(
+        `${target.paths.build}/${target.entry.development}`,
+        [target.paths.build],
+        [{
+          from: target.paths.source,
+          to: target.paths.build,
+        }],
+        []
+      );
+    });
+
+    it('should run a target and watch an included target that also requires transpilation', () => {
+      // Given
+      const buildNodeRunnerProcess = jest.fn();
+      const includedTarget = {
+        name: 'included-target',
+        transpile: true,
+        paths: {
+          source: 'included-target-source-path',
+          build: 'included-target-build-path',
+        },
+      };
+      const targets = {
+        getTarget: jest.fn(() => includedTarget),
+      };
+      const target = {
+        bundle: false,
+        transpile: true,
+        paths: {
+          source: 'target-source-path',
+          build: 'target-build-path',
+        },
+        entry: {
+          development: 'index.development',
+        },
+        includeTargets: [includedTarget.name],
+      };
+      let sut = null;
+      // When
+      sut = new BuildNodeRunner(buildNodeRunnerProcess, targets);
+      sut.runTarget(target);
+      // Then
+      expect(buildNodeRunnerProcess).toHaveBeenCalledTimes(1);
+      expect(buildNodeRunnerProcess).toHaveBeenCalledWith(
+        `${target.paths.build}/${target.entry.development}`,
+        [
+          target.paths.build,
+          includedTarget.paths.build,
+        ],
+        [
+          {
+            from: target.paths.source,
+            to: target.paths.build,
+          },
+          {
+            from: includedTarget.paths.source,
+            to: includedTarget.paths.build,
+          },
+        ],
+        []
+      );
+    });
+
+    it('should run a target and watch an included target that doesn\'t requires transp.', () => {
+      // Given
+      const buildNodeRunnerProcess = jest.fn();
+      const includedTarget = {
+        name: 'included-target',
+        transpile: false,
+        paths: {
+          source: 'included-target-source-path',
+          build: 'included-target-build-path',
+        },
+      };
+      const targets = {
+        getTarget: jest.fn(() => includedTarget),
+      };
+      const target = {
+        bundle: false,
+        transpile: true,
+        paths: {
+          source: 'target-source-path',
+          build: 'target-build-path',
+        },
+        entry: {
+          development: 'index.development',
+        },
+        includeTargets: [includedTarget.name],
+      };
+      let sut = null;
+      // When
+      sut = new BuildNodeRunner(buildNodeRunnerProcess, targets);
+      sut.runTarget(target);
+      // Then
+      expect(buildNodeRunnerProcess).toHaveBeenCalledTimes(1);
+      expect(buildNodeRunnerProcess).toHaveBeenCalledWith(
+        `${target.paths.build}/${target.entry.development}`,
+        [
+          target.paths.build,
+          includedTarget.paths.build,
+        ],
+        [{
+          from: target.paths.source,
+          to: target.paths.build,
+        }],
+        [{
+          from: includedTarget.paths.source,
+          to: includedTarget.paths.build,
+        }]
+      );
+    });
+
+    it('should throw an error when an included target requires bundling', () => {
+      // Given
+      const buildNodeRunnerProcess = jest.fn();
+      const includedTarget = {
+        name: 'included-target',
+        bundle: true,
+      };
+      const targets = {
+        getTarget: jest.fn(() => includedTarget),
+      };
+      const target = {
+        bundle: false,
+        transpile: true,
+        paths: {
+          source: 'target-source-path',
+          build: 'target-build-path',
+        },
+        entry: {
+          development: 'index.development',
+        },
+        includeTargets: [includedTarget.name],
+      };
+      let sut = null;
+      // When/Then
+      sut = new BuildNodeRunner(buildNodeRunnerProcess, targets);
+      expect(() => sut.runTarget(target)).toThrow(/requires bundling/i);
+    });
   });
 
   it('should include a provider for the DIC', () => {
@@ -109,5 +340,6 @@ describe('services/building:buildNodeRunner', () => {
     expect(serviceFn).toBeFunction();
     expect(sut).toBeInstanceOf(BuildNodeRunner);
     expect(sut.buildNodeRunnerProcess).toBe('buildNodeRunnerProcess');
+    expect(sut.targets).toBe('targets');
   });
 });

--- a/tests/services/building/buildNodeWatcher.test.js
+++ b/tests/services/building/buildNodeWatcher.test.js
@@ -1,0 +1,237 @@
+const JimpleMock = require('/tests/mocks/jimple.mock');
+
+jest.mock('jimple', () => JimpleMock);
+jest.unmock('/src/services/building/buildNodeWatcher');
+
+require('jasmine-expect');
+const {
+  BuildNodeWatcher,
+  buildNodeWatcher,
+} = require('/src/services/building/buildNodeWatcher');
+
+describe('services/building:buildNodeWatcher', () => {
+  it('should be instantiated with all its dependencies', () => {
+    // Given
+    const buildNodeWatcherProcess = 'buildNodeWatcherProcess';
+    const targets = 'targets';
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcher(buildNodeWatcherProcess, targets);
+    // Then
+    expect(sut).toBeInstanceOf(BuildNodeWatcher);
+    expect(sut.buildNodeWatcherProcess).toBe(buildNodeWatcherProcess);
+    expect(sut.targets).toBe(targets);
+  });
+
+  it('should throw an error when called with a target that requires bundling', () => {
+    // Given
+    const buildNodeWatcherProcess = 'buildNodeWatcherProcess';
+    const targets = 'targets';
+    const target = {
+      bundle: true,
+    };
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcher(buildNodeWatcherProcess, targets);
+    // Then
+    expect(() => sut.watchTarget(target)).toThrow(/needs to be bundled/i);
+  });
+
+  it('should watch a target', () => {
+    // Given
+    const buildNodeWatcherProcess = jest.fn();
+    const targets = 'targets';
+    const target = {
+      bundle: false,
+      transpile: false,
+      paths: {
+        source: 'target-source-path',
+        build: 'target-build-path',
+      },
+      includeTargets: [],
+    };
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcher(buildNodeWatcherProcess, targets);
+    sut.watchTarget(target);
+    // Then
+    expect(buildNodeWatcherProcess).toHaveBeenCalledTimes(1);
+    expect(buildNodeWatcherProcess).toHaveBeenCalledWith(
+      [target.paths.source],
+      [],
+      [{
+        from: target.paths.source,
+        to: target.paths.build,
+      }]
+    );
+  });
+
+  it('should watch a target that requires transpilation', () => {
+    // Given
+    const buildNodeWatcherProcess = jest.fn();
+    const targets = 'targets';
+    const target = {
+      bundle: false,
+      transpile: true,
+      paths: {
+        source: 'target-source-path',
+        build: 'target-build-path',
+      },
+      includeTargets: [],
+    };
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcher(buildNodeWatcherProcess, targets);
+    sut.watchTarget(target);
+    // Then
+    expect(buildNodeWatcherProcess).toHaveBeenCalledTimes(1);
+    expect(buildNodeWatcherProcess).toHaveBeenCalledWith(
+      [target.paths.source],
+      [{
+        from: target.paths.source,
+        to: target.paths.build,
+      }],
+      []
+    );
+  });
+
+  it('should watch a target and include one that requires transpilation', () => {
+    // Given
+    const buildNodeWatcherProcess = jest.fn();
+    const includedTarget = {
+      name: 'included-target',
+      transpile: true,
+      paths: {
+        source: 'included-target-source-path',
+        build: 'included-target-build-path',
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => includedTarget),
+    };
+    const target = {
+      bundle: false,
+      transpile: false,
+      paths: {
+        source: 'target-source-path',
+        build: 'target-build-path',
+      },
+      includeTargets: [includedTarget.name],
+    };
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcher(buildNodeWatcherProcess, targets);
+    sut.watchTarget(target);
+    // Then
+    expect(buildNodeWatcherProcess).toHaveBeenCalledTimes(1);
+    expect(buildNodeWatcherProcess).toHaveBeenCalledWith(
+      [
+        target.paths.source,
+        includedTarget.paths.source,
+      ],
+      [{
+        from: includedTarget.paths.source,
+        to: includedTarget.paths.build,
+      }],
+      [{
+        from: target.paths.source,
+        to: target.paths.build,
+      }]
+    );
+  });
+
+  it('should watch a target and include one that doesn\'t requires transpilation', () => {
+    // Given
+    const buildNodeWatcherProcess = jest.fn();
+    const includedTarget = {
+      name: 'included-target',
+      transpile: false,
+      paths: {
+        source: 'included-target-source-path',
+        build: 'included-target-build-path',
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => includedTarget),
+    };
+    const target = {
+      bundle: false,
+      transpile: true,
+      paths: {
+        source: 'target-source-path',
+        build: 'target-build-path',
+      },
+      includeTargets: [includedTarget.name],
+    };
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcher(buildNodeWatcherProcess, targets);
+    sut.watchTarget(target);
+    // Then
+    expect(buildNodeWatcherProcess).toHaveBeenCalledTimes(1);
+    expect(buildNodeWatcherProcess).toHaveBeenCalledWith(
+      [
+        target.paths.source,
+        includedTarget.paths.source,
+      ],
+      [{
+        from: target.paths.source,
+        to: target.paths.build,
+      }],
+      [{
+        from: includedTarget.paths.source,
+        to: includedTarget.paths.build,
+      }]
+    );
+  });
+
+  it('should throw an error when an included target requires bundling', () => {
+    // Given
+    const buildNodeWatcherProcess = jest.fn();
+    const includedTarget = {
+      name: 'included-target',
+      bundle: true,
+      paths: {
+        source: 'included-target-source-path',
+        build: 'included-target-build-path',
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => includedTarget),
+    };
+    const target = {
+      bundle: false,
+      transpile: true,
+      paths: {
+        source: 'target-source-path',
+        build: 'target-build-path',
+      },
+      includeTargets: [includedTarget.name],
+    };
+    let sut = null;
+    // When/Then
+    sut = new BuildNodeWatcher(buildNodeWatcherProcess, targets);
+    expect(() => sut.watchTarget(target)).toThrow(/requires bundling/i);
+  });
+
+  it('should include a provider for the DIC', () => {
+    // Given
+    let sut = null;
+    const container = {
+      set: jest.fn(),
+      get: jest.fn((service) => service),
+    };
+    let serviceName = null;
+    let serviceFn = null;
+    // When
+    buildNodeWatcher(container);
+    [[serviceName, serviceFn]] = container.set.mock.calls;
+    sut = serviceFn();
+    // Then
+    expect(serviceName).toBe('buildNodeWatcher');
+    expect(serviceFn).toBeFunction();
+    expect(sut).toBeInstanceOf(BuildNodeWatcher);
+    expect(sut.buildNodeWatcherProcess).toBe('buildNodeWatcherProcess');
+    expect(sut.targets).toBe('targets');
+  });
+});

--- a/tests/services/building/buildNodeWatcherProcess.test.js
+++ b/tests/services/building/buildNodeWatcherProcess.test.js
@@ -1,0 +1,324 @@
+const JimpleMock = require('/tests/mocks/jimple.mock');
+const NodeWatcherMock = require('/tests/mocks/nodeWatcher.mock');
+
+jest.mock('jimple', () => JimpleMock);
+jest.mock('/src/abstracts/nodeWatcher', () => NodeWatcherMock);
+jest.mock('fs-extra');
+jest.unmock('/src/services/building/buildNodeWatcherProcess');
+
+const fs = require('fs-extra');
+require('jasmine-expect');
+const {
+  BuildNodeWatcherProcess,
+  buildNodeWatcherProcess,
+} = require('/src/services/building/buildNodeWatcherProcess');
+
+describe('services/building:buildNodeWatcherProcess', () => {
+  beforeEach(() => {
+    NodeWatcherMock.reset();
+    fs.ensureDirSync.mockReset();
+    fs.copySync.mockReset();
+  });
+
+  it('should be instantiated', () => {
+    // Given
+    const appLogger = 'appLogger';
+    const buildTranspiler = 'buildTranspiler';
+    const poll = 'something';
+    const projectConfiguration = {
+      others: {
+        watch: {
+          poll,
+        },
+      },
+    };
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcherProcess(
+      appLogger,
+      buildTranspiler,
+      projectConfiguration
+    );
+    // Then
+    expect(sut).toBeInstanceOf(BuildNodeWatcherProcess);
+    expect(NodeWatcherMock.mocks.constructor).toHaveBeenCalledTimes(1);
+    expect(NodeWatcherMock.mocks.constructor).toHaveBeenCalledWith({
+      poll,
+    });
+    expect(sut.appLogger).toBe(appLogger);
+    expect(sut.buildTranspiler).toBe(buildTranspiler);
+  });
+
+  it('should log a message when the service starts watching', () => {
+    // Given
+    const appLogger = {
+      success: jest.fn(),
+      info: jest.fn(),
+    };
+    const buildTranspiler = 'buildTranspiler';
+    const poll = 'something';
+    const projectConfiguration = {
+      others: {
+        watch: {
+          poll,
+        },
+      },
+    };
+    const paths = ['path-one', 'path-two'];
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcherProcess(
+      appLogger,
+      buildTranspiler,
+      projectConfiguration
+    );
+    sut.setPaths(paths);
+    sut.callOnStart();
+    // Then
+    expect(appLogger.success).toHaveBeenCalledTimes(1);
+    expect(appLogger.success).toHaveBeenCalledWith('Starting watch mode');
+    expect(appLogger.info).toHaveBeenCalledTimes(1);
+    expect(appLogger.info).toHaveBeenCalledWith(paths.map((path) => `watching: ${path}`));
+  });
+
+  it('should log a message when a file changes, then call the parent class', () => {
+    // Given
+    const appLogger = {
+      warning: jest.fn(),
+    };
+    const buildTranspiler = 'buildTranspiler';
+    const poll = 'something';
+    const projectConfiguration = {
+      others: {
+        watch: {
+          poll,
+        },
+      },
+    };
+    const file = 'some/random/file.js';
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcherProcess(
+      appLogger,
+      buildTranspiler,
+      projectConfiguration
+    );
+    sut.callOnChange(file);
+    // Then
+    expect(appLogger.warning).toHaveBeenCalledTimes(1);
+    expect(appLogger.warning).toHaveBeenCalledWith(`Change detected on ${file}`);
+    expect(NodeWatcherMock.mocks.onChange).toHaveBeenCalledTimes(1);
+    expect(NodeWatcherMock.mocks.onChange).toHaveBeenCalledWith(file);
+  });
+
+  it('should log a message when there\'s no valid path for a changed file', () => {
+    // Given
+    const appLogger = {
+      error: jest.fn(),
+    };
+    const buildTranspiler = 'buildTranspiler';
+    const poll = 'something';
+    const projectConfiguration = {
+      others: {
+        watch: {
+          poll,
+        },
+      },
+    };
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcherProcess(
+      appLogger,
+      buildTranspiler,
+      projectConfiguration
+    );
+    sut.callOnInvalidPathForChange();
+    // Then
+    expect(appLogger.error).toHaveBeenCalledTimes(1);
+    expect(appLogger.error)
+    .toHaveBeenCalledWith('Error: The file directory is not on the list of allowed paths');
+  });
+
+  it('should transpile a file', () => {
+    // Given
+    const appLogger = {
+      success: jest.fn(),
+    };
+    const buildTranspiler = {
+      transpileFileSync: jest.fn(),
+    };
+    const poll = 'something';
+    const projectConfiguration = {
+      others: {
+        watch: {
+          poll,
+        },
+      },
+    };
+    const source = 'some/original/file.js';
+    const outputDir = 'some/output';
+    const output = `${outputDir}/file.js`;
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcherProcess(
+      appLogger,
+      buildTranspiler,
+      projectConfiguration
+    );
+    sut.callTranspileFile(source, output);
+    // Then
+    expect(fs.ensureDirSync).toHaveBeenCalledTimes(1);
+    expect(fs.ensureDirSync).toHaveBeenCalledWith(outputDir);
+    expect(buildTranspiler.transpileFileSync).toHaveBeenCalledTimes(1);
+    expect(buildTranspiler.transpileFileSync).toHaveBeenCalledWith({
+      source,
+      output,
+    });
+    expect(appLogger.success).toHaveBeenCalledTimes(1);
+    expect(appLogger.success)
+    .toHaveBeenCalledWith('The file was successfully copied and transpiled');
+  });
+
+  it('should fail to transpile a file', () => {
+    // Given
+    const appLogger = {
+      error: jest.fn(),
+    };
+    const error = new Error('Something!');
+    fs.ensureDirSync.mockImplementationOnce(() => {
+      throw error;
+    });
+    const buildTranspiler = {
+      transpileFileSync: jest.fn(),
+    };
+    const poll = 'something';
+    const projectConfiguration = {
+      others: {
+        watch: {
+          poll,
+        },
+      },
+    };
+    const source = 'some/original/file.js';
+    const outputDir = 'some/output';
+    const output = `${outputDir}/file.js`;
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcherProcess(
+      appLogger,
+      buildTranspiler,
+      projectConfiguration
+    );
+    sut.callTranspileFile(source, output);
+    // Then
+    expect(fs.ensureDirSync).toHaveBeenCalledTimes(1);
+    expect(fs.ensureDirSync).toHaveBeenCalledWith(outputDir);
+    expect(appLogger.error).toHaveBeenCalledTimes(2);
+    expect(appLogger.error).toHaveBeenCalledWith('Error: The file couldn\'t be updated');
+    expect(appLogger.error).toHaveBeenCalledWith(error);
+  });
+
+  it('should copy a file', () => {
+    // Given
+    const appLogger = {
+      success: jest.fn(),
+    };
+    const buildTranspiler = 'buildTranspiler';
+    const poll = 'something';
+    const projectConfiguration = {
+      others: {
+        watch: {
+          poll,
+        },
+      },
+    };
+    const from = 'some/original/file.js';
+    const toDir = 'some/output';
+    const to = `${toDir}/file.js`;
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcherProcess(
+      appLogger,
+      buildTranspiler,
+      projectConfiguration
+    );
+    sut.callCopyFile(from, to);
+    // Then
+    expect(fs.ensureDirSync).toHaveBeenCalledTimes(1);
+    expect(fs.ensureDirSync).toHaveBeenCalledWith(toDir);
+    expect(fs.copySync).toHaveBeenCalledTimes(1);
+    expect(fs.copySync).toHaveBeenCalledWith(from, to);
+    expect(appLogger.success).toHaveBeenCalledTimes(1);
+    expect(appLogger.success)
+    .toHaveBeenCalledWith('The file was successfully copied');
+  });
+
+  it('should fail to copy a file', () => {
+    // Given
+    const appLogger = {
+      error: jest.fn(),
+    };
+    const error = new Error('Something!');
+    fs.ensureDirSync.mockImplementationOnce(() => {
+      throw error;
+    });
+    const buildTranspiler = 'buildTranspiler';
+    const poll = 'something';
+    const projectConfiguration = {
+      others: {
+        watch: {
+          poll,
+        },
+      },
+    };
+    const from = 'some/original/file.js';
+    const toDir = 'some/output';
+    const to = `${toDir}/file.js`;
+    let sut = null;
+    // When
+    sut = new BuildNodeWatcherProcess(
+      appLogger,
+      buildTranspiler,
+      projectConfiguration
+    );
+    sut.callCopyFile(from, to);
+    // Then
+    expect(fs.ensureDirSync).toHaveBeenCalledTimes(1);
+    expect(fs.ensureDirSync).toHaveBeenCalledWith(toDir);
+    expect(appLogger.error).toHaveBeenCalledTimes(2);
+    expect(appLogger.error).toHaveBeenCalledWith('Error: The file couldn\'t be copied');
+    expect(appLogger.error).toHaveBeenCalledWith(error);
+  });
+
+  it('should include a provider for the DIC', () => {
+    // Given
+    let sut = null;
+    const poll = 'something';
+    const projectConfiguration = {
+      getConfig: () => ({
+        others: {
+          watch: {
+            poll,
+          },
+        },
+      }),
+    };
+    const services = {
+      projectConfiguration,
+    };
+    const container = {
+      set: jest.fn(),
+      get: jest.fn((service) => (services[service] || service)),
+    };
+    let serviceName = null;
+    let serviceFn = null;
+    // When
+    buildNodeWatcherProcess(container);
+    [[serviceName, serviceFn]] = container.set.mock.calls;
+    sut = serviceFn();
+    // Then
+    expect(serviceName).toBe('buildNodeWatcherProcess');
+    expect(serviceFn).toBeFunction();
+    expect(sut).toBeFunction();
+  });
+});

--- a/tests/services/building/builder.test.js
+++ b/tests/services/building/builder.test.js
@@ -51,6 +51,7 @@ describe('services/building:builder', () => {
     };
     const buildType = 'development';
     const forceRun = false;
+    const forceWatch = false;
     let sut = null;
     let result = null;
     // When
@@ -70,7 +71,8 @@ describe('services/building:builder', () => {
     expect(engine.getBuildCommand).toHaveBeenCalledWith(
       target,
       buildType,
-      forceRun
+      forceRun,
+      forceWatch
     );
   });
 
@@ -93,6 +95,7 @@ describe('services/building:builder', () => {
     };
     const buildType = 'development';
     const forceRun = true;
+    const forceWatch = false;
     let sut = null;
     let result = null;
     // When
@@ -112,7 +115,52 @@ describe('services/building:builder', () => {
     expect(engine.getBuildCommand).toHaveBeenCalledWith(
       target,
       buildType,
-      forceRun
+      forceRun,
+      forceWatch
+    );
+  });
+
+  it('should return the build command for a bundled target and force watch', () => {
+    // Given
+    const buildCleaner = 'buildCleaner';
+    const buildCopier = 'buildCopier';
+    const command = 'some-command';
+    const engine = {
+      getBuildCommand: jest.fn(() => command),
+    };
+    const buildEngines = {
+      getEngine: jest.fn(() => engine),
+    };
+    const buildTranspiler = 'buildTranspiler';
+    const targets = 'targets';
+    const target = {
+      bundle: true,
+      engine: 'webpack',
+    };
+    const buildType = 'development';
+    const forceRun = false;
+    const forceWatch = true;
+    let sut = null;
+    let result = null;
+    // When
+    sut = new Builder(
+      buildCleaner,
+      buildCopier,
+      buildEngines,
+      buildTranspiler,
+      targets
+    );
+    result = sut.getTargetBuildCommand(target, buildType, forceRun, forceWatch);
+    // Then
+    expect(result).toBe(command);
+    expect(buildEngines.getEngine).toHaveBeenCalledTimes(1);
+    expect(buildEngines.getEngine).toHaveBeenCalledWith(target.engine);
+    expect(engine.getBuildCommand).toHaveBeenCalledTimes(1);
+    expect(engine.getBuildCommand).toHaveBeenCalledWith(
+      target,
+      buildType,
+      forceRun,
+      forceWatch
     );
   });
 

--- a/tests/services/cli/cliSHBuild.test.js
+++ b/tests/services/cli/cliSHBuild.test.js
@@ -54,7 +54,10 @@ describe('services/cli:sh-build', () => {
     test.cliSHNodeRunCommand = {
       generate: jest.fn(() => test.runCommand),
     };
-    test.watchCommand = '';
+    test.watchCommand = 'watch';
+    test.cliSHNodeWatchCommand = {
+      generate: jest.fn(() => test.watchCommand),
+    };
     test.transpileCommand = 'transpile';
     test.cliSHTranspileCommand = {
       generate: jest.fn(() => test.transpileCommand),
@@ -93,6 +96,7 @@ describe('services/cli:sh-build', () => {
       test.cliRevisionCommand,
       test.cliSHCopyCommand,
       test.cliSHNodeRunCommand,
+      test.cliSHNodeWatchCommand,
       test.cliSHTranspileCommand,
       test.events,
       test.projectConfiguration,
@@ -121,6 +125,7 @@ describe('services/cli:sh-build', () => {
     const cliRevisionCommand = 'cliRevisionCommand';
     const cliSHCopyCommand = 'cliSHCopyCommand';
     const cliSHNodeRunCommand = 'cliSHNodeRunCommand';
+    const cliSHNodeWatchCommand = 'cliSHNodeWatchCommand';
     const cliSHTranspileCommand = 'cliSHTranspileCommand';
     const events = 'events';
     const projectConfiguration = 'projectConfiguration';
@@ -134,6 +139,7 @@ describe('services/cli:sh-build', () => {
       cliRevisionCommand,
       cliSHCopyCommand,
       cliSHNodeRunCommand,
+      cliSHNodeWatchCommand,
       cliSHTranspileCommand,
       events,
       projectConfiguration,
@@ -148,6 +154,7 @@ describe('services/cli:sh-build', () => {
     expect(sut.cliRevisionCommand).toBe(cliRevisionCommand);
     expect(sut.cliSHCopyCommand).toBe(cliSHCopyCommand);
     expect(sut.cliSHNodeRunCommand).toBe(cliSHNodeRunCommand);
+    expect(sut.cliSHNodeWatchCommand).toBe(cliSHNodeWatchCommand);
     expect(sut.cliSHTranspileCommand).toBe(cliSHTranspileCommand);
     expect(sut.events).toBe(events);
     expect(sut.projectConfiguration).toBe(projectConfiguration);
@@ -547,7 +554,7 @@ describe('services/cli:sh-build', () => {
     expect(test.targets.getTarget).toHaveBeenCalledWith(test.targetName);
     expect(test.cliCleanCommand.generate).toHaveBeenCalledTimes(1);
     expect(test.cliSHCopyCommand.generate).toHaveBeenCalledTimes(1);
-    // expect(test.cliSHNodeRunCommand.generate).toHaveBeenCalledTimes(1);
+    expect(test.cliSHNodeWatchCommand.generate).toHaveBeenCalledTimes(1);
     expect(test.cliSHTranspileCommand.generate).toHaveBeenCalledTimes(1);
     expect(test.cliRevisionCommand.generate).toHaveBeenCalledTimes(0);
     expect(test.cliCopyProjectFilesCommand.generate).toHaveBeenCalledTimes(0);
@@ -559,7 +566,7 @@ describe('services/cli:sh-build', () => {
         test.buildCommand,
         test.copyCommand,
         test.transpileCommand,
-        // test.watchCommand,
+        test.watchCommand,
       ],
       {
         target: test.target,
@@ -576,7 +583,7 @@ describe('services/cli:sh-build', () => {
       test.buildCommand,
       test.copyCommand,
       test.transpileCommand,
-      // test.watchCommand,
+      test.watchCommand,
     ].join(';'));
   });
 
@@ -1196,6 +1203,7 @@ describe('services/cli:sh-build', () => {
     expect(sut.cliRevisionCommand).toBe('cliRevisionCommand');
     expect(sut.cliSHCopyCommand).toBe('cliSHCopyCommand');
     expect(sut.cliSHNodeRunCommand).toBe('cliSHNodeRunCommand');
+    expect(sut.cliSHNodeWatchCommand).toBe('cliSHNodeWatchCommand');
     expect(sut.cliSHTranspileCommand).toBe('cliSHTranspileCommand');
     expect(sut.events).toBe('events');
     expect(sut.projectConfiguration).toBe('projectConfiguration');

--- a/tests/services/cli/cliSHNodeWatch.test.js
+++ b/tests/services/cli/cliSHNodeWatch.test.js
@@ -1,0 +1,80 @@
+const JimpleMock = require('/tests/mocks/jimple.mock');
+const CLICommandMock = require('/tests/mocks/cliCommand.mock');
+
+jest.mock('jimple', () => JimpleMock);
+jest.mock('/src/abstracts/cliCommand', () => CLICommandMock);
+jest.unmock('/src/services/cli/cliSHNodeWatch');
+
+require('jasmine-expect');
+const {
+  CLISHNodeWatchCommand,
+  cliSHNodeWatchCommand,
+} = require('/src/services/cli/cliSHNodeWatch');
+
+describe('services/cli:sh-node-watch', () => {
+  beforeEach(() => {
+    CLICommandMock.reset();
+  });
+
+  it('should be instantiated with all its dependencies', () => {
+    // Given
+    const buildNodeWatcher = 'buildNodeWatcher';
+    const targets = 'targets';
+    let sut = null;
+    // When
+    sut = new CLISHNodeWatchCommand(buildNodeWatcher, targets);
+    // Then
+    expect(sut).toBeInstanceOf(CLISHNodeWatchCommand);
+    expect(sut.constructorMock).toHaveBeenCalledTimes(1);
+    expect(sut.buildNodeWatcher).toBe(buildNodeWatcher);
+    expect(sut.targets).toBe(targets);
+    expect(sut.command).not.toBeEmptyString();
+    expect(sut.description).not.toBeEmptyString();
+    expect(sut.hidden).toBeTrue();
+    expect(sut.allowUnknownOptions).toBeTrue();
+  });
+
+  it('should call the method to watch a node target when executed', () => {
+    // Given
+    const message = 'done';
+    const target = 'some-target';
+    const buildNodeWatcher = {
+      watchTarget: jest.fn(() => message),
+    };
+    const targets = {
+      getTarget: jest.fn(() => target),
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new CLISHNodeWatchCommand(buildNodeWatcher, targets);
+    result = sut.handle(target);
+    // Then
+    expect(result).toBe(message);
+    expect(targets.getTarget).toHaveBeenCalledTimes(1);
+    expect(targets.getTarget).toHaveBeenCalledWith(target);
+    expect(buildNodeWatcher.watchTarget).toHaveBeenCalledTimes(1);
+    expect(buildNodeWatcher.watchTarget).toHaveBeenCalledWith(target);
+  });
+
+  it('should include a provider for the DIC', () => {
+    // Given
+    let sut = null;
+    const container = {
+      set: jest.fn(),
+      get: jest.fn((service) => service),
+    };
+    let serviceName = null;
+    let serviceFn = null;
+    // When
+    cliSHNodeWatchCommand(container);
+    [[serviceName, serviceFn]] = container.set.mock.calls;
+    sut = serviceFn();
+    // Then
+    expect(serviceName).toBe('cliSHNodeWatchCommand');
+    expect(serviceFn).toBeFunction();
+    expect(sut).toBeInstanceOf(CLISHNodeWatchCommand);
+    expect(sut.buildNodeWatcher).toBe('buildNodeWatcher');
+    expect(sut.targets).toBe('targets');
+  });
+});

--- a/tests/services/cli/cliSHValidateBuild.test.js
+++ b/tests/services/cli/cliSHValidateBuild.test.js
@@ -34,7 +34,7 @@ describe('services/cli:sh-validate-build', () => {
     expect(sut.tempFiles).toBe(tempFiles);
     expect(sut.command).not.toBeEmptyString();
     expect(sut.description).not.toBeEmptyString();
-    expect(sut.addOption).toHaveBeenCalledTimes(2);
+    expect(sut.addOption).toHaveBeenCalledTimes(3);
     expect(sut.addOption).toHaveBeenCalledWith(
       'type',
       '-t, --type [type]',
@@ -44,6 +44,12 @@ describe('services/cli:sh-validate-build', () => {
     expect(sut.addOption).toHaveBeenCalledWith(
       'run',
       '-r, --run',
+      expect.any(String),
+      false
+    );
+    expect(sut.addOption).toHaveBeenCalledWith(
+      'watch',
+      '-w, --watch',
       expect.any(String),
       false
     );
@@ -63,6 +69,10 @@ describe('services/cli:sh-validate-build', () => {
       },
       bundle: false,
       transpile: false,
+      watch: {
+        production: false,
+        development: false,
+      },
     };
     const targets = {
       getTarget: jest.fn(() => target),
@@ -90,6 +100,10 @@ describe('services/cli:sh-validate-build', () => {
       is: {
         node: true,
       },
+      watch: {
+        production: false,
+        development: false,
+      },
     };
     const targets = {
       getTarget: jest.fn(() => target),
@@ -106,6 +120,103 @@ describe('services/cli:sh-validate-build', () => {
     expect(appLogger.warning).toHaveBeenCalledTimes(0);
   });
 
+  it('should log a warning when trying to watch a target that doesn\'t need it', () => {
+    // Given
+    const appLogger = {
+      warning: jest.fn(),
+    };
+    const targetName = 'some-target';
+    const target = {
+      is: {
+        node: true,
+      },
+      bundle: false,
+      transpile: false,
+      watch: {
+        production: false,
+        development: true,
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => target),
+    };
+    const targetsHTML = 'targetsHTML';
+    const tempFiles = 'tempFiles';
+    const run = false;
+    const type = 'development';
+    let sut = null;
+    // When
+    sut = new CLISHValidateBuildCommand(appLogger, targets, targetsHTML, tempFiles);
+    sut.handle(targetName, null, { run, type });
+    // Then
+    expect(appLogger.warning).toHaveBeenCalledTimes(1);
+  });
+
+  it('shouldn\'t log a warning when trying to watch a target that requires tranpilation', () => {
+    // Given
+    const appLogger = {
+      warning: jest.fn(),
+    };
+    const targetName = 'some-target';
+    const target = {
+      is: {
+        node: true,
+      },
+      bundle: false,
+      transpile: true,
+      watch: {
+        production: false,
+        development: true,
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => target),
+    };
+    const targetsHTML = 'targetsHTML';
+    const tempFiles = 'tempFiles';
+    const run = false;
+    const type = 'development';
+    let sut = null;
+    // When
+    sut = new CLISHValidateBuildCommand(appLogger, targets, targetsHTML, tempFiles);
+    sut.handle(targetName, null, { run, type });
+    // Then
+    expect(appLogger.warning).toHaveBeenCalledTimes(0);
+  });
+
+  it('shouldn\'t log a warning when trying to watch a target production build', () => {
+    // Given
+    const appLogger = {
+      warning: jest.fn(),
+    };
+    const targetName = 'some-target';
+    const target = {
+      is: {
+        node: true,
+      },
+      bundle: false,
+      transpile: false,
+      watch: {
+        production: false,
+        development: false,
+      },
+    };
+    const targets = {
+      getTarget: jest.fn(() => target),
+    };
+    const targetsHTML = 'targetsHTML';
+    const tempFiles = 'tempFiles';
+    const run = false;
+    const watch = true;
+    const type = 'production';
+    let sut = null;
+    // When
+    sut = new CLISHValidateBuildCommand(appLogger, targets, targetsHTML, tempFiles);
+    sut.handle(targetName, null, { run, type, watch });
+    // Then
+    expect(appLogger.warning).toHaveBeenCalledTimes(0);
+  });
+
   it('should validate the temp directory when trying to build a browser target', () => {
     // Given
     const appLogger = 'appLogger';
@@ -114,6 +225,10 @@ describe('services/cli:sh-validate-build', () => {
       is: {
         node: false,
         browser: true,
+      },
+      watch: {
+        production: false,
+        development: false,
       },
     };
     const targets = {
@@ -147,6 +262,10 @@ describe('services/cli:sh-validate-build', () => {
       is: {
         node: false,
         browser: true,
+      },
+      watch: {
+        production: false,
+        development: false,
       },
     };
     const targets = {
@@ -183,6 +302,10 @@ describe('services/cli:sh-validate-build', () => {
         node: false,
         browser: true,
       },
+      watch: {
+        production: false,
+        development: false,
+      },
     };
     const targets = {
       getTarget: jest.fn(() => target),
@@ -207,6 +330,10 @@ describe('services/cli:sh-validate-build', () => {
     const target = {
       is: {
         node: true,
+      },
+      watch: {
+        production: false,
+        development: false,
       },
       bundle: false,
       transpile: false,

--- a/tests/services/cli/cliSHValidateWatch.test.js
+++ b/tests/services/cli/cliSHValidateWatch.test.js
@@ -3,15 +3,15 @@ const CLICommandMock = require('/tests/mocks/cliCommand.mock');
 
 jest.mock('jimple', () => JimpleMock);
 jest.mock('/src/abstracts/cliCommand', () => CLICommandMock);
-jest.unmock('/src/services/cli/cliSHValidateRun');
+jest.unmock('/src/services/cli/cliSHValidateWatch');
 
 require('jasmine-expect');
 const {
-  CLISHValidateRunCommand,
-  cliSHValidateRunCommand,
-} = require('/src/services/cli/cliSHValidateRun');
+  CLISHValidateWatchCommand,
+  cliSHValidateWatchCommand,
+} = require('/src/services/cli/cliSHValidateWatch');
 
-describe('services/cli:validate-run', () => {
+describe('services/cli:validate-watch', () => {
   beforeEach(() => {
     CLICommandMock.reset();
   });
@@ -21,13 +21,20 @@ describe('services/cli:validate-run', () => {
     const targets = 'targets';
     let sut = null;
     // When
-    sut = new CLISHValidateRunCommand(targets);
+    sut = new CLISHValidateWatchCommand(targets);
     // Then
-    expect(sut).toBeInstanceOf(CLISHValidateRunCommand);
+    expect(sut).toBeInstanceOf(CLISHValidateWatchCommand);
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.targets).toBe(targets);
     expect(sut.command).not.toBeEmptyString();
     expect(sut.description).not.toBeEmptyString();
+    expect(sut.addOption).toHaveBeenCalledTimes(1);
+    expect(sut.addOption).toHaveBeenCalledWith(
+      'type',
+      '-t, --type [type]',
+      expect.any(String),
+      'development'
+    );
     expect(sut.hidden).toBeTrue();
     expect(sut.allowUnknownOptions).toBeTrue();
   });
@@ -42,7 +49,7 @@ describe('services/cli:validate-run', () => {
     let sut = null;
     let result = null;
     // When
-    sut = new CLISHValidateRunCommand(targets);
+    sut = new CLISHValidateWatchCommand(targets);
     result = sut.handle(target);
     // Then
     expect(result).toBe(message);
@@ -59,7 +66,7 @@ describe('services/cli:validate-run', () => {
     let sut = null;
     let result = null;
     // When
-    sut = new CLISHValidateRunCommand(targets);
+    sut = new CLISHValidateWatchCommand(targets);
     result = sut.handle();
     // Then
     expect(result).toBe(message);
@@ -76,13 +83,13 @@ describe('services/cli:validate-run', () => {
     let serviceName = null;
     let serviceFn = null;
     // When
-    cliSHValidateRunCommand(container);
+    cliSHValidateWatchCommand(container);
     [[serviceName, serviceFn]] = container.set.mock.calls;
     sut = serviceFn();
     // Then
-    expect(serviceName).toBe('cliSHValidateRunCommand');
+    expect(serviceName).toBe('cliSHValidateWatchCommand');
     expect(serviceFn).toBeFunction();
-    expect(sut).toBeInstanceOf(CLISHValidateRunCommand);
+    expect(sut).toBeInstanceOf(CLISHValidateWatchCommand);
     expect(sut.targets).toBe('targets');
   });
 });

--- a/tests/services/cli/cliSHWatch.test.js
+++ b/tests/services/cli/cliSHWatch.test.js
@@ -1,0 +1,147 @@
+const JimpleMock = require('/tests/mocks/jimple.mock');
+const CLICommandMock = require('/tests/mocks/cliCommand.mock');
+
+jest.mock('jimple', () => JimpleMock);
+jest.mock('/src/abstracts/cliCommand', () => CLICommandMock);
+jest.unmock('/src/services/cli/cliSHWatch');
+
+require('jasmine-expect');
+const {
+  CLISHWatchCommand,
+  cliSHWatchCommand,
+} = require('/src/services/cli/cliSHWatch');
+
+describe('services/cli:sh-watch', () => {
+  beforeEach(() => {
+    CLICommandMock.reset();
+  });
+
+  it('should be instantiated with all its dependencies', () => {
+    // Given
+    const cliBuildCommand = 'cliBuildCommand';
+    const targets = 'targets';
+    let sut = null;
+    // When
+    sut = new CLISHWatchCommand(cliBuildCommand, targets);
+    // Then
+    expect(sut).toBeInstanceOf(CLISHWatchCommand);
+    expect(sut.constructorMock).toHaveBeenCalledTimes(1);
+    expect(sut.cliBuildCommand).toBe(cliBuildCommand);
+    expect(sut.targets).toBe(targets);
+    expect(sut.command).not.toBeEmptyString();
+    expect(sut.description).not.toBeEmptyString();
+    expect(sut.hidden).toBeTrue();
+    expect(sut.allowUnknownOptions).toBeTrue();
+  });
+
+  it('should return the command to watch a target when executed', () => {
+    // Given
+    const target = 'some-target';
+    const type = 'development';
+    const buildCommand = 'build';
+    const cliBuildCommand = {
+      generate: jest.fn(() => buildCommand),
+    };
+    const targets = {
+      getTarget: jest.fn(() => ({ name: target })),
+    };
+    let sut = null;
+    // When
+    sut = new CLISHWatchCommand(cliBuildCommand, targets);
+    sut.handle(target, null, { type });
+    // Then
+    expect(targets.getTarget).toHaveBeenCalledTimes(1);
+    expect(targets.getTarget).toHaveBeenCalledWith(target);
+    expect(cliBuildCommand.generate).toHaveBeenCalledTimes(1);
+    expect(cliBuildCommand.generate).toHaveBeenCalledWith({
+      target,
+      type,
+      watch: true,
+    });
+    expect(sut.output).toHaveBeenCalledTimes(1);
+    expect(sut.output).toHaveBeenCalledWith(buildCommand);
+  });
+
+  it('should return the command to watch a target when executed and include unkown options', () => {
+    // Given
+    const target = 'some-target';
+    const type = 'development';
+    const buildCommand = 'build';
+    const cliBuildCommand = {
+      generate: jest.fn(() => buildCommand),
+    };
+    const targets = {
+      getTarget: jest.fn(() => ({ name: target })),
+    };
+    const unknownOptName = 'name';
+    const unknownOptValue = 'Rosario';
+    const unknownOptions = {
+      target: 'someTarget',
+      [unknownOptName]: unknownOptValue,
+    };
+    let sut = null;
+    // When
+    sut = new CLISHWatchCommand(cliBuildCommand, targets);
+    sut.handle(target, null, { type }, unknownOptions);
+    // Then
+    expect(targets.getTarget).toHaveBeenCalledTimes(1);
+    expect(targets.getTarget).toHaveBeenCalledWith(target);
+    expect(cliBuildCommand.generate).toHaveBeenCalledTimes(1);
+    expect(cliBuildCommand.generate).toHaveBeenCalledWith({
+      target,
+      type,
+      watch: true,
+      [unknownOptName]: unknownOptValue,
+    });
+    expect(sut.output).toHaveBeenCalledTimes(1);
+    expect(sut.output).toHaveBeenCalledWith(buildCommand);
+  });
+
+  it('should return the command to run the default target when executed', () => {
+    // Given
+    const target = 'some-target';
+    const type = 'development';
+    const buildCommand = 'build';
+    const cliBuildCommand = {
+      generate: jest.fn(() => buildCommand),
+    };
+    const targets = {
+      getDefaultTarget: jest.fn(() => ({ name: target })),
+    };
+    let sut = null;
+    // When
+    sut = new CLISHWatchCommand(cliBuildCommand, targets);
+    sut.handle(null, null, { type });
+    // Then
+    expect(targets.getDefaultTarget).toHaveBeenCalledTimes(1);
+    expect(cliBuildCommand.generate).toHaveBeenCalledTimes(1);
+    expect(cliBuildCommand.generate).toHaveBeenCalledWith({
+      target,
+      type,
+      watch: true,
+    });
+    expect(sut.output).toHaveBeenCalledTimes(1);
+    expect(sut.output).toHaveBeenCalledWith(buildCommand);
+  });
+
+  it('should include a provider for the DIC', () => {
+    // Given
+    let sut = null;
+    const container = {
+      set: jest.fn(),
+      get: jest.fn((service) => service),
+    };
+    let serviceName = null;
+    let serviceFn = null;
+    // When
+    cliSHWatchCommand(container);
+    [[serviceName, serviceFn]] = container.set.mock.calls;
+    sut = serviceFn();
+    // Then
+    expect(serviceName).toBe('cliSHWatchCommand');
+    expect(serviceFn).toBeFunction();
+    expect(sut).toBeInstanceOf(CLISHWatchCommand);
+    expect(sut.cliBuildCommand).toBe('cliBuildCommand');
+    expect(sut.targets).toBe('targets');
+  });
+});

--- a/tests/services/cli/cliWatch.test.js
+++ b/tests/services/cli/cliWatch.test.js
@@ -3,15 +3,15 @@ const CLICommandMock = require('/tests/mocks/cliCommand.mock');
 
 jest.mock('jimple', () => JimpleMock);
 jest.mock('/src/abstracts/cliCommand', () => CLICommandMock);
-jest.unmock('/src/services/cli/cliBuild');
+jest.unmock('/src/services/cli/cliWatch');
 
 require('jasmine-expect');
 const {
-  CLIBuildCommand,
-  cliBuildCommand,
-} = require('/src/services/cli/cliBuild');
+  CLIWatchCommand,
+  cliWatchCommand,
+} = require('/src/services/cli/cliWatch');
 
-describe('services/cli:build', () => {
+describe('services/cli:watch', () => {
   beforeEach(() => {
     CLICommandMock.reset();
   });
@@ -20,30 +20,18 @@ describe('services/cli:build', () => {
     // Given
     let sut = null;
     // When
-    sut = new CLIBuildCommand();
+    sut = new CLIWatchCommand();
     // Then
-    expect(sut).toBeInstanceOf(CLIBuildCommand);
+    expect(sut).toBeInstanceOf(CLIWatchCommand);
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.command).not.toBeEmptyString();
     expect(sut.description).not.toBeEmptyString();
-    expect(sut.addOption).toHaveBeenCalledTimes(3);
+    expect(sut.addOption).toHaveBeenCalledTimes(1);
     expect(sut.addOption).toHaveBeenCalledWith(
       'type',
       '-t, --type [type]',
       expect.any(String),
       'development'
-    );
-    expect(sut.addOption).toHaveBeenCalledWith(
-      'run',
-      '-r, --run',
-      expect.any(String),
-      false
-    );
-    expect(sut.addOption).toHaveBeenCalledWith(
-      'watch',
-      '-w, --watch',
-      expect.any(String),
-      false
     );
     expect(sut.allowUnknownOptions).toBeTrue();
   });
@@ -57,12 +45,12 @@ describe('services/cli:build', () => {
     let serviceName = null;
     let serviceFn = null;
     // When
-    cliBuildCommand(container);
+    cliWatchCommand(container);
     [[serviceName, serviceFn]] = container.set.mock.calls;
     sut = serviceFn();
     // Then
-    expect(serviceName).toBe('cliBuildCommand');
+    expect(serviceName).toBe('cliWatchCommand');
     expect(serviceFn).toBeFunction();
-    expect(sut).toBeInstanceOf(CLIBuildCommand);
+    expect(sut).toBeInstanceOf(CLIWatchCommand);
   });
 });


### PR DESCRIPTION
### What does this PR do?

It introduces the new _"watch mode"_... and fixes the implementation of `includeTargets` for the Node runner.

> This PR is super breaking for some of the CLI commands, so I'll try to describe each change as much as I can.

#### Watch mode

It all started with a new flag on the build command, `--watch/-w`; I updated the command service but I noticed that adding new flags was kind of a pain:

- All the methods on `cliSHBuildCommand` received an `args` dictionary to send directly to the other commands, and then the same arguments as parameters... not my best idea.
- All the methods were public, when there was no need for it.

So the first thing was to define a new `params` object to send to all the methods, similar to the `args` they were using, but with all the information, and if the method uses a `generate` from another command, the method itself should define the `args`.

And then I made all the methods `protected`.

Moving along... I added a new setting for both kind of targets, Node and browser:

```js
...
watch: {
  development: false,
  production: false,
}
...
```

This is like the `runOnDevelopment`, it triggers the watch mode when the user builds and if the target won't run.

I added a new `watch` command to work like `run`, which internally calls `build` with the flag.

Finally (or so I thought), I added a new parameter to the build engine `getCommand` method: `forceWatch=false`. So the webpack and Rollup plugins can take care of watching a target.

I tested it with an alpha version of the plugins and everything worked as expected... and then it happened.

#### `includeTargets` for the Node runnner... and watcher

After I got it working with the bundling plugins, I realized that if the target wasn't being bundled, I needed a watcher with transpilation.

I took the Node runner as example and implemented `watchpack` directly, but then I noticed that if the target had `includeTargets`, I needed to copy and/or transpile their files too... something the Node runner should've been doing al along, but it wasn't.

That's when the refactoring started... I changed everything on the Node runner that wasn't related to `nodemon`:

First, I created a new abstract class called `NodeWatcher`. A helper that services that the runner or the watcher (which I was also working on) can extend and it would take care of watching files, deciding whether they needed to be transpiled or copied and call the necessary methods so the services themselves will handle the messages and the copying and transpiling functionality.

The runner now validates a few extra things before executing a target (remember that the runner is only for development):

- No matter if the target requires trasnspilation or not, it can't include a target that requires bundling.
- If the target doesn't require transpilation, it can only include targets that don't require transpilation. This is because in this case, the target is executed from its source directory, but if it includes a target that requires transpilation, that target would be on the distribution directory, and the relative paths would break.

> The commands that copy and transpile files were also updated to implement `includeTargets`

The signature and options of the runner (`buildNodeRunnerProcess`) changed completely: It now only requires the directories `nodemon` will watch and the path to the executable.

You can also send _"transpilation paths"_ and _"copy paths"_, in order to enable the watching of source files. Both kind of paths are lists of dictionaries with the following format:

```js
{
  from: '/source/path',
  to: '/distribution/path',
},
```

> In the case of the runner, the _"copy paths"_ are only used if _"transpilation paths"_ have at least one item, because that means that the target being executed requires tanspilation, and the code will be on the distribution directory, where other targets can be copied into. If the target doesn't require transpilation, because the runner only works for development, the target will be executed from the source directory, and there won't be any need to copy/transpile other targets.

The runner will make a list of all the `from` properties from both list and enable the watching of the parent class (`NodeWatcher`). When the parent class detects a change on a file, it will try to match the file path to the `from` of one of those list, and depending the one that matched, call `_transpileFile` or `_copyFile` on the service.

> The abstract class doesn't do the transpilation and the copying automatically in order to avoid specific `if`s (since the runner and the watcher show different messages) and injecting building services when the idea is for it to be kind of generic.

Ok, last thing to do: I created `buildNodeWatcher` (for the validations) and `buildNodeWatcherProcess` (to actually watch the files and extend `NodeWatcher`) with just the methods to transpile, copy and show information messages.

Similar to the runner, the watcher also has a validation: No matter if the target requires trasnspilation or not, it can't include a target that requires bundling.

### How should it be tested manually?

With a lot of patience...

Now, this can only be tested with Node targets that don't require bundling, as that functionality is going to be added on the plugins.

Also, you can't use the `projext-plugin-runner` yet, it also needs to be updated.

1. Try `projext watch [target]`
2. Try `projext build [target] --watch`
3. Try the runner validations.
4. Try the watcher validations.

And of course...

```bash
npm test
# or
yarn test
```
