### PR TITLE
v6.0.3: fix(project): restore the previous @babel/polyfill version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "projext",
     "description": "Bundle and run your javascript project without configuring an specific module bundler.",
     "homepage": "https://homer0.github.io/projext/",
-    "version": "6.0.2",
+    "version": "6.0.3",
     "repository": "homer0/projext",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "@babel/plugin-syntax-dynamic-import": "7.2.0",
       "@babel/plugin-proposal-object-rest-spread": "7.4.3",
       "@babel/plugin-transform-runtime": "7.4.3",
-      "@babel/polyfill": "7.4.3",
+      "@babel/polyfill": "7.4.0",
       "@babel/preset-flow": "7.0.0",
       "@babel/preset-typescript": "7.3.3",
       "@babel/preset-env": "7.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,10 +631,10 @@
     "@babel/helper-regex" "^7.4.3"
     regexpu-core "^4.5.4"
 
-"@babel/polyfill@7.4.3":
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.3.tgz#332dc6f57b718017c3a8b37b4eea8aa6eeac1187"
-  integrity sha512-rkv8WIvJshA5Ev8iNMGgz5WZkRtgtiPexiT7w5qevGTuT7ZBfM3de9ox1y9JR5/OXb/sWGBbWlHNa7vQKqku3Q==
+"@babel/polyfill@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.0.tgz#90f9d68ae34ac42ab4b4aa03151848f536960218"
+  integrity sha512-bVsjsrtsDflIHp5I6caaAa2V25Kzn50HKPL6g3X0P0ni1ks+58cPB8Mz6AOKVuRPgaVdq/OwEUc/1vKqX+Mo4A==
   dependencies:
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"


### PR DESCRIPTION
### What does this PR do?

`@babel/polyfill@7.43` includes ES6 code that when tried to uglify causes errors. They already fixed it, but it hasn't been released yet, so that's why I'm restoring the old version until they do.

Also, the polyfill itself [was deprecated](https://babeljs.io/docs/en/next/babel-polyfill.html), so in the next major version I'll removed and replaced with their recommendation (`core-js` and `rengerator-runtime`).

### How should it be tested manually?

Use the webpack or rollup plugin and try to uglify a bundle that has polyfill, it should throw an error on `master` and work on this branch.

And...

```bash
yarn test
# or
npm test
```
