### PR TITLE
Update unit tests

### DIFF
--- a/src/services/targets/targets.js
+++ b/src/services/targets/targets.js
@@ -453,16 +453,12 @@ class Targets {
     const newOutput = Object.assign({}, target.output);
     Object.keys(newOutput).forEach((name) => {
       const value = newOutput[name];
-      if (typeof value === 'string') {
-        newOutput[name] = this.utils.replacePlaceholders(value, placeholders);
-      } else if (value) {
-        Object.keys(value).forEach((propName) => {
-          newOutput[name][propName] = this.utils.replacePlaceholders(
-            newOutput[name][propName],
-            placeholders
-          );
-        });
-      }
+      Object.keys(value).forEach((propName) => {
+        newOutput[name][propName] = this.utils.replacePlaceholders(
+          newOutput[name][propName],
+          placeholders
+        );
+      });
     });
 
     return newOutput;

--- a/src/services/targets/targetsFinder.js
+++ b/src/services/targets/targetsFinder.js
@@ -433,10 +433,8 @@ class TargetsFinder {
           const [, extract] = match;
           // Normalize the extracted text.
           const normalized = extract.toLowerCase().trim();
-          // If it's not on the list, add it.
-          if (!items.includes(normalized)) {
-            items.push(normalized);
-          }
+          // Add it to the list.
+          items.push(normalized);
           // Continue the execution loop.
           match = regex.exec(contents);
         }

--- a/tests/services/building/buildCopier.test.js
+++ b/tests/services/building/buildCopier.test.js
@@ -342,6 +342,7 @@ describe('services/building:buildCopier', () => {
       devDependencies: {
         [developmentDependency]: 'latest',
       },
+      _ignoredProperty: 'true',
     }));
     fs.readJson.mockImplementationOnce(() => Promise.resolve({
       dependencies: {


### PR DESCRIPTION
### What does this PR do?

After #60, the new version of Jest (of Istanbul, to be exact) found a couple of lines that weren't being tested:

- `target.js`: The method `_replaceTargetOutputPlaceholders` was still supporting an `output` object with `string` values (like it was on the first version of `projext`), but that can't happen anymore, so I just removed it and the method now assumes that `output` is an object of objects.
- `targetsFinder.js`: When reading the imports and exports, the `_extractFromCode` method checking the paths to avoid adding the same twice, but since all the implementations of that method end up on a call to `.includes`, it was impossible to test... without creating a weird test case with a duplicated import/export and no special `expect`. I removed the check and it now adds them even if they're already on the list.
- `buildCopier.js`: The method `addPrivateModules`, when reading a `package.json` of a private module, it removes the NPM private properties (prefixed with `_`). The issue is that there was no test case that included private properties, so I just added one property on one of the existing cases.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
