### PR TITLE
New target setting: uglifyOnProduction

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -95,6 +95,7 @@ Since there are a lot of settings for the templates, will divide them by type an
   includeModules: [],
   excludeModules: [],
   includeTargets: [],
+  uglifyOnProduction: true,
   runOnDevelopment: false,
   watch: { ... },
   babel: { ... },
@@ -228,6 +229,13 @@ For example, you have two targets, let's call them `frontend` and `backend`, tha
 
 You have two possible solutions now, thanks to `includeTargets`: You can either add the other target name on each `includeTargets` setting, or define a third `shared` target that both have on the setting.
 
+#### `uglifyOnProduction`
+> Default value: `true`
+
+When a bundle is created, this setting will tell the build engine whether to uglify the code for production or not.
+
+This can be useful for debugging production code.
+
 #### `runOnDevelopment`
 > Default value: `false`
 
@@ -336,6 +344,7 @@ This is different from the main `copy` feature as this is specific to targets an
   css: { ... },
   includeModules: [],
   includeTargets: [],
+  uglifyOnProduction: true,
   runOnDevelopment: false,
   watch: { ... },
   babel: { ... },
@@ -493,6 +502,13 @@ This setting can be used to specify a list of other targets you want to process 
 For example, you have two targets, let's call them `frontend` and `backend`, that share some functionality and which code needs to be transpiled/processed. Since projext define the paths for transpilation/processing to match each target's directory, the wouldn't be able to use shared code between each other.
 
 You have two possible solutions now, thanks to `includeTargets`: You can either add the other target name on each `includeTargets` setting, or define a third `shared` target that both have on the setting.
+
+#### `uglifyOnProduction`
+> Default value: `true`
+
+When a bundle is created, this setting will tell the build engine whether to uglify the code for production or not.
+
+This can be useful for debugging production code.
 
 #### `runOnDevelopment`
 > Default value: `false`

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -92,6 +92,7 @@ class ProjectConfiguration extends ConfigurationFile {
           includeModules: [],
           excludeModules: [],
           includeTargets: [],
+          uglifyOnProduction: true,
           runOnDevelopment: false,
           watch: {
             development: false,
@@ -151,6 +152,7 @@ class ProjectConfiguration extends ConfigurationFile {
           },
           includeModules: [],
           includeTargets: [],
+          uglifyOnProduction: true,
           runOnDevelopment: false,
           watch: {
             development: false,

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -408,6 +408,9 @@
  * @property {Array} [includeTargets=[]]
  * This setting can be used to specify a list of other targets you want to process on your bundle.
  * This means that JS and SCSS files from these targets will be transpiled/processed.
+ * @property {boolean} [uglifyOnProduction=true]
+ * When a bundle is created, this setting will tell the build engine whether to uglify the code
+ * for production or not.
  * @property {boolean} [runOnDevelopment=false]
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
@@ -476,6 +479,9 @@
  * @property {Array} includeTargets
  * This setting can be used to specify a list of other targets you want to process on your bundle.
  * This means that JS and SCSS files from these targets will be transpiled/processed.
+ * @property {boolean} uglifyOnProduction
+ * When a bundle is created, this setting will tell the build engine whether to uglify the code
+ * for production or not.
  * @property {boolean} runOnDevelopment
  * This tells projext that when the target is builded (bundled/copied) on a development
  * environment, it should execute it.
@@ -547,6 +553,9 @@
  * @property {Array} [includeTargets=[]]
  * This setting can be used to specify a list of other targets you want to process on your bundle.
  * This means that JS and SCSS files from these targets will be transpiled/processed.
+ * @property {boolean} [uglifyOnProduction=true]
+ * When a bundle is created, this setting will tell the build engine whether to uglify the code
+ * for production or not.
  * @property {boolean} [runOnDevelopment=false]
  * This will tell the build engine that when you build the target for a development environment,
  * it should bring up an `http` server to _"run"_ your target.
@@ -611,6 +620,9 @@
  * @property {Array} includeTargets
  * This setting can be used to specify a list of other targets you want to process on your bundle.
  * This means that JS and SCSS files from these targets will be transpiled/processed.
+ * @property {boolean} uglifyOnProduction
+ * When a bundle is created, this setting will tell the build engine whether to uglify the code
+ * for production or not.
  * @property {boolean} runOnDevelopment
  * This will tell the build engine that when you build the target for a development environment,
  * it should bring up an `http` server to _"run"_ your target.


### PR DESCRIPTION
### What does this PR do?

This PR documents a new target setting: `uglifyOnProduction` (`boolean`).

The idea is for the developers to be able to disable the uglification on a really simple way if they need to debug some production code.

The PR by itself just documents the setting, the real implementation will be done by the build engine plugins.

### How should it be tested manually?

Read, and if you are bored...

```bash
npm test
# or
yarn test
```
