### PR TITLE
refactor(project): remove the deprecated Babel polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
       "@babel/plugin-syntax-dynamic-import": "7.2.0",
       "@babel/plugin-proposal-object-rest-spread": "7.5.5",
       "@babel/plugin-transform-runtime": "7.5.5",
-      "@babel/polyfill": "7.4.4",
       "@babel/preset-flow": "7.0.0",
       "@babel/preset-typescript": "7.3.3",
       "@babel/preset-env": "7.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,14 +673,6 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
-"@babel/polyfill@7.4.4":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.4.tgz#78801cf3dbe657844eeabf31c1cae3828051e893"
-  integrity sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.2"
-
 "@babel/preset-env@7.5.4":
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.5.4.tgz#64bc15041a3cbb0798930319917e70fcca57713d"
@@ -1982,7 +1974,7 @@ core-js-pure@3.1.4:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
-core-js@^2.4.0, core-js@^2.6.5:
+core-js@^2.4.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==


### PR DESCRIPTION
### What does this PR do?

The package [`@babel/polyfill`](https://yarnpkg.com/en/package/@babel/polyfill) has been deprecated in favor of using [`core-js`](https://yarnpkg.com/en/package/core-js) and [`regenerator-runtime`](https://yarnpkg.com/en/package/rengerator-runtime) directly, so this PRs removes the depenendency.

The replacement packages are not being installed on this repository because they'll be added by the build engines.

This is breaking because the package `@babel/polyfill` is not longer installed.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```