### PR TITLE
Detect a target that uses Aurelia

### DIFF
--- a/src/services/targets/targetsFinder.js
+++ b/src/services/targets/targetsFinder.js
@@ -87,6 +87,7 @@ class TargetsFinder {
       angular: /@angular(?:\/(?:\w+))?$/i,
       angularjs: /angular/i,
       react: /react(?:(?!(?:-dom\/server)))/i,
+      aurelia: /aurelia/i,
     };
     /**
      * A dictionary of known frameworks that can be used on Node, and regular expressions that

--- a/tests/services/targets/targetsFinder.test.js
+++ b/tests/services/targets/targetsFinder.test.js
@@ -1114,6 +1114,49 @@ describe('services/targets:targetsFinder', () => {
     expect(result).toEqual(expectedTargets);
   });
 
+  it('should find a browser target that uses Aurelia', () => {
+    // Given
+    const packageInfo = {
+      name: 'my-app',
+    };
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    // 1 - When checking if the source directory exists.
+    fs.pathExistsSync.mockReturnValueOnce(true);
+    // 2 - When checking if the default index exists.
+    fs.pathExistsSync.mockReturnValueOnce(true);
+    const indexFile = 'index.js';
+    const sourceDirectoryContents = ['..', '.', indexFile];
+    // 1 - When reading the source directory.
+    fs.readdirSync.mockReturnValueOnce(sourceDirectoryContents);
+    // 2 - When parsing the target.
+    fs.readdirSync.mockReturnValueOnce(sourceDirectoryContents);
+    const fileContents = 'import { PLATFORM } from \'aurelia-pal\';';
+    fs.readFileSync.mockReturnValueOnce(fileContents);
+    const directory = 'src';
+    let sut = null;
+    let result = null;
+    const expectedTargets = [{
+      name: packageInfo.name,
+      hasFolder: false,
+      createFolder: false,
+      entry: {
+        default: indexFile,
+        development: null,
+        production: null,
+      },
+      type: 'browser',
+      library: false,
+      framework: 'aurelia',
+    }];
+    // When
+    sut = new TargetsFinder(packageInfo, pathUtils);
+    result = sut.find(directory);
+    // Then
+    expect(result).toEqual(expectedTargets);
+  });
+
   it('should include a provider for the DIC', () => {
     // Given
     const container = {


### PR DESCRIPTION
### What does this PR do?

The plugin to add support for [Aurelia](https://aurelia.io) it's going to be released soon, so it makes sense to add it to the list of frameworks detected by the `TargetsFinder` service.

### How should it be tested manually?

Add this code to your target entry file:

```js
import { PLATFORM } from 'aurelia-pal';
```

And run `projext info targets` to see if the `framework` setting of the target was set to `aurelia`.

Finally...

```bash
yarn test
# or
npm test
```