### PR TITLE
v6.0.1: Fix Aurelia detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "projext",
     "description": "Bundle and run your javascript project without configuring an specific module bundler.",
     "homepage": "https://homer0.github.io/projext/",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "repository": "homer0/projext",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",

--- a/src/services/targets/targetsFinder.js
+++ b/src/services/targets/targetsFinder.js
@@ -90,6 +90,14 @@ class TargetsFinder {
       aurelia: /aurelia/i,
     };
     /**
+     * A list of known browser frameworks that need to export something on the entry point in order
+     * to work. This is list is used to prevent the service from thinking an app is a library.
+     * @type {Array}
+     * @ignore
+     * @access protected
+     */
+    this._browserFrameworksWithExports = ['aurelia'];
+    /**
      * A dictionary of known frameworks that can be used on Node, and regular expressions that
      * match their module name.
      * @type {Object}
@@ -284,8 +292,6 @@ class TargetsFinder {
     const importInfo = this._getFileImports(contents);
     // Get the information of all the export statements
     const exportInfo = this._getFileExports(contents);
-    // If the target is exporting something, then it's a library.
-    const library = exportInfo.items.length > 0;
 
     // Loop all the known browser frameworks.
     const framework = Object.keys(this._browserFrameworks)
@@ -294,6 +300,14 @@ class TargetsFinder {
       const regex = this._browserFrameworks[name];
       return !!importInfo.items.find((file) => file.match(regex));
     });
+
+    /**
+     * Check if the framework requires the use of `export` on the entry file; that why we can
+     * prevent the method to assume the target is a library.
+     */
+    const falseLibrary = !!(framework && this._browserFrameworksWithExports.includes(framework));
+    // If the target is exporting something, then it's a library.
+    const library = !falseLibrary && exportInfo.items.length > 0;
 
     /**
      * Try to determine if the target type is `browser` by either checking if a browser framework

--- a/tests/services/targets/targetsFinder.test.js
+++ b/tests/services/targets/targetsFinder.test.js
@@ -1132,7 +1132,11 @@ describe('services/targets:targetsFinder', () => {
     fs.readdirSync.mockReturnValueOnce(sourceDirectoryContents);
     // 2 - When parsing the target.
     fs.readdirSync.mockReturnValueOnce(sourceDirectoryContents);
-    const fileContents = 'import { PLATFORM } from \'aurelia-pal\';';
+    const fileContents = `
+      import { PLATFORM } from \'aurelia-pal\';
+
+      export const configure = () => {};
+    `.trim();
     fs.readFileSync.mockReturnValueOnce(fileContents);
     const directory = 'src';
     let sut = null;


### PR DESCRIPTION
### What does this PR do?

Aurelia requires that the entry file exports a `configure` function, which was making the `TargetsFinder` service _think_ it was a library.

I added a protected property with a list (with just Aurelia for now) of frameworks that use `export` on the entry file, that way the service will check the list and if the framework is there, it won't set `library` to `true`.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
