### PR TITLE
Code splitting

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -13,7 +13,8 @@
               "./documents/overwrite.md",
               "./documents/plugins.md",
               "./documents/engines.md",
-              "./documents/browserTargetConfiguration.md"
+              "./documents/browserTargetConfiguration.md",
+              "./documents/codeSplitting.md"
             ]
           }
         }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - "8.11"
+  - "10.15"
 after_success:
   - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'

--- a/README-esdoc.md
+++ b/README-esdoc.md
@@ -208,7 +208,6 @@ When you try to bundle a Node target for development, if you didn't change the s
 
 Now, Node targets have two special settings: `bundle` and `transpile`. With `bundle` you can specify whether you want to bundle the entire code on a single file or not; and with `transpile` you can tell projext to just transpile the files content using Babel but keeping all the files.
 
-
 ## Other features
 
 ### Running the targets

--- a/README-esdoc.md
+++ b/README-esdoc.md
@@ -114,7 +114,7 @@ This is aimed to those who use bundlers everyday to build web sites, libraries a
 |--------------|-------------------------------------------------------------------------------|
 | Package      | projext                                                                       |
 | Description  | Bundle your Javascript projects without having to learn how to use a bundler. |
-| Node Version | >= v6.10.0                                                                    |
+| Node Version | >= v8.0.0                                                                    |
 
 ## Usage
 

--- a/README-esdoc.md
+++ b/README-esdoc.md
@@ -281,19 +281,19 @@ Before doing anything, install the repository hooks:
 
 ```bash
 # You can either use npm or yarn, it doesn't matter
-npm run install-hooks
+yarn run hooks
 ```
 
 ### NPM/Yarn Tasks
 
 | Task                    | Description                         |
 |-------------------------|-------------------------------------|
-| `npm run install-hooks` | Install the GIT repository hooks.   |
-| `npm test`              | Run the project unit tests.         |
-| `npm run lint`          | Lint the modified files.            |
-| `npm run lint:full`     | Lint the project code.              |
-| `npm run docs`          | Generate the project documentation. |
-| `npm run todo`          | List all the pending to-do's.       |
+| `yarn run hooks`        | Install the GIT repository hooks.   |
+| `yarn test`             | Run the project unit tests.         |
+| `yarn run lint`         | Lint the modified files.            |
+| `yarn run lint:full`    | Lint the project code.              |
+| `yarn run docs`         | Generate the project documentation. |
+| `yarn run todo`         | List all the pending to-do's.       |
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ When you try to bundle a Node target for development, if you didn't change the s
 
 Now, Node targets have two special settings: `bundle` and `transpile`. With `bundle` you can specify whether you want to bundle the entire code on a single file or not; and with `transpile` you can tell projext to just transpile the files content using Babel but keeping all the files.
 
-
 ## Other features
 
 ### Running the targets

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This is aimed to those who use bundlers everyday to build web sites, libraries a
 |--------------|-------------------------------------------------------------------------------|
 | Package      | projext                                                                       |
 | Description  | Bundle your Javascript projects without having to learn how to use a bundler. |
-| Node Version | >= v6.10.0                                                                    |
+| Node Version | >= v8.0.0                                                                    |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -281,19 +281,19 @@ Before doing anything, install the repository hooks:
 
 ```bash
 # You can either use npm or yarn, it doesn't matter
-npm run install-hooks
+yarn run hooks
 ```
 
 ### NPM/Yarn Tasks
 
 | Task                    | Description                         |
 |-------------------------|-------------------------------------|
-| `npm run install-hooks` | Install the GIT repository hooks.   |
-| `npm test`              | Run the project unit tests.         |
-| `npm run lint`          | Lint the modified files.            |
-| `npm run lint:full`     | Lint the project code.              |
-| `npm run docs`          | Generate the project documentation. |
-| `npm run todo`          | List all the pending to-do's.       |
+| `yarn run hooks`        | Install the GIT repository hooks.   |
+| `yarn test`             | Run the project unit tests.         |
+| `yarn run lint`         | Lint the modified files.            |
+| `yarn run lint:full`    | Lint the project code.              |
+| `yarn run docs`         | Generate the project documentation. |
+| `yarn run todo`         | List all the pending to-do's.       |
 
 ### Testing
 

--- a/documents/codeSplitting.md
+++ b/documents/codeSplitting.md
@@ -1,0 +1,95 @@
+# Code splitting
+
+This feature allows you to split your bundles on smaller pieces and then load those pieces when you need them (basically, _"lazy loading"_ parts of your bundle).
+
+Let's say you are building an application with an admin panel, you could use code splitting for the route/module that handles the admin panel and only load it if the user goes to an `/admin` route. Doing something like this will make the initial load and the initialization of the app faster, providing a better experience for the user.
+
+
+## How does it work?
+
+Instead of importing a file on the top of your file, you use `import` as a function and wait for a `Promise` with the module's content to be resolved.
+
+Using the same example as above, here's some code to better understand it: You have a module that exports a function that will return a component for a given route:
+
+```js
+import Home from './components/home';
+import Admin from './components/admin';
+
+const getComponentForRoute = (route) => {
+  switch(route) {
+  case '/admin':
+    return Admin;
+  default:
+    return Home;
+  }
+};
+
+export default getComponentForRoute;
+```
+
+Easy enough, if the route is `/admin`, you return the admin panel component, which was imported at the top.
+
+Let's switch it a little bit in order to import the admin panel only when the user goes to `/admin`, thus, splitting it on different bundle:
+
+```js
+import Home from './components/home';
+
+const getComponentForRoute = (route) => {
+  switch(route) {
+  case '/admin':
+    return import('./components/admin');
+  default:
+    return Promise.resolve(Home);
+  }
+};
+
+export default getComponentForRoute;
+```
+
+There are 3 changes here:
+
+1. The `import` for the admin component is not longer on the top.
+2. The `case` for `/admin` now returns a call to the `import` function.
+3. The default `case` returns `Home` on an already resolved `Promise`.
+
+First and second go together: By using the `import` function instead of doing the regular `import` declaration, we tell the bundle engine that we don't need that file right now, but that it will be required later, so the engine will create a smaller bundle with that code.
+
+Third, why do we return `Home` on a `Promise`? Well, the `import` function returns a promise as the other bundle is loaded asynchronously, we should try to keep a consistent signature for the function, so the part of the app that implements it won't need to know whether the component was loaded from this bundle or a different one.
+
+## How to use it with projext
+
+Adding code splitting to your targets is really simple, you just need to define a `jsChunks` (_"chunks"_ are the smaller bundles with the code that will be lazy loaded) with a value of `true` on you target output settings:
+
+```js
+...
+output: {
+  default: {
+    ...
+    jsChunks: true,
+  },
+  ...
+}
+```
+
+In the example above, you define it on the `default` so both `production` and `development` will inherit it.
+
+This will tell the bundle engine to use code splitting and that the chunks should be on the same directory as the main bundle and that the name format will be `[original-bundle-name].[chunk-name].js`.
+
+You can also set `jsChunks` as a string and send a path and name format for your chunks:
+
+```js
+...
+output: {
+  default: {
+    ...
+    jsChunks: 'statics/js/[target-name].[hash].[name].js',
+  },
+  ...
+}
+```
+
+The special placeholder there is `[name]`, which will be replaced with the chunk name, decided by the bundle engine.
+
+That's all, enable `jsChunks` and enjoy code splitting!
+
+> Currently, the webpack bundle engine will enable code splitting by default (you can even use the special `webpackChunkName` comment to set a name for it) but other engines still need the property in order to make it work. So, if you are using webpack as an engine, you can still enjoy zero configuration and take advantage of this feature.

--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -290,8 +290,9 @@ Using this flags, you can tell projext to always watch your files when building 
 >
 > ```js
 > {
->   features: [],
->   defaultFeatures: {
+>   features: {
+>     classProperties: false,
+>     decorators: false,
 >     dynamicImports: true,
 >   },
 >   nodeVersion: 'current',
@@ -303,15 +304,13 @@ These options are used in the case the target needs to be bundled or transpile t
 
 **`babel.features`**
 
-projext includes by default two Babel plugins: [`@babel/plugin-proposal-class-properties`](https://yarnpkg.com/en/package/@babel/plugin-proposal-class-properties) and [`@babel/plugin-proposal-decorators`](https://yarnpkg.com/en/package/@babel/plugin-proposal-decorators). On this list you can use the values `properties` or `decorators` to include them.
+This object can be used to enable/disable the Babel plugins projext includes:
+
+- `classProperties` (disabled): [`@babel/plugin-proposal-class-properties`](https://yarnpkg.com/en/package/@babel/plugin-proposal-class-properties).
+- `decorators` (disabled): [`@babel/plugin-proposal-decorators`](https://yarnpkg.com/en/package/@babel/plugin-proposal-decorators).
+- `dynamicImports` (enabled): [`@babel/plugin-syntax-dynamic-import`](https://yarnpkg.com/en/package/@babel/plugin-syntax-dynamic-import).
 
 If you need other plugins, they can be included on the `overwrites` option.
-
-**`babel.defaultFeatures`**
-
-This is a dictionary where you can turn off any of the default Babel plugins projext enables by default:
-
-- `dynamicImports`: This enables `@babel/plugin-syntax-dynamic-import` so a target can do dynamic imports and code splitting.
 
 **`babel.nodeVersion`**
 
@@ -571,8 +570,9 @@ Using this flags, you can tell projext to always watch your files when building 
 >
 > ```js
 > {
->   features: [],
->   defaultFeatures: {
+>   features: {
+>     classProperties: false,
+>     decorators: false,
 >     dynamicImports: true,
 >   },
 >   browserVersions: 2,
@@ -586,15 +586,13 @@ These options are used by the build engine to configure [Babel](https://babeljs.
 
 **`babel.features`**
 
-projext includes by default two Babel plugins: [`@babel/plugin-proposal-class-properties`](https://yarnpkg.com/en/package/@babel/plugin-proposal-class-properties) and [`@babel/plugin-proposal-decorators`](https://yarnpkg.com/en/package/@babel/plugin-proposal-decorators). On this list you can use the values `properties` or `decorators` to include them.
+This object can be used to enable/disable the Babel plugins projext includes:
+
+- `classProperties` (disabled): [`@babel/plugin-proposal-class-properties`](https://yarnpkg.com/en/package/@babel/plugin-proposal-class-properties).
+- `decorators` (disabled): [`@babel/plugin-proposal-decorators`](https://yarnpkg.com/en/package/@babel/plugin-proposal-decorators).
+- `dynamicImports` (enabled): [`@babel/plugin-syntax-dynamic-import`](https://yarnpkg.com/en/package/@babel/plugin-syntax-dynamic-import).
 
 If you need other plugins, they can be included on the `overwrites` option.
-
-**`babel.defaultFeatures`**
-
-This is a dictionary where you can turn off any of the default Babel plugins projext enables by default:
-
-- `dynamicImports`: This enables `@babel/plugin-syntax-dynamic-import` so a target can do dynamic imports and code splitting.
 
 **`babel.browserVersions`**
 

--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -193,7 +193,7 @@ You can use the following placeholders:
 
 #### `inspect`
 > Default value:
-> 
+>
 > ```js
 > {
 >   enabled: false,
@@ -291,6 +291,9 @@ Using this flags, you can tell projext to always watch your files when building 
 > ```js
 > {
 >   features: [],
+>   defaultFeatures: {
+>     dynamicImports: true,
+>   },
 >   nodeVersion: 'current',
 >   overwrites: {},
 > }
@@ -300,13 +303,19 @@ These options are used in the case the target needs to be bundled or transpile t
 
 **`babel.features`**
 
-projext includes by default two Babel plugins: [`transform-class-properties`](https://yarnpkg.com/en/package/babel-plugin-transform-class-properties) and [`transform-decorators-legacy`](https://yarnpkg.com/en/package/babel-plugin-transform-decorators-legacy). On this list you can use the values `properties` or `decorators` to include them.
+projext includes by default two Babel plugins: [`@babel/plugin-proposal-class-properties`](https://yarnpkg.com/en/package/@babel/plugin-proposal-class-properties) and [`@babel/plugin-proposal-decorators`](https://yarnpkg.com/en/package/@babel/plugin-proposal-decorators). On this list you can use the values `properties` or `decorators` to include them.
 
 If you need other plugins, they can be included on the `overwrites` option.
 
+**`babel.defaultFeatures`**
+
+This is a dictionary where you can turn off any of the default Babel plugins projext enables by default:
+
+- `dynamicImports`: This enables `@babel/plugin-syntax-dynamic-import` so a target can do dynamic imports and code splitting.
+
 **`babel.nodeVersion`**
 
-When building the Babel configuration, projext uses the [`babel-preset-env`](https://yarnpkg.com/en/package/babel-preset-env) to just include the necessary stuff. This setting tells the preset the version of Node it should _"complete"_.
+When building the Babel configuration, projext uses the [`@babel/preset-env`](https://yarnpkg.com/en/package/@babel/preset-env) to just include the necessary stuff. This setting tells the preset the version of Node it should _"complete"_.
 
 **`babel.overwrites`**
 
@@ -563,6 +572,9 @@ Using this flags, you can tell projext to always watch your files when building 
 > ```js
 > {
 >   features: [],
+>   defaultFeatures: {
+>     dynamicImports: true,
+>   },
 >   browserVersions: 2,
 >   mobileSupport: true,
 >   polyfill: true,
@@ -574,13 +586,19 @@ These options are used by the build engine to configure [Babel](https://babeljs.
 
 **`babel.features`**
 
-projext includes by default two Babel plugins: [`transform-class-properties`](https://yarnpkg.com/en/package/babel-plugin-transform-class-properties) and [`transform-decorators-legacy`](https://yarnpkg.com/en/package/babel-plugin-transform-decorators-legacy). On this list you can use the values `properties` or `decorators` to include them.
+projext includes by default two Babel plugins: [`@babel/plugin-proposal-class-properties`](https://yarnpkg.com/en/package/@babel/plugin-proposal-class-properties) and [`@babel/plugin-proposal-decorators`](https://yarnpkg.com/en/package/@babel/plugin-proposal-decorators). On this list you can use the values `properties` or `decorators` to include them.
 
 If you need other plugins, they can be included on the `overwrites` option.
 
+**`babel.defaultFeatures`**
+
+This is a dictionary where you can turn off any of the default Babel plugins projext enables by default:
+
+- `dynamicImports`: This enables `@babel/plugin-syntax-dynamic-import` so a target can do dynamic imports and code splitting.
+
 **`babel.browserVersions`**
 
-When building the Babel configuration, projext uses the [`babel-preset-env`](https://yarnpkg.com/en/package/babel-preset-env) to just include the necessary stuff. This setting tells how many old versions of the major browsers the target needs transpilation for.
+When building the Babel configuration, projext uses the [`@babel/preset-env`](https://yarnpkg.com/en/package/@babel/preset-env) to just include the necessary stuff. This setting tells how many old versions of the major browsers the target needs transpilation for.
 
 > Major browsers: Firefox, Chrome, Safari and Edge.
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
       "@babel/cli": "7.2.3",
       "@babel/plugin-proposal-class-properties": "7.3.0",
       "@babel/plugin-proposal-decorators": "7.3.0",
+      "@babel/plugin-syntax-dynamic-import": "7.2.0",
       "@babel/plugin-transform-runtime": "7.2.0",
       "@babel/polyfill": "7.2.5",
       "@babel/preset-flow": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "projext-cli": "./src/bin/projext-cli"
     },
     "scripts": {
-      "install-hooks": "./utils/hooks/install",
+      "hooks": "./utils/hooks/install",
       "test": "./utils/scripts/test",
       "lint": "./utils/scripts/lint",
       "lint:full": "./utils/scripts/lint-full",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",
     "dependencies": {
-      "wootils": "^1.4.0",
+      "wootils": "^2.0.0",
       "jimple": "1.5.0",
       "fs-extra": "7.0.1",
       "extend": "3.0.2",

--- a/src/services/configurations/babelConfiguration.js
+++ b/src/services/configurations/babelConfiguration.js
@@ -20,6 +20,7 @@ class BabelConfiguration {
     this.plugins = {
       properties: '@babel/plugin-proposal-class-properties',
       decorators: '@babel/plugin-proposal-decorators',
+      dynamicImports: '@babel/plugin-syntax-dynamic-import',
     };
   }
   /**
@@ -34,6 +35,7 @@ class BabelConfiguration {
     const {
       babel: {
         features,
+        defaultFeatures,
         nodeVersion,
         browserVersions,
         mobileSupport,
@@ -71,6 +73,17 @@ class BabelConfiguration {
       // Push the new `env` preset on top of the list.
       presets.unshift([envPresetName, { targets: presetTargets }]);
     }
+
+    // Check for the default _"features"_.
+    Object.keys(defaultFeatures).forEach((feature) => {
+      if (defaultFeatures[feature]) {
+        const featurePlugin = this.plugins[feature];
+        if (!plugins.includes(featurePlugin)) {
+          plugins.push(featurePlugin);
+        }
+      }
+    });
+
     // Check if the configuration should include any _'known plugin'_.
     features.forEach((feature) => {
       const featurePlugin = this.plugins[feature];

--- a/src/services/configurations/babelConfiguration.js
+++ b/src/services/configurations/babelConfiguration.js
@@ -18,7 +18,7 @@ class BabelConfiguration {
      * @type {Object}
      */
     this.plugins = {
-      properties: '@babel/plugin-proposal-class-properties',
+      classProperties: '@babel/plugin-proposal-class-properties',
       decorators: '@babel/plugin-proposal-decorators',
       dynamicImports: '@babel/plugin-syntax-dynamic-import',
     };
@@ -89,8 +89,8 @@ class BabelConfiguration {
      */
     if (flow) {
       presets.push(['@babel/preset-flow']);
-      if (!plugins.includes(this.plugins.properties)) {
-        plugins.push(this.plugins.properties);
+      if (!plugins.includes(this.plugins.classProperties)) {
+        plugins.push(this.plugins.classProperties);
       }
     }
 

--- a/src/services/configurations/babelConfiguration.js
+++ b/src/services/configurations/babelConfiguration.js
@@ -35,7 +35,6 @@ class BabelConfiguration {
     const {
       babel: {
         features,
-        defaultFeatures,
         nodeVersion,
         browserVersions,
         mobileSupport,
@@ -74,21 +73,13 @@ class BabelConfiguration {
       presets.unshift([envPresetName, { targets: presetTargets }]);
     }
 
-    // Check for the default _"features"_.
-    Object.keys(defaultFeatures).forEach((feature) => {
-      if (defaultFeatures[feature]) {
+    // Check if the configuration should include any _'known plugin'_.
+    Object.keys(features).forEach((feature) => {
+      if (features[feature] && this.plugins[feature]) {
         const featurePlugin = this.plugins[feature];
         if (!plugins.includes(featurePlugin)) {
           plugins.push(featurePlugin);
         }
-      }
-    });
-
-    // Check if the configuration should include any _'known plugin'_.
-    features.forEach((feature) => {
-      const featurePlugin = this.plugins[feature];
-      if (!plugins.includes(featurePlugin)) {
-        plugins.push(featurePlugin);
       }
     });
 

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -105,8 +105,9 @@ class ProjectConfiguration extends ConfigurationFile {
             production: false,
           },
           babel: {
-            features: [],
-            defaultFeatures: {
+            features: {
+              classProperties: false,
+              decorators: false,
               dynamicImports: true,
             },
             nodeVersion: 'current',
@@ -168,8 +169,9 @@ class ProjectConfiguration extends ConfigurationFile {
             production: false,
           },
           babel: {
-            features: [],
-            defaultFeatures: {
+            features: {
+              classProperties: false,
+              decorators: false,
               dynamicImports: true,
             },
             browserVersions: 2,

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -106,6 +106,9 @@ class ProjectConfiguration extends ConfigurationFile {
           },
           babel: {
             features: [],
+            defaultFeatures: {
+              dynamicImports: true,
+            },
             nodeVersion: 'current',
             overwrites: {},
           },
@@ -166,6 +169,9 @@ class ProjectConfiguration extends ConfigurationFile {
           },
           babel: {
             features: [],
+            defaultFeatures: {
+              dynamicImports: true,
+            },
             browserVersions: 2,
             mobileSupport: true,
             polyfill: true,

--- a/src/services/targets/targets.js
+++ b/src/services/targets/targets.js
@@ -454,10 +454,13 @@ class Targets {
     Object.keys(newOutput).forEach((name) => {
       const value = newOutput[name];
       Object.keys(value).forEach((propName) => {
-        newOutput[name][propName] = this.utils.replacePlaceholders(
-          newOutput[name][propName],
-          placeholders
-        );
+        const propValue = newOutput[name][propName];
+        newOutput[name][propName] = typeof propValue === 'string' ?
+          this.utils.replacePlaceholders(
+            propValue,
+            placeholders
+          ) :
+          propValue;
       });
     });
 

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -205,7 +205,13 @@
  */
 
 /**
- * @typedef {Object} ProjectConfigurationTargetTemplateBabelDefaultFeatures
+ * @typedef {Object} ProjectConfigurationTargetTemplateBabelFeatures
+ * @property {boolean} [classProperties=false]
+ * This enables `@babel/plugin-proposal-class-properties` so the targets can use classes with
+ * properties.
+ * @property {boolean} [decorators=false]
+ * This enables `@babel/plugin-proposal-decorators` so the targets can use decorators (based on
+ * the current TC39 proposal).
  * @property {boolean} [dynamicImports=true]
  * This enables `@babel/plugin-syntax-dynamic-import` so the targets can do dynamic imports and
  * code splitting.
@@ -219,13 +225,9 @@
 
 /**
  * @typedef {Object} ProjectConfigurationNodeTargetTemplateBabelSettings
- * @property {Array} [features=[]]
- * projext includes by default two Babel plugins: `@babel/plugin-proposal-class-properties` and
- * `@babel/plugin-proposal-decorators`. On this list you can use the values `properties` or
- * `decorators` to include them.
+ * @property {ProjectConfigurationTargetTemplateBabelFeatures} [features]
+ * This object can be used to enable/disable the Babel plugins projext includes.
  * If you need other plugins, they can be included on the `overwrites` option.
- * @property {ProjectConfigurationTargetTemplateBabelDefaultFeatures} [defaultFeatures]
- * A dictionary where you can turn off any of the default Babel plugins projext enables by default.
  * @property {string} [nodeVersion='current']
  * When building the Babel configuration, projext uses the `babel-preset-env` to just include the
  * necessary stuff. This setting tells the preset the version of Node it should _"complete"_.
@@ -302,13 +304,9 @@
 
 /**
  * @typedef {Object} ProjectConfigurationBrowserTargetTemplateBabelSettings
- * @property {Array} [features=[]]
- * projext includes by default two Babel plugins: `@babel/plugin-proposal-class-properties` and
- * `@babel/plugin-proposal-decorators`. On this list you can use the values `properties` or
- * `decorators` to include them.
+ * @property {ProjectConfigurationTargetTemplateBabelFeatures} [features]
+ * This object can be used to enable/disable the Babel plugins projext includes.
  * If you need other plugins, they can be included on the `overwrites` option.
- * @property {ProjectConfigurationTargetTemplateBabelDefaultFeatures} [defaultFeatures]
- * A dictionary where you can turn off any of the default Babel plugins projext enables by default.
  * @property {number} [browserVersions=2]
  * When building the Babel configuration, projext uses the `babel-preset-env` to just include the
  * necessary stuff. This setting tells how many old versions of the major browsers the target needs
@@ -450,7 +448,7 @@
  * The target transpilation options.
  * @property {boolean} [flow=false]
  * Whether or not your target uses [flow](https://flow.org/). This will update the Babel
- * configuration in order to add support and, in case it was disabled, it will enable transpilation.
+ * configuration in order to add support and, in case it was disabled, enable transpilation.
  * @property {boolean} [library=false]
  * If the project is bundled, this will tell the build engine that it needs to be builded as a
  * library to be `require`d.
@@ -520,7 +518,7 @@
  * The target transpilation options.
  * @property {boolean} flow
  * Whether or not your target uses [flow](https://flow.org/). This will update the Babel
- * configuration in order to add support and, in case it was disabled, it will enable transpilation.
+ * configuration in order to add support and, in case it was disabled, enable transpilation.
  * @property {boolean} library
  * If the project is bundled, this will tell the build engine that it needs to be builded as a
  * library to be `require`d.

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -205,6 +205,13 @@
  */
 
 /**
+ * @typedef {Object} ProjectConfigurationTargetTemplateBabelDefaultFeatures
+ * @property {boolean} [dynamicImports=true]
+ * This enables `@babel/plugin-syntax-dynamic-import` so the targets can do dynamic imports and
+ * code splitting.
+ */
+
+/**
  * ================================================================================================
  * Project configuration > Targets templates > Sub properties > Node
  * ================================================================================================
@@ -217,6 +224,8 @@
  * `@babel/plugin-proposal-decorators`. On this list you can use the values `properties` or
  * `decorators` to include them.
  * If you need other plugins, they can be included on the `overwrites` option.
+ * @property {ProjectConfigurationTargetTemplateBabelDefaultFeatures} [defaultFeatures]
+ * A dictionary where you can turn off any of the default Babel plugins projext enables by default.
  * @property {string} [nodeVersion='current']
  * When building the Babel configuration, projext uses the `babel-preset-env` to just include the
  * necessary stuff. This setting tells the preset the version of Node it should _"complete"_.
@@ -298,6 +307,8 @@
  * `@babel/plugin-proposal-decorators`. On this list you can use the values `properties` or
  * `decorators` to include them.
  * If you need other plugins, they can be included on the `overwrites` option.
+ * @property {ProjectConfigurationTargetTemplateBabelDefaultFeatures} [defaultFeatures]
+ * A dictionary where you can turn off any of the default Babel plugins projext enables by default.
  * @property {number} [browserVersions=2]
  * When building the Babel configuration, projext uses the `babel-preset-env` to just include the
  * necessary stuff. This setting tells how many old versions of the major browsers the target needs

--- a/tests/services/configurations/babelConfiguration.test.js
+++ b/tests/services/configurations/babelConfiguration.test.js
@@ -213,7 +213,7 @@ describe('services/configurations:babelConfiguration', () => {
         nodeVersion,
         features: {
           dynamicImports: false,
-          properties: true,
+          classProperties: true,
           unknownFeature: true,
         },
         overwrites: {},
@@ -342,7 +342,7 @@ describe('services/configurations:babelConfiguration', () => {
       babel: {
         nodeVersion,
         features: {
-          properties: true,
+          classProperties: true,
         },
       },
       flow: true,

--- a/tests/services/configurations/babelConfiguration.test.js
+++ b/tests/services/configurations/babelConfiguration.test.js
@@ -35,6 +35,7 @@ describe('services/configurations:babelConfiguration', () => {
       babel: {
         browserVersions,
         features: [],
+        defaultFeatures: {},
         mobileSupport: true,
         overwrites: {},
         polyfill: true,
@@ -84,6 +85,7 @@ describe('services/configurations:babelConfiguration', () => {
       babel: {
         browserVersions,
         features: [],
+        defaultFeatures: {},
         mobileSupport: false,
         overwrites: {},
       },
@@ -130,12 +132,144 @@ describe('services/configurations:babelConfiguration', () => {
       babel: {
         nodeVersion,
         features: [],
+        defaultFeatures: {},
         overwrites: {},
       },
       flow: false,
     };
     const expected = {
       plugins: [],
+      presets: [[
+        '@babel/preset-env',
+        {
+          targets: {
+            node: nodeVersion,
+          },
+        },
+      ]],
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new BabelConfiguration(events);
+    result = sut.getConfigForTarget(target);
+    // Then
+    expect(result).toEqual(expected);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(eventName, expected, target);
+  });
+
+  it('should create a Babel config and include the `dynamic imports` feature by default', () => {
+    // Given
+    const eventName = 'babel-configuration';
+    const events = {
+      reduce: jest.fn((name, config) => config),
+    };
+    const nodeVersion = 'current';
+    const target = {
+      is: {
+        browser: false,
+      },
+      babel: {
+        nodeVersion,
+        features: [],
+        defaultFeatures: {
+          dynamicImports: true,
+        },
+        overwrites: {},
+      },
+      flow: false,
+    };
+    const expected = {
+      plugins: ['@babel/plugin-syntax-dynamic-import'],
+      presets: [[
+        '@babel/preset-env',
+        {
+          targets: {
+            node: nodeVersion,
+          },
+        },
+      ]],
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new BabelConfiguration(events);
+    result = sut.getConfigForTarget(target);
+    // Then
+    expect(result).toEqual(expected);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(eventName, expected, target);
+  });
+
+  it('should create a Babel config and disable the `dynamic imports` feature by default', () => {
+    // Given
+    const eventName = 'babel-configuration';
+    const events = {
+      reduce: jest.fn((name, config) => config),
+    };
+    const nodeVersion = 'current';
+    const target = {
+      is: {
+        browser: false,
+      },
+      babel: {
+        nodeVersion,
+        features: [],
+        defaultFeatures: {
+          dynamicImports: false,
+        },
+        overwrites: {},
+      },
+      flow: false,
+    };
+    const expected = {
+      plugins: [],
+      presets: [[
+        '@babel/preset-env',
+        {
+          targets: {
+            node: nodeVersion,
+          },
+        },
+      ]],
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new BabelConfiguration(events);
+    result = sut.getConfigForTarget(target);
+    // Then
+    expect(result).toEqual(expected);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(eventName, expected, target);
+  });
+
+  it('should create a Babel config and avoid adding the `dynamic imports` feature twice', () => {
+    // Given
+    const eventName = 'babel-configuration';
+    const events = {
+      reduce: jest.fn((name, config) => config),
+    };
+    const nodeVersion = 'current';
+    const target = {
+      is: {
+        browser: false,
+      },
+      babel: {
+        nodeVersion,
+        features: [],
+        defaultFeatures: {
+          dynamicImports: true,
+        },
+        overwrites: {
+          plugins: ['@babel/plugin-syntax-dynamic-import'],
+        },
+      },
+      flow: false,
+    };
+    const expected = {
+      plugins: ['@babel/plugin-syntax-dynamic-import'],
       presets: [[
         '@babel/preset-env',
         {
@@ -170,6 +304,7 @@ describe('services/configurations:babelConfiguration', () => {
       babel: {
         nodeVersion,
         features: ['properties'],
+        defaultFeatures: {},
         overwrites: {},
       },
       flow: false,
@@ -210,6 +345,7 @@ describe('services/configurations:babelConfiguration', () => {
       babel: {
         nodeVersion,
         features: ['decorators'],
+        defaultFeatures: {},
         overwrites: {},
       },
       flow: false,
@@ -263,6 +399,7 @@ describe('services/configurations:babelConfiguration', () => {
       },
       babel: {
         features: ['decorators'],
+        defaultFeatures: {},
         overwrites,
       },
       flow: false,
@@ -292,6 +429,7 @@ describe('services/configurations:babelConfiguration', () => {
       babel: {
         nodeVersion,
         features: ['properties'],
+        defaultFeatures: {},
       },
       flow: true,
     };
@@ -331,6 +469,7 @@ describe('services/configurations:babelConfiguration', () => {
       babel: {
         nodeVersion,
         features: [],
+        defaultFeatures: {},
         overwrites: {},
       },
       flow: true,

--- a/tests/services/configurations/babelConfiguration.test.js
+++ b/tests/services/configurations/babelConfiguration.test.js
@@ -34,8 +34,7 @@ describe('services/configurations:babelConfiguration', () => {
       },
       babel: {
         browserVersions,
-        features: [],
-        defaultFeatures: {},
+        features: {},
         mobileSupport: true,
         overwrites: {},
         polyfill: true,
@@ -84,8 +83,7 @@ describe('services/configurations:babelConfiguration', () => {
       },
       babel: {
         browserVersions,
-        features: [],
-        defaultFeatures: {},
+        features: {},
         mobileSupport: false,
         overwrites: {},
       },
@@ -131,8 +129,7 @@ describe('services/configurations:babelConfiguration', () => {
       },
       babel: {
         nodeVersion,
-        features: [],
-        defaultFeatures: {},
+        features: {},
         overwrites: {},
       },
       flow: false,
@@ -159,7 +156,7 @@ describe('services/configurations:babelConfiguration', () => {
     expect(events.reduce).toHaveBeenCalledWith(eventName, expected, target);
   });
 
-  it('should create a Babel config and include the `dynamic imports` feature by default', () => {
+  it('should create a Babel configuration and include the `dynamic imports` feature', () => {
     // Given
     const eventName = 'babel-configuration';
     const events = {
@@ -172,99 +169,10 @@ describe('services/configurations:babelConfiguration', () => {
       },
       babel: {
         nodeVersion,
-        features: [],
-        defaultFeatures: {
+        features: {
           dynamicImports: true,
         },
         overwrites: {},
-      },
-      flow: false,
-    };
-    const expected = {
-      plugins: ['@babel/plugin-syntax-dynamic-import'],
-      presets: [[
-        '@babel/preset-env',
-        {
-          targets: {
-            node: nodeVersion,
-          },
-        },
-      ]],
-    };
-    let sut = null;
-    let result = null;
-    // When
-    sut = new BabelConfiguration(events);
-    result = sut.getConfigForTarget(target);
-    // Then
-    expect(result).toEqual(expected);
-    expect(events.reduce).toHaveBeenCalledTimes(1);
-    expect(events.reduce).toHaveBeenCalledWith(eventName, expected, target);
-  });
-
-  it('should create a Babel config and disable the `dynamic imports` feature by default', () => {
-    // Given
-    const eventName = 'babel-configuration';
-    const events = {
-      reduce: jest.fn((name, config) => config),
-    };
-    const nodeVersion = 'current';
-    const target = {
-      is: {
-        browser: false,
-      },
-      babel: {
-        nodeVersion,
-        features: [],
-        defaultFeatures: {
-          dynamicImports: false,
-        },
-        overwrites: {},
-      },
-      flow: false,
-    };
-    const expected = {
-      plugins: [],
-      presets: [[
-        '@babel/preset-env',
-        {
-          targets: {
-            node: nodeVersion,
-          },
-        },
-      ]],
-    };
-    let sut = null;
-    let result = null;
-    // When
-    sut = new BabelConfiguration(events);
-    result = sut.getConfigForTarget(target);
-    // Then
-    expect(result).toEqual(expected);
-    expect(events.reduce).toHaveBeenCalledTimes(1);
-    expect(events.reduce).toHaveBeenCalledWith(eventName, expected, target);
-  });
-
-  it('should create a Babel config and avoid adding the `dynamic imports` feature twice', () => {
-    // Given
-    const eventName = 'babel-configuration';
-    const events = {
-      reduce: jest.fn((name, config) => config),
-    };
-    const nodeVersion = 'current';
-    const target = {
-      is: {
-        browser: false,
-      },
-      babel: {
-        nodeVersion,
-        features: [],
-        defaultFeatures: {
-          dynamicImports: true,
-        },
-        overwrites: {
-          plugins: ['@babel/plugin-syntax-dynamic-import'],
-        },
       },
       flow: false,
     };
@@ -303,8 +211,11 @@ describe('services/configurations:babelConfiguration', () => {
       },
       babel: {
         nodeVersion,
-        features: ['properties'],
-        defaultFeatures: {},
+        features: {
+          dynamicImports: false,
+          properties: true,
+          unknownFeature: true,
+        },
         overwrites: {},
       },
       flow: false,
@@ -344,8 +255,9 @@ describe('services/configurations:babelConfiguration', () => {
       },
       babel: {
         nodeVersion,
-        features: ['decorators'],
-        defaultFeatures: {},
+        features: {
+          decorators: true,
+        },
         overwrites: {},
       },
       flow: false,
@@ -398,8 +310,9 @@ describe('services/configurations:babelConfiguration', () => {
         browser: true,
       },
       babel: {
-        features: ['decorators'],
-        defaultFeatures: {},
+        features: {
+          decorators: true,
+        },
         overwrites,
       },
       flow: false,
@@ -428,8 +341,9 @@ describe('services/configurations:babelConfiguration', () => {
       },
       babel: {
         nodeVersion,
-        features: ['properties'],
-        defaultFeatures: {},
+        features: {
+          properties: true,
+        },
       },
       flow: true,
     };
@@ -468,8 +382,7 @@ describe('services/configurations:babelConfiguration', () => {
       },
       babel: {
         nodeVersion,
-        features: [],
-        defaultFeatures: {},
+        features: {},
         overwrites: {},
       },
       flow: true,

--- a/tests/services/targets/targets.test.js
+++ b/tests/services/targets/targets.test.js
@@ -377,6 +377,7 @@ describe('services/targets:targets', () => {
           output: {
             default: {
               js: 'app/[target-name].js',
+              jsChunks: true,
               fonts: 'app/fonts/[name].[ext]',
               css: 'app/styles/[target-name].css',
               images: 'app/images/[name].[ext]',
@@ -395,12 +396,14 @@ describe('services/targets:targets', () => {
           output: {
             development: {
               js: 'app/[target-name].js',
+              jsChunks: true,
               fonts: 'app/fonts/[name].[ext]',
               css: 'app/styles/[target-name].css',
               images: 'app/images/[name].[ext]',
             },
             production: {
               js: 'app/[target-name].js',
+              jsChunks: true,
               fonts: 'app/fonts/[name].[ext]',
               css: 'app/styles/[target-name].css',
               images: 'app/images/[name].[ext]',
@@ -483,6 +486,7 @@ describe('services/targets:targets', () => {
       expectedTargets[data.expected.name].originalOutput = data.expected.output;
       expectedReplacements.push(
         ...Object.keys(data.expected.output.development)
+        .filter((name) => typeof data.expected.output.development[name] === 'string')
         .map((name) => ({
           targetName: data.expected.name,
           string: data.expected.output.development[name],
@@ -490,6 +494,7 @@ describe('services/targets:targets', () => {
       );
       expectedReplacements.push(
         ...Object.keys(data.expected.output.production)
+        .filter((name) => typeof data.expected.output.production[name] === 'string')
         .map((name) => ({
           targetName: data.expected.name,
           string: data.expected.output.production[name],

--- a/utils/hooks/install
+++ b/utils/hooks/install
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/bin/sh -e
 if [ -d ".git" ]; then
     ln -sv ../../utils/hooks/pre-commit.local ./.git/hooks/pre-commit
     ln -sv ../../utils/hooks/post-merge.local ./.git/hooks/post-merge
-    echo "Hooks installed"
+    echo "\033[92mHooks installed!"
     exit 0
 fi
 
-echo ".git directory not found"
+echo -e "\033[31m.git directory not found"
 exit 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,12 +1477,7 @@ colors@1.0.x:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.0.tgz#5f20c9fef6945cb1134260aab33bfbdc8295e04e"
-  integrity sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==
-
-colors@^1.1.2:
+colors@1.3.3, colors@^1.1.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
   integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
@@ -2514,15 +2509,6 @@ fs-extra@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
   integrity sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
-  integrity sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -6214,13 +6200,13 @@ winston@2.1.x:
     pkginfo "0.3.x"
     stack-trace "0.0.x"
 
-wootils@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/wootils/-/wootils-1.4.0.tgz#af630fa16514cd6684d0775346a9b4a225046c74"
-  integrity sha512-8gz7Slb8Gb64cfMBdX7Mv7HHJrf6VVP1I/6HFMpVT/a140C5vPmohMRWreMAMuOsW/kmRsRDHJ2JR2M8CKCkSA==
+wootils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/wootils/-/wootils-2.0.0.tgz#bf9349775ab5a4b9e4ef88f2350ce7443e0bc818"
+  integrity sha512-Htp7bBJD4Dmnok1pu7XeDNg68JJdGhZHLPuv7edzNOAgvcG+LDDLOAFpH/J3XsHGWd/WDfNdwwWZicD4fkdGMw==
   dependencies:
-    colors "1.3.0"
-    fs-extra "6.0.1"
+    colors "1.3.3"
+    fs-extra "7.0.1"
     jimple "1.5.0"
     statuses "1.5.0"
     urijs "1.19.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,6 +319,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-dynamic-import@7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz#69c159ffaf4998122161ad8ebc5e6d1f55df8612"
+  integrity sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-syntax-flow@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz#a765f061f803bc48f240c26f8747faf97c26bf7c"


### PR DESCRIPTION
### What does this PR do?

mainly, it brings code splitting to projext!! Now, to read the feature on detail, I recommend you to take a look at the new document on this PR.

The biggest change, required by the feature, and which makes this PR _"super-breaking"_ is the reformat of the target's `babel.features` settings:

We needed [`@babel/plugin-syntax-dynamic-import`](https://yarnpkg.com/en/package/@babel/plugin-syntax-dynamic-import), but it needed to be a "smart default" instead of an optional feature, because the idea was for the feature to be easy to use, enabled by default and managed by a single setting.

The initial idea was to add it as the default value of the targets `.babel.features` list, but when projext merges the target's templates and the target's settings (using [`extend`](https://yarnpkg.com/en/package/extend)), arrays get merged by index, so if it already had a value and you were to enable `properties`, it would replace the dynamic imports with that one... not cool.

The first approach was to create a different setting under the `babel` options, called `defaultFeatures`:

```js
{
  ...
  babel: {
    features: [],
    defaultFeatures: {
      dynamicImports: true,
    },
    ...
  },
  ...
}
```

It would work like a dictionary of flags for default features/plugins... but just before merging the PR I decided that having two properties with different formats for kind of the same functionality wasn't a great idea, so I took the `features` options and changed it to dictionary format:

```js
{
  ...
  babel: {
    features: {
      classProperties: false,
      decorators: false,
      dynamicImports: true,
    },
    ...
  },
  ...
}
```

Easy to read, overwrite and to set default values.

#### Other small changes

- Since it's already LTS, Node `10.15` was added to the list of targets for Travis.
- The command to install the repository hooks was renamed from `install-hooks` to just `hooks`, to align with the other projects.
- [`wootils`](https://yarnpkg.com/en/package/wootils) was updated to its latest version.

### How should it be tested manually?

You can't yet completely test the feature, as the handling of the chunks will come from the bundle engines, but you can test changes on the Babel features by enabling/disabling them and trying them out.

And of course:

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
