### PR TITLE
feat(bin/projext): add log messages for all the steps

### DIFF
--- a/src/bin/projext
+++ b/src/bin/projext
@@ -1,4 +1,28 @@
 #!/bin/sh -e
+
+# Logs an information message (dark gray)
+projextCLIInfoLog() {
+  echo "\033[90m[projext] $1\033[39m"
+}
+
+# Logs a success message (green)
+projextCLISuccessLog() {
+  echo "\033[32m[projext] $*\033[39m"
+}
+
+# Logs a message that indicates a task is starting (yellow)
+projextCLIStartTaskLog() {
+  echo "\033[33m[projext] $1\033[39m"
+}
+
+# Logs a message that indicates a task was completed (green), and replaces the last logged
+# message
+projextCLICompleteTaskLog() {
+  echo "\033[2A";
+  printf "\033[0K\r\033[32m[projext] %s\033[39m" "$*"
+  echo ""
+}
+
 # Get the name of the task to execute
 task=$1
 # If this flags gets to be true, the execution will be handled by the Node CLI
@@ -28,19 +52,26 @@ else
 
   # If the task is a shell task that needs commands...
   if [ "$isSHTask" = true ] && [ "$disableSHTasks" = false ]; then
-      # ...execute a validation command to avoid any error being thrown on the
+      # ... let the user know the CLI started working
+      projextCLISuccessLog "CLI started"
+      # execute a validation command to avoid any error being thrown on the
       # command that returns the list.
+      projextCLIStartTaskLog "Validating the command"
       if [ "$showSHCommand" = true ]; then
         echo "> projext-cli sh-validate-$*"
       fi
       eval "projext-cli sh-validate-$*"
+      projextCLICompleteTaskLog "Command validated"
       # Capture the commands that need to run
       if [ "$showSHCommand" = true ]; then
         echo "> projext-cli sh-$*"
       fi
+      projextCLIStartTaskLog "Loading instructions"
       command=$(eval "projext-cli sh-$*")
       # If there are commands to run...
       if [ "$command" != "" ]; then
+        projextCLICompleteTaskLog "Instructions loaded"
+        projextCLIInfoLog "Executing instructions"
         # Show the real command(s) if the debug flag was used.
         if [ "$showSHCommand" = true ]; then
           echo "> $command"


### PR DESCRIPTION
### What does this PR do?

This has been bothering me for some time now: the bin commands are SLOW. My theory is that the problem is a mix of `sync` calls on the file system and [`commander`](https://yarnpkg.com/en/package/commander).

On the long run, the idea is to fix those issues (go async when possible and replace `commander`), but for now, I added more log mesages on the binary so you can at least know what's happening while you wait.

### How should it be tested manually?

Install the branch and try running a target, you'll see step by step what is projext doing.