### PR TITLE
v6.0.5:  fix(services/projectConfiguration): change Babel features order

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "projext",
     "description": "Bundle and run your javascript project without configuring an specific module bundler.",
     "homepage": "https://homer0.github.io/projext/",
-    "version": "6.0.4",
+    "version": "6.0.5",
     "repository": "homer0/projext",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -110,8 +110,8 @@ class ProjectConfiguration extends ConfigurationFile {
           },
           babel: {
             features: {
-              classProperties: false,
               decorators: false,
+              classProperties: false,
               dynamicImports: true,
               objectRestSpread: false,
             },
@@ -176,8 +176,8 @@ class ProjectConfiguration extends ConfigurationFile {
           },
           babel: {
             features: {
-              classProperties: false,
               decorators: false,
+              classProperties: false,
               dynamicImports: true,
               objectRestSpread: false,
             },


### PR DESCRIPTION
### What does this PR do?

If you use both decorators and class properties, you'll see an error from Babel saying that decorators should go before class properties, but they way the features are declared on the target templates, when a service does an `Object.keys`, class properties always comes first.

This PR is a hotfix that just changes their position on the template; I'll add a better fix soon: I'm still trying to decide whether to do something that checks the order before building a Babel configuration or making it so the order can be changed by the implementation.

### How should it be tested manually?

Run a target with both features working, and of course...

```bash
yarn test
# or
npm test
```
