### PR TITLE
feat(project): add support for .env files

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -106,6 +106,7 @@ Since there are a lot of settings for the templates, will divide them by type an
   libraryOptions: { ... },
   cleanBeforeBuild: true,
   copy: [],
+  dotEnv: { ... },
 }
 ```
 
@@ -315,7 +316,7 @@ Using this flags, you can tell projext to always watch your files when building 
 > }
 > ```
 
-These options are used in the case the target needs to be bundled or transpile to configure [Babel](https://babeljs.io):
+These options are used in the case the target needs to be bundled or transpiled, to configure [Babel](https://babeljs.io):
 
 **`babel.features`**
 
@@ -387,6 +388,54 @@ A list of files to be copied during the bundling process. It can be a list of fi
 
 This is different from the main `copy` feature as this is specific to targets and you may require it for your app to work. For example: You may use this setting to copy a `manifest.json` for your PWA while you can use the main `copy` feature for the `package.json` or an `.nvmrc`, things you need for distribution.
 
+#### `dotEnv`
+> Default value:
+>
+> ```js
+> {
+>   enabled: true,
+>   files: [
+>     '.env.[target-name].[build-type]',
+>     '.env.[target-name]',
+>     '.env.[build-type]',
+>     '.env',
+>   ],
+>   extend: true,
+>   overwrite: false,
+> }
+> ```
+
+These options are used by both projext and the build engine in order to load environment variables from an "environment file". The variables are parsed with [`dotenv`](https://yarnpkg.com/en/package/dotenv) and expanded with [`dotenv-expand`](https://yarnpkg.com/en/package/dotenv-expand).
+
+**`dotEnv.enabled`**
+
+Whether or not the feature is enabled.
+
+**`dotEnv.files`**
+
+The list of files projext will try to find in order to load the variables. Based on the value of `extend`, the way projext will process them may change.
+
+**`dotEnv.extend`**
+
+Whether or not projext should merge all the variables from all the files it can find.
+
+Take for example the following list of files:
+
+```js
+[
+  '.env.[target-name].[build-type],
+  '.env.[target-name]',
+]
+```
+
+If `extend` is set to `true` and both files exist, projext will load `.env.[target-name]` as the first file and then merge the values from `.env.[target-name].[build-type]` on top of it.
+
+If `extend` is set to `false`, projext will use the first file it can find.
+
+**`dotEnv.overwrite`**
+
+When projext injects a target variables in the environment, having this setting in `false`, prevents it from overwriting already declared variables.
+
 ### `browser`
 
 ```js
@@ -413,6 +462,7 @@ This is different from the main `copy` feature as this is specific to targets an
   libraryOptions: { ... },
   cleanBeforeBuild: true,
   copy: [],
+  dotEnv: { ... },
   devServer: { ... },
   configuration: { ... },
 }
@@ -692,6 +742,54 @@ A list of files to be copied during the bundling process. It can be a list of fi
 ```
 
 This is different from the main `copy` feature as this is specific to targets and you may require it for your app to work. For example: You may use this setting to copy a `manifest.json` for your PWA while you can use the main `copy` feature for the `package.json` or an `.nvmrc`, things you need for distribution.
+
+#### `dotEnv`
+> Default value:
+>
+> ```js
+> {
+>   enabled: true,
+>   files: [
+>     '.env.[target-name].[build-type]',
+>     '.env.[target-name]',
+>     '.env.[build-type]',
+>     '.env',
+>   ],
+>   extend: true,
+>   overwrite: false,
+> }
+> ```
+
+These options are used by both projext and the build engine in order to load environment variables from an "environment file". The variables are parsed with [`dotenv`](https://yarnpkg.com/en/package/dotenv) and expanded with [`dotenv-expand`](https://yarnpkg.com/en/package/dotenv-expand).
+
+**`dotEnv.enabled`**
+
+Whether or not the feature is enabled.
+
+**`dotEnv.files`**
+
+The list of files projext will try to find in order to load the variables. Based on the value of `extend`, the way projext will process them may change.
+
+**`dotEnv.extend`**
+
+Whether or not projext should merge all the variables from all the files it can find.
+
+Take for example the following list of files:
+
+```js
+[
+  '.env.[target-name].[build-type],
+  '.env.[target-name]',
+]
+```
+
+If `extend` is set to `true` and both files exist, projext will load `.env.[target-name]` as the first file and then merge the values from `.env.[target-name].[build-type]` on top of it.
+
+If `extend` is set to `false`, projext will use the first file it can find.
+
+**`dotEnv.overwrite`**
+
+When projext injects a target variables in the environment, having this setting in `false`, prevents it from overwriting already declared variables.
 
 #### `devServer`
 > Default value:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       "watchpack": "^1.6.0",
       "nodemon": "^1.19.1",
       "prompt": "^1.0.0",
-      "dotenv": "^8.0.0"
+      "dotenv": "^8.0.0",
+      "dotenv-expand": "^5.1.0"
     },
     "devDependencies": {
       "eslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
       "@babel/runtime": "7.5.5",
       "watchpack": "^1.6.0",
       "nodemon": "^1.19.1",
-      "prompt": "^1.0.0"
+      "prompt": "^1.0.0",
+      "dotenv": "^8.0.0"
     },
     "devDependencies": {
       "eslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",
     "dependencies": {
-      "wootils": "^2.4.1",
+      "wootils": "^2.5.0",
       "jimple": "^1.5.0",
       "fs-extra": "^8.1.0",
       "extend": "^3.0.2",

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -15,6 +15,7 @@ const {
   babelHelper,
   cleaner,
   copier,
+  dotEnvUtils,
   events,
   plugins,
   appPrompt,
@@ -100,6 +101,7 @@ class Projext extends Jimple {
     this.register(babelHelper);
     this.register(cleaner);
     this.register(copier);
+    this.register(dotEnvUtils);
     this.register(events);
     this.register(plugins('projext-plugin-'));
     this.register(appPrompt);

--- a/src/services/building/buildNodeRunner.js
+++ b/src/services/building/buildNodeRunner.js
@@ -14,8 +14,10 @@ class BuildNodeRunner {
    *                                                              templates.
    * @param {Targets}                      targets                To get the information of the
    *                                                              included targets.
+   * @param {Utils}                        utils                  To normalize executable
+   *                                                              extensions.
    */
-  constructor(buildNodeRunnerProcess, projectConfiguration, targets) {
+  constructor(buildNodeRunnerProcess, projectConfiguration, targets, utils) {
     /**
      * A local reference for the `buildNodeRunnerProcess` service.
      * @type {BuildNodeRunnerProcess}
@@ -26,6 +28,11 @@ class BuildNodeRunner {
      * @type {Targets}
      */
     this.targets = targets;
+    /**
+     * A local reference for the `utils` service.
+     * @type {Utils}
+     */
+    this.utils = utils;
     // Check the project settings and enable the `nodemon` legacy watch mode.
     if (projectConfiguration.others.nodemon.legacyWatch) {
       this.buildNodeRunnerProcess.enableLegacyWatch();
@@ -64,7 +71,6 @@ class BuildNodeRunner {
    * @throws {Error} If one of the included targets requires bundling.
    * @access protected
    * @ignore
-   * @todo inject `utils` on the next breaking release and remove `this.targets.utils`.
    */
   _runWithTranspilation(target, inspectOptions) {
     const { paths: { source, build }, includeTargets } = target;
@@ -97,11 +103,12 @@ class BuildNodeRunner {
     });
 
     this.buildNodeRunnerProcess.run(
-      this.targets.utils.ensureExtension(executable),
+      this.utils.ensureExtension(executable),
       watch,
       inspectOptions,
       transpilationPaths,
-      copyPaths
+      copyPaths,
+      this.targets.loadTargetDotEnvFile(target, 'development', false)
     );
   }
   /**
@@ -137,7 +144,10 @@ class BuildNodeRunner {
     this.buildNodeRunnerProcess.run(
       executable,
       watch,
-      inspectOptions
+      inspectOptions,
+      [],
+      [],
+      this.targets.loadTargetDotEnvFile(target, 'development', false)
     );
   }
 }
@@ -155,7 +165,8 @@ const buildNodeRunner = provider((app) => {
   app.set('buildNodeRunner', () => new BuildNodeRunner(
     app.get('buildNodeRunnerProcess'),
     app.get('projectConfiguration').getConfig(),
-    app.get('targets')
+    app.get('targets'),
+    app.get('utils')
   ));
 });
 

--- a/src/services/building/buildTranspiler.js
+++ b/src/services/building/buildTranspiler.js
@@ -13,11 +13,13 @@ class BuildTranspiler {
    * @param {Logger}             appLogger          To print information messages after transpiling
    *                                                files.
    * @param {Targets}            targets            To access targets information.
+   * @param {Utils}              utils              To normalize file extensions.
    */
   constructor(
     babelConfiguration,
     appLogger,
-    targets
+    targets,
+    utils
   ) {
     /**
      * A local reference for the `babelConfiguration` service.
@@ -34,6 +36,11 @@ class BuildTranspiler {
      * @type {Targets}
      */
     this.targets = targets;
+    /**
+     * A local reference for the `utils` service.
+     * @type {Utils}
+     */
+    this.utils = utils;
   }
   /**
    * Transpile a target files for a given build type. This requires the target files to have been
@@ -130,7 +137,6 @@ class BuildTranspiler {
    *                                        was transpiled) and `code`; but if the parameter is
    *                                        `false`, the promise will resolve on a string with
    *                                        the path to the file.
-   * @todo inject `utils` on the next breaking release and remove `this.targets.utils`.
    */
   transpileFile(filepath, buildType = 'development', options = null, writeFile = true) {
     let from = '';
@@ -148,7 +154,7 @@ class BuildTranspiler {
       originalTo = filepath.output;
     }
     // Normalize custom JS extensions (jsx, ts or tsx) to `.js`
-    to = this.targets.utils.ensureExtension(originalTo);
+    to = this.utils.ensureExtension(originalTo);
     // If no options were defined, try to get them from a target, using the path of the file.
     const babelOptions = options || this.getTargetConfigurationForFile(from, buildType);
     // First, transform the file with Babel.
@@ -223,7 +229,6 @@ class BuildTranspiler {
    *                         `filepath` (the path where it was transpiled) and `code`; but if the
    *                         parameter is `false`, it will return a string with the path to the
    *                         file.
-   * @todo inject `utils` on the next breaking release and remove `this.targets.utils`.
    */
   transpileFileSync(filepath, buildType = 'development', options = null, writeFile = true) {
     let from = '';
@@ -241,7 +246,7 @@ class BuildTranspiler {
       originalTo = filepath.output;
     }
     // Normalize custom JS extensions (jsx, ts or tsx) to `.js`
-    to = this.targets.utils.ensureExtension(originalTo);
+    to = this.utils.ensureExtension(originalTo);
     // If no options were defined, try to get them from a target, using the path of the file.
     const babelOptions = options || this.getTargetConfigurationForFile(from, buildType);
     // First, transform the file with Babel.
@@ -386,7 +391,8 @@ const buildTranspiler = provider((app) => {
   app.set('buildTranspiler', () => new BuildTranspiler(
     app.get('babelConfiguration'),
     app.get('appLogger'),
-    app.get('targets')
+    app.get('targets'),
+    app.get('utils')
   ));
 });
 

--- a/src/services/common/dotEnvUtils.js
+++ b/src/services/common/dotEnvUtils.js
@@ -1,0 +1,161 @@
+const fs = require('fs-extra');
+const ObjectUtils = require('wootils/shared/objectUtils');
+const dotenv = require('dotenv');
+const dotenvExpand = require('dotenv-expand');
+const { provider } = require('jimple');
+
+/**
+ * @typedef {Object} DotEnvUtilsFileInfo
+ * @property {string} name The name of the file.
+ * @property {string} path The absolute path of the file.
+ * @ignore
+ */
+
+/**
+ * A utility class/service to work with .env files for environment variables.
+ */
+class DotEnvUtils {
+  /**
+   * @param {EnvironmentUtils} environmentUtils To set variables in the environment.
+   * @param {AppLogger}        appLogger        To log information messages when files are loaded
+   *                                            or when there's a problem loading them.
+   * @param {PathUtils}        pathUtils        To get paths relative to the project root.
+   */
+  constructor(environmentUtils, appLogger, pathUtils) {
+    /**
+     * A local reference for the `environmentUtils` service.
+     * @type {EnvironmentUtils}
+     * @access protected
+     * @ignore
+     */
+    this._environmentUtils = environmentUtils;
+    /**
+     * A local reference for the `appLogger` service.
+     * @type {AppLogger}
+     * @access protected
+     * @ignore
+     */
+    this._appLogger = appLogger;
+    /**
+     * A local reference for the `pathUtils` service.
+     * @type {PathUtils}
+     * @access protected
+     * @ignore
+     */
+    this._pathUtils = pathUtils;
+  }
+  /**
+   * Given a list of `.env` files (relative to the project root directory), this method will
+   * validate if they exist, load them, merge them (if `extend` is `true`) and return an object
+   * with all the variable declarations it found.
+   * @param {Array}   files         The list of file names relative to the project root directory.
+   * @param {boolean} [extend=true] Whether or not the variables found on the files should be
+   *                                merged on a single object. If this is `true`, it will reverse
+   *                                the list of files and merge all the variables in top of
+   *                                each other (to ensure that the final overwrite is from the
+   *                                file that was first on the list). If this is `false`, even
+   *                                if multiple files were found, it will only use the first one.
+   * @return {Object}
+   * @property {boolean} loaded    Whether or not variables were loaded.
+   * @property {Object}  variables A dictionary with all the loaded variables.
+   */
+  load(files, extend = true) {
+    const filesInfo = files
+    .map((file) => ({
+      name: file,
+      path: this._pathUtils.join(file),
+    }))
+    .filter((info) => fs.pathExistsSync(info.path));
+
+    const result = {
+      loaded: true,
+      variables: {},
+    };
+
+    if (filesInfo.length) {
+      const useFiles = extend ? filesInfo : [filesInfo[0]];
+      result.variables = this._parseFiles(useFiles);
+      result.loaded = !!Object.keys(result.variables).length;
+    } else {
+      result.loaded = false;
+    }
+
+    return result;
+  }
+  /**
+   * Given a dictionary of variables, this method will inject all of them on the environment.
+   * @param {Object}  variables        A dictionary with the variables to inject.
+   * @param {boolean} [overwrite=true] If `true`, and a variable is already declared, it will
+   *                                   overwrite it, otherwise, it will skip it.
+   */
+  inject(variables, overwrite = true) {
+    Object.keys(variables).forEach((name) => {
+      const value = variables[name];
+      this._environmentUtils.set(name, value, overwrite);
+    });
+  }
+  /**
+   * Given a list of files, the method will reverse the list, load the variables from each file
+   * and then merge them on top of each other. The reason the method first reverses the list is
+   * so the files with higher priority (lower index) are merged on top of the ones with lower
+   * priority (higher index). For example, `[fileOne, fileTwo]` will result on `fileOne` being
+   * merged in top of `fileTwo`, because it was first on the list.
+   * @param {Array} files A list of {@link DotEnvUtilsFileInfo} elements.
+   * @return {Object}
+   * @access protected
+   * @ignore
+   */
+  _parseFiles(files) {
+    const parsed = files
+    .reverse()
+    .reduce(
+      (current, fileInfo) => ObjectUtils.merge(current, this._parseFile(fileInfo)),
+      {}
+    );
+
+    return dotenvExpand({ parsed }).parsed;
+  }
+  /**
+   * Loads and parses a single environment file.
+   * @param {DotEnvUtilsFileInfo} fileInfo The information for the file to load.
+   * @return {Object} The variables from the file.
+   * @throws {Error} If the file can't be read.
+   * @access protected
+   * @ignore
+   */
+  _parseFile(fileInfo) {
+    let result;
+    try {
+      const contents = fs.readFileSync(fileInfo.path);
+      result = dotenv.parse(contents);
+      this._appLogger.success(`Environment file successfully loaded: ${fileInfo.name}`);
+    } catch (error) {
+      this._appLogger.error(`Error: The environment file couldn't be read: ${fileInfo.name}`);
+      throw error;
+    }
+
+    return result;
+  }
+}
+/**
+ * The service provider that once registered on the app container will set an instance of
+ * `DotEnvUtils` as the `dotEnvUtils` service.
+ * @example
+ * // Register it on the container
+ * container.register(dotEnvUtils);
+ * // Getting access to the service instance
+ * const dotEnvUtils = container.get('dotEnvUtils');
+ * @type {Provider}
+ */
+const dotEnvUtils = provider((app) => {
+  app.set('dotEnvUtils', () => new DotEnvUtils(
+    app.get('environmentUtils'),
+    app.get('appLogger'),
+    app.get('pathUtils')
+  ));
+});
+
+module.exports = {
+  DotEnvUtils,
+  dotEnvUtils,
+};

--- a/src/services/common/index.js
+++ b/src/services/common/index.js
@@ -1,6 +1,7 @@
 const { babelHelper } = require('./babelHelper');
 const { cleaner } = require('./cleaner');
 const { copier } = require('./copier');
+const { dotEnvUtils } = require('./dotEnvUtils');
 const { events } = require('./events');
 const { plugins } = require('./plugins');
 const { promptWithOptions, prompt, appPrompt } = require('./prompt');
@@ -13,6 +14,7 @@ module.exports = {
   babelHelper,
   cleaner,
   copier,
+  dotEnvUtils,
   events,
   plugins,
   promptWithOptions,

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -128,11 +128,13 @@ class ProjectConfiguration extends ConfigurationFile {
           copy: [],
           dotEnv: {
             enabled: true,
-            file: {
-              default: '.env',
-              development: null,
-              production: null,
-            },
+            extend: true,
+            files: [
+              '.env.[target-name].[build-type]',
+              '.env.[target-name]',
+              '.env.[build-type]',
+              '.env',
+            ],
           },
         },
         browser: {
@@ -206,11 +208,13 @@ class ProjectConfiguration extends ConfigurationFile {
           copy: [],
           dotEnv: {
             enabled: true,
-            file: {
-              default: '.env',
-              development: null,
-              production: null,
-            },
+            extend: true,
+            files: [
+              '.env.[target-name].[build-type]',
+              '.env.[target-name]',
+              '.env.[build-type]',
+              '.env',
+            ],
           },
           devServer: {
             port: 2509,

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -128,14 +128,14 @@ class ProjectConfiguration extends ConfigurationFile {
           copy: [],
           dotEnv: {
             enabled: true,
-            extend: true,
-            overwrite: false,
             files: [
               '.env.[target-name].[build-type]',
               '.env.[target-name]',
               '.env.[build-type]',
               '.env',
             ],
+            extend: true,
+            overwrite: false,
           },
         },
         browser: {
@@ -209,14 +209,14 @@ class ProjectConfiguration extends ConfigurationFile {
           copy: [],
           dotEnv: {
             enabled: true,
-            extend: true,
-            overwrite: false,
             files: [
               '.env.[target-name].[build-type]',
               '.env.[target-name]',
               '.env.[build-type]',
               '.env',
             ],
+            extend: true,
+            overwrite: false,
           },
           devServer: {
             port: 2509,

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -126,6 +126,14 @@ class ProjectConfiguration extends ConfigurationFile {
           },
           cleanBeforeBuild: true,
           copy: [],
+          dotEnv: {
+            enabled: true,
+            file: {
+              default: '.env',
+              development: null,
+              production: null,
+            },
+          },
         },
         browser: {
           type: 'browser',
@@ -196,6 +204,14 @@ class ProjectConfiguration extends ConfigurationFile {
           },
           cleanBeforeBuild: true,
           copy: [],
+          dotEnv: {
+            enabled: true,
+            file: {
+              default: '.env',
+              development: null,
+              production: null,
+            },
+          },
           devServer: {
             port: 2509,
             open: true,

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -129,6 +129,7 @@ class ProjectConfiguration extends ConfigurationFile {
           dotEnv: {
             enabled: true,
             extend: true,
+            overwrite: false,
             files: [
               '.env.[target-name].[build-type]',
               '.env.[target-name]',
@@ -209,6 +210,7 @@ class ProjectConfiguration extends ConfigurationFile {
           dotEnv: {
             enabled: true,
             extend: true,
+            overwrite: false,
             files: [
               '.env.[target-name].[build-type]',
               '.env.[target-name]',

--- a/src/services/targets/targets.js
+++ b/src/services/targets/targets.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs-extra');
-const extend = require('extend');
+const ObjectUtils = require('wootils/shared/objectUtils');
 const { AppConfiguration } = require('wootils/node/appConfiguration');
 const { provider } = require('jimple');
 /**
@@ -117,7 +117,7 @@ class Targets {
          * Create the new target information by merging the template, the target information from
          * the configuration and the information defined by this method.
          */
-        const newTarget = extend(true, {}, template, target, {
+        const newTarget = ObjectUtils.merge(template, target, {
           name,
           type,
           paths: {
@@ -147,7 +147,7 @@ class Targets {
          * Keep the original output settings without the placeholders so internal services or
          * plugins can use them.
          */
-        newTarget.originalOutput = extend(true, {}, newTarget.output);
+        newTarget.originalOutput = ObjectUtils.copy(newTarget.output);
         // Replace placeholders on the output settings
         newTarget.output = this._replaceTargetOutputPlaceholders(newTarget);
 
@@ -460,7 +460,7 @@ class Targets {
         if (value === null) {
           newOutput[name] = Object.assign({}, defaultOutput);
         } else {
-          newOutput[name] = extend(true, {}, defaultOutput, value);
+          newOutput[name] = ObjectUtils.merge(defaultOutput, value);
           Object.keys(newOutput[name]).forEach((propName) => {
             if (!newOutput[name][propName] && defaultOutput[propName]) {
               newOutput[name][propName] = defaultOutput[propName];

--- a/src/services/targets/targets.js
+++ b/src/services/targets/targets.js
@@ -184,10 +184,11 @@ class Targets {
           }
         }
 
-        // Check if the target should be transpiled (You can use types without transpilation).
+        // Check if the target should be transpiled (You can't use types without transpilation).
         if (!newTarget.transpile && (newTarget.flow || newTarget.typeScript)) {
           newTarget.transpile = true;
         }
+
         // Generate the target paths and folders.
         newTarget.folders.source = newTarget.hasFolder ?
           path.join(source, sourceFolderName) :

--- a/src/services/targets/targets.js
+++ b/src/services/targets/targets.js
@@ -151,6 +151,15 @@ class Targets {
         // Replace placeholders on the output settings
         newTarget.output = this._replaceTargetOutputPlaceholders(newTarget);
 
+        /**
+         * To avoid merge issues with arrays (they get merge "by index"), if the target already
+         * had a defined list of files for the dotEnv feature, overwrite whatever is on the
+         * template.
+         */
+        if (target.dotEnv && target.dotEnv.files && target.dotEnv.files.length) {
+          newTarget.dotEnv.files = target.dotEnv.files;
+        }
+
         // If the target has an `html` setting...
         if (newTarget.html) {
           // Check if there are missing settings that should be replaced with a fallback.

--- a/tests/services/building/buildNodeRunner.test.js
+++ b/tests/services/building/buildNodeRunner.test.js
@@ -21,13 +21,20 @@ describe('services/building:buildNodeRunner', () => {
       },
     };
     const targets = 'targets';
+    const utils = 'utils';
     let sut = null;
     // When
-    sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+    sut = new BuildNodeRunner(
+      buildNodeRunnerProcess,
+      projectConfiguration,
+      targets,
+      utils
+    );
     // Then
     expect(sut).toBeInstanceOf(BuildNodeRunner);
     expect(sut.buildNodeRunnerProcess).toBe(buildNodeRunnerProcess);
     expect(sut.targets).toBe(targets);
+    expect(sut.utils).toBe(utils);
   });
 
   it('should be instantiated and enable nodemon legacy watch mode', () => {
@@ -43,13 +50,20 @@ describe('services/building:buildNodeRunner', () => {
       },
     };
     const targets = 'targets';
+    const utils = 'utils';
     let sut = null;
     // When
-    sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+    sut = new BuildNodeRunner(
+      buildNodeRunnerProcess,
+      projectConfiguration,
+      targets,
+      utils
+    );
     // Then
     expect(sut).toBeInstanceOf(BuildNodeRunner);
     expect(sut.buildNodeRunnerProcess).toEqual(buildNodeRunnerProcess);
     expect(sut.targets).toBe(targets);
+    expect(sut.utils).toBe(utils);
     expect(buildNodeRunnerProcess.enableLegacyWatch).toHaveBeenCalledTimes(1);
   });
 
@@ -64,6 +78,7 @@ describe('services/building:buildNodeRunner', () => {
       },
     };
     const targets = 'targets';
+    const utils = 'utils';
     const target = {
       is: {
         browser: true,
@@ -72,7 +87,12 @@ describe('services/building:buildNodeRunner', () => {
     };
     let sut = null;
     // When
-    sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+    sut = new BuildNodeRunner(
+      buildNodeRunnerProcess,
+      projectConfiguration,
+      targets,
+      utils
+    );
     // Then
     expect(() => sut.runTarget(target)).toThrow(/is a browser target/i);
   });
@@ -88,6 +108,7 @@ describe('services/building:buildNodeRunner', () => {
       },
     };
     const targets = 'targets';
+    const utils = 'utils';
     const target = {
       is: {
         browser: false,
@@ -96,7 +117,12 @@ describe('services/building:buildNodeRunner', () => {
     };
     let sut = null;
     // When
-    sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+    sut = new BuildNodeRunner(
+      buildNodeRunnerProcess,
+      projectConfiguration,
+      targets,
+      utils
+    );
     // Then
     expect(() => sut.runTarget(target)).toThrow(/needs to be bundled/i);
   });
@@ -114,7 +140,14 @@ describe('services/building:buildNodeRunner', () => {
           },
         },
       };
-      const targets = 'targets';
+      const environmentVariables = {
+        ROSARIO: 'Charito!',
+        PILAR: 'Pili!',
+      };
+      const targets = {
+        loadTargetDotEnvFile: jest.fn(() => environmentVariables),
+      };
+      const utils = 'utils';
       const target = {
         bundle: false,
         transpile: false,
@@ -133,14 +166,28 @@ describe('services/building:buildNodeRunner', () => {
       };
       let sut = null;
       // When
-      sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+      sut = new BuildNodeRunner(
+        buildNodeRunnerProcess,
+        projectConfiguration,
+        targets,
+        utils
+      );
       sut.runTarget(target);
       // Then
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledTimes(1);
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledWith(
         `${target.paths.source}/${target.entry.development}`,
         [target.paths.source],
-        target.inspect
+        target.inspect,
+        [],
+        [],
+        environmentVariables
+      );
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
+        target,
+        'development',
+        false
       );
     });
 
@@ -156,7 +203,14 @@ describe('services/building:buildNodeRunner', () => {
           },
         },
       };
-      const targets = 'targets';
+      const environmentVariables = {
+        ROSARIO: 'Charito!',
+        PILAR: 'Pili!',
+      };
+      const targets = {
+        loadTargetDotEnvFile: jest.fn(() => environmentVariables),
+      };
+      const utils = 'utils';
       const target = {
         bundle: false,
         transpile: false,
@@ -175,14 +229,28 @@ describe('services/building:buildNodeRunner', () => {
       };
       let sut = null;
       // When
-      sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+      sut = new BuildNodeRunner(
+        buildNodeRunnerProcess,
+        projectConfiguration,
+        targets,
+        utils
+      );
       sut.runTarget(target, true);
       // Then
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledTimes(1);
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledWith(
         `${target.paths.source}/${target.entry.development}`,
         [target.paths.source],
-        Object.assign({}, target.inspect, { enabled: true })
+        Object.assign({}, target.inspect, { enabled: true }),
+        [],
+        [],
+        environmentVariables
+      );
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
+        target,
+        'development',
+        false
       );
     });
 
@@ -204,9 +272,15 @@ describe('services/building:buildNodeRunner', () => {
           source: 'included-target-source-path',
         },
       };
+      const environmentVariables = {
+        ROSARIO: 'Charito!',
+        PILAR: 'Pili!',
+      };
       const targets = {
         getTarget: jest.fn(() => includedTarget),
+        loadTargetDotEnvFile: jest.fn(() => environmentVariables),
       };
+      const utils = 'utils';
       const target = {
         bundle: false,
         transpile: false,
@@ -225,7 +299,12 @@ describe('services/building:buildNodeRunner', () => {
       };
       let sut = null;
       // When
-      sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+      sut = new BuildNodeRunner(
+        buildNodeRunnerProcess,
+        projectConfiguration,
+        targets,
+        utils
+      );
       sut.runTarget(target);
       // Then
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledTimes(1);
@@ -235,7 +314,16 @@ describe('services/building:buildNodeRunner', () => {
           target.paths.source,
           includedTarget.paths.source,
         ],
-        target.inspect
+        target.inspect,
+        [],
+        [],
+        environmentVariables
+      );
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
+        target,
+        'development',
+        false
       );
     });
 
@@ -258,6 +346,7 @@ describe('services/building:buildNodeRunner', () => {
       const targets = {
         getTarget: jest.fn(() => includedTarget),
       };
+      const utils = 'utils';
       const target = {
         bundle: false,
         transpile: false,
@@ -276,7 +365,12 @@ describe('services/building:buildNodeRunner', () => {
       };
       let sut = null;
       // When/Then
-      sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+      sut = new BuildNodeRunner(
+        buildNodeRunnerProcess,
+        projectConfiguration,
+        targets,
+        utils
+      );
       expect(() => sut.runTarget(target)).toThrow(/requires bundling/i);
     });
 
@@ -299,6 +393,7 @@ describe('services/building:buildNodeRunner', () => {
       const targets = {
         getTarget: jest.fn(() => includedTarget),
       };
+      const utils = 'utils';
       const target = {
         bundle: false,
         transpile: false,
@@ -317,7 +412,12 @@ describe('services/building:buildNodeRunner', () => {
       };
       let sut = null;
       // When/Then
-      sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+      sut = new BuildNodeRunner(
+        buildNodeRunnerProcess,
+        projectConfiguration,
+        targets,
+        utils
+      );
       expect(() => sut.runTarget(target)).toThrow(/requires transpilation/i);
     });
   });
@@ -335,10 +435,15 @@ describe('services/building:buildNodeRunner', () => {
           },
         },
       };
+      const environmentVariables = {
+        ROSARIO: 'Charito!',
+        PILAR: 'Pili!',
+      };
       const targets = {
-        utils: {
-          ensureExtension: jest.fn((filepath) => filepath),
-        },
+        loadTargetDotEnvFile: jest.fn(() => environmentVariables),
+      };
+      const utils = {
+        ensureExtension: jest.fn((filepath) => filepath),
       };
       const target = {
         bundle: false,
@@ -359,7 +464,12 @@ describe('services/building:buildNodeRunner', () => {
       };
       let sut = null;
       // When
-      sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+      sut = new BuildNodeRunner(
+        buildNodeRunnerProcess,
+        projectConfiguration,
+        targets,
+        utils
+      );
       sut.runTarget(target);
       // Then
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledTimes(1);
@@ -371,10 +481,17 @@ describe('services/building:buildNodeRunner', () => {
           from: target.paths.source,
           to: target.paths.build,
         }],
-        []
+        [],
+        environmentVariables
       );
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledWith(
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
+        target,
+        'development',
+        false
+      );
+      expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+      expect(utils.ensureExtension).toHaveBeenCalledWith(
         `${target.paths.build}/${target.entry.development}`
       );
     });
@@ -399,11 +516,16 @@ describe('services/building:buildNodeRunner', () => {
           build: 'included-target-build-path',
         },
       };
+      const environmentVariables = {
+        ROSARIO: 'Charito!',
+        PILAR: 'Pili!',
+      };
       const targets = {
         getTarget: jest.fn(() => includedTarget),
-        utils: {
-          ensureExtension: jest.fn((filepath) => filepath),
-        },
+        loadTargetDotEnvFile: jest.fn(() => environmentVariables),
+      };
+      const utils = {
+        ensureExtension: jest.fn((filepath) => filepath),
       };
       const target = {
         bundle: false,
@@ -424,7 +546,12 @@ describe('services/building:buildNodeRunner', () => {
       };
       let sut = null;
       // When
-      sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+      sut = new BuildNodeRunner(
+        buildNodeRunnerProcess,
+        projectConfiguration,
+        targets,
+        utils
+      );
       sut.runTarget(target);
       // Then
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledTimes(1);
@@ -445,10 +572,17 @@ describe('services/building:buildNodeRunner', () => {
             to: includedTarget.paths.build,
           },
         ],
-        []
+        [],
+        environmentVariables
       );
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledWith(
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
+        target,
+        'development',
+        false
+      );
+      expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+      expect(utils.ensureExtension).toHaveBeenCalledWith(
         `${target.paths.build}/${target.entry.development}`
       );
     });
@@ -473,11 +607,16 @@ describe('services/building:buildNodeRunner', () => {
           build: 'included-target-build-path',
         },
       };
+      const environmentVariables = {
+        ROSARIO: 'Charito!',
+        PILAR: 'Pili!',
+      };
       const targets = {
         getTarget: jest.fn(() => includedTarget),
-        utils: {
-          ensureExtension: jest.fn((filepath) => filepath),
-        },
+        loadTargetDotEnvFile: jest.fn(() => environmentVariables),
+      };
+      const utils = {
+        ensureExtension: jest.fn((filepath) => filepath),
       };
       const target = {
         bundle: false,
@@ -498,7 +637,12 @@ describe('services/building:buildNodeRunner', () => {
       };
       let sut = null;
       // When
-      sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+      sut = new BuildNodeRunner(
+        buildNodeRunnerProcess,
+        projectConfiguration,
+        targets,
+        utils
+      );
       sut.runTarget(target);
       // Then
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledTimes(1);
@@ -516,10 +660,17 @@ describe('services/building:buildNodeRunner', () => {
         [{
           from: includedTarget.paths.source,
           to: includedTarget.paths.build,
-        }]
+        }],
+        environmentVariables
       );
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledWith(
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
+        target,
+        'development',
+        false
+      );
+      expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+      expect(utils.ensureExtension).toHaveBeenCalledWith(
         `${target.paths.build}/${target.entry.development}`
       );
     });
@@ -543,6 +694,7 @@ describe('services/building:buildNodeRunner', () => {
       const targets = {
         getTarget: jest.fn(() => includedTarget),
       };
+      const utils = 'utils';
       const target = {
         bundle: false,
         transpile: true,
@@ -562,7 +714,12 @@ describe('services/building:buildNodeRunner', () => {
       };
       let sut = null;
       // When/Then
-      sut = new BuildNodeRunner(buildNodeRunnerProcess, projectConfiguration, targets);
+      sut = new BuildNodeRunner(
+        buildNodeRunnerProcess,
+        projectConfiguration,
+        targets,
+        utils
+      );
       expect(() => sut.runTarget(target)).toThrow(/requires bundling/i);
     });
   });
@@ -599,5 +756,6 @@ describe('services/building:buildNodeRunner', () => {
     expect(sut).toBeInstanceOf(BuildNodeRunner);
     expect(sut.buildNodeRunnerProcess).toBe('buildNodeRunnerProcess');
     expect(sut.targets).toBe('targets');
+    expect(sut.utils).toBe('utils');
   });
 });

--- a/tests/services/building/buildTranspiler.test.js
+++ b/tests/services/building/buildTranspiler.test.js
@@ -37,18 +37,21 @@ describe('services/building:buildTranspiler', () => {
     const babelConfiguration = 'babelConfiguration';
     const appLogger = 'appLogger';
     const targets = 'targets';
+    const utils = 'utils';
     let sut = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     // Then
     expect(sut).toBeInstanceOf(BuildTranspiler);
     expect(sut.babelConfiguration).toBe(babelConfiguration);
     expect(sut.appLogger).toBe(appLogger);
     expect(sut.targets).toBe(targets);
+    expect(sut.utils).toBe(utils);
   });
 
   it('should transpile a target files', () => {
@@ -75,10 +78,9 @@ describe('services/building:buildTranspiler', () => {
       success: jest.fn(),
       info: jest.fn(),
     };
-    const targets = {
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    const targets = 'targets';
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     const target = {
       paths: {
@@ -98,7 +100,8 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     return sut.transpileTargetFiles(target)
     .then(() => {
@@ -113,7 +116,7 @@ describe('services/building:buildTranspiler', () => {
       );
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledTimes(1);
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(target);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(files.length);
+      expect(utils.ensureExtension).toHaveBeenCalledTimes(files.length);
       expect(babel.transformFile).toHaveBeenCalledTimes(files.length);
       expect(fs.writeFile).toHaveBeenCalledTimes(files.length);
       files.forEach((file) => {
@@ -126,7 +129,7 @@ describe('services/building:buildTranspiler', () => {
           path.join(target.paths.build, toJS(file)),
           code
         );
-        expect(targets.utils.ensureExtension).toHaveBeenCalledWith(
+        expect(utils.ensureExtension).toHaveBeenCalledWith(
           path.join(target.paths.build, file)
         );
       });
@@ -137,7 +140,6 @@ describe('services/building:buildTranspiler', () => {
       expect(fs.remove).toHaveBeenCalledWith(path.join(target.paths.build, jsxFile));
       expect(appLogger.success).toHaveBeenCalledTimes(1);
       expect(appLogger.info).toHaveBeenCalledTimes(files.length);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(files.length);
     })
     .catch((error) => {
       throw error;
@@ -170,10 +172,9 @@ describe('services/building:buildTranspiler', () => {
       success: jest.fn(),
       info: jest.fn(),
     };
-    const targets = {
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    const targets = 'targets';
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     const target = {
       paths: {
@@ -193,7 +194,8 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     return sut.transpileTargetFiles(target)
     .then(() => {
@@ -208,8 +210,8 @@ describe('services/building:buildTranspiler', () => {
       );
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledTimes(1);
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(target);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledWith(
+      expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+      expect(utils.ensureExtension).toHaveBeenCalledWith(
         path.join(target.paths.build, tsFile)
       );
       expect(babel.transformFile).toHaveBeenCalledTimes(1);
@@ -278,9 +280,9 @@ describe('services/building:buildTranspiler', () => {
     };
     const targets = {
       getTarget: jest.fn(() => includedTarget),
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    };
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     const target = {
       paths: {
@@ -300,7 +302,8 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     return sut.transpileTargetFiles(target)
     .then(() => {
@@ -323,11 +326,11 @@ describe('services/building:buildTranspiler', () => {
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledTimes(2);
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(target);
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(includedTarget);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(files.length * 2);
+      expect(utils.ensureExtension).toHaveBeenCalledTimes(files.length * 2);
       expect(babel.transformFile).toHaveBeenCalledTimes(files.length * 2);
       expect(fs.writeFile).toHaveBeenCalledTimes(files.length * 2);
       files.forEach((file) => {
-        expect(targets.utils.ensureExtension).toHaveBeenCalledWith(
+        expect(utils.ensureExtension).toHaveBeenCalledWith(
           path.join(target.paths.build, file)
         );
         expect(babel.transformFile).toHaveBeenCalledWith(
@@ -369,6 +372,7 @@ describe('services/building:buildTranspiler', () => {
       error: jest.fn(),
     };
     const targets = 'targets';
+    const utils = 'utils';
     const target = {
       paths: {
         build: '/some-absolute-path/to-the/build/directory',
@@ -387,7 +391,8 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     return sut.transpileTargetFiles(target)
     .then(() => {
@@ -432,6 +437,7 @@ describe('services/building:buildTranspiler', () => {
     const targets = {
       getTarget: jest.fn(() => includedTarget),
     };
+    const utils = 'utils';
     const target = {
       paths: {
         build: '/some-absolute-path/to-the/build/directory',
@@ -450,7 +456,8 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     return sut.transpileTargetFiles(target)
     .then(() => {
@@ -484,24 +491,25 @@ describe('services/building:buildTranspiler', () => {
     };
     const targets = {
       findTargetForFile: jest.fn(() => target),
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    };
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     let sut = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     return sut.transpileFile(file)
     .then(() => {
       // Then
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledTimes(1);
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(target);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledWith(file);
+      expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+      expect(utils.ensureExtension).toHaveBeenCalledWith(file);
       expect(babel.transformFile).toHaveBeenCalledTimes(1);
       expect(babel.transformFile).toHaveBeenCalledWith(
         file,
@@ -539,24 +547,25 @@ describe('services/building:buildTranspiler', () => {
     };
     const targets = {
       findTargetForFile: jest.fn(() => target),
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    };
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     let sut = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     return sut.transpileFile(file, 'production')
     .then(() => {
       // Then
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledTimes(1);
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(target);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledWith(file);
+      expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+      expect(utils.ensureExtension).toHaveBeenCalledWith(file);
       expect(babel.transformFile).toHaveBeenCalledTimes(1);
       expect(babel.transformFile).toHaveBeenCalledWith(
         file,
@@ -595,16 +604,17 @@ describe('services/building:buildTranspiler', () => {
     };
     const targets = {
       findTargetForFile: jest.fn(() => target),
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    };
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     let sut = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     return sut.transpileFile({
       source: file,
@@ -614,8 +624,8 @@ describe('services/building:buildTranspiler', () => {
       // Then
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledTimes(1);
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(target);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledWith(newFile);
+      expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+      expect(utils.ensureExtension).toHaveBeenCalledWith(newFile);
       expect(babel.transformFile).toHaveBeenCalledTimes(1);
       expect(babel.transformFile).toHaveBeenCalledWith(
         file,
@@ -650,16 +660,17 @@ describe('services/building:buildTranspiler', () => {
     };
     const targets = {
       findTargetForFile: jest.fn(() => target),
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    };
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     let sut = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     return sut.transpileFile(file, 'development', {}, false)
     .then((result) => {
@@ -668,8 +679,8 @@ describe('services/building:buildTranspiler', () => {
         filepath: file,
         code,
       });
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledWith(file);
+      expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+      expect(utils.ensureExtension).toHaveBeenCalledWith(file);
       expect(babel.transformFile).toHaveBeenCalledTimes(1);
       expect(babel.transformFile).toHaveBeenCalledWith(
         file,
@@ -703,16 +714,17 @@ describe('services/building:buildTranspiler', () => {
     };
     const targets = {
       findTargetForFile: jest.fn(() => target),
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    };
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     let sut = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     return sut.transpileFile(file)
     .then(() => {
@@ -723,8 +735,8 @@ describe('services/building:buildTranspiler', () => {
       expect(resultError).toBe(error);
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledTimes(1);
       expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(target);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-      expect(targets.utils.ensureExtension).toHaveBeenCalledWith(file);
+      expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+      expect(utils.ensureExtension).toHaveBeenCalledWith(file);
       expect(babel.transformFile).toHaveBeenCalledTimes(1);
       expect(babel.transformFile).toHaveBeenCalledWith(
         file,
@@ -752,23 +764,24 @@ describe('services/building:buildTranspiler', () => {
     };
     const targets = {
       findTargetForFile: jest.fn(() => target),
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    };
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     let sut = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     sut.transpileFileSync(file);
     // Then
     expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledTimes(1);
     expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(target);
-    expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-    expect(targets.utils.ensureExtension).toHaveBeenCalledWith(file);
+    expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+    expect(utils.ensureExtension).toHaveBeenCalledWith(file);
     expect(babel.transformFileSync).toHaveBeenCalledTimes(1);
     expect(babel.transformFileSync).toHaveBeenCalledWith(file, {});
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
@@ -796,23 +809,24 @@ describe('services/building:buildTranspiler', () => {
     };
     const targets = {
       findTargetForFile: jest.fn(() => target),
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    };
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     let sut = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     sut.transpileFileSync(file, 'production');
     // Then
     expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledTimes(1);
     expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(target);
-    expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-    expect(targets.utils.ensureExtension).toHaveBeenCalledWith(file);
+    expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+    expect(utils.ensureExtension).toHaveBeenCalledWith(file);
     expect(babel.transformFileSync).toHaveBeenCalledTimes(1);
     expect(babel.transformFileSync).toHaveBeenCalledWith(file, { sourceMaps: true });
     expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
@@ -839,23 +853,24 @@ describe('services/building:buildTranspiler', () => {
     };
     const targets = {
       findTargetForFile: jest.fn(() => target),
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    };
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     let sut = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     sut.transpileFileSync(file);
     // Then
     expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledTimes(1);
     expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(target);
-    expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-    expect(targets.utils.ensureExtension).toHaveBeenCalledWith(file);
+    expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+    expect(utils.ensureExtension).toHaveBeenCalledWith(file);
     expect(babel.transformFileSync).toHaveBeenCalledTimes(1);
     expect(babel.transformFileSync).toHaveBeenCalledWith(file, {});
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
@@ -885,16 +900,17 @@ describe('services/building:buildTranspiler', () => {
     };
     const targets = {
       findTargetForFile: jest.fn(() => target),
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    };
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     let sut = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     sut.transpileFileSync({
       source: file,
@@ -903,8 +919,8 @@ describe('services/building:buildTranspiler', () => {
     // Then
     expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledTimes(1);
     expect(babelConfiguration.getConfigForTarget).toHaveBeenCalledWith(target);
-    expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-    expect(targets.utils.ensureExtension).toHaveBeenCalledWith(newFile);
+    expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+    expect(utils.ensureExtension).toHaveBeenCalledWith(newFile);
     expect(babel.transformFileSync).toHaveBeenCalledTimes(1);
     expect(babel.transformFileSync).toHaveBeenCalledWith(file, {});
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
@@ -929,9 +945,9 @@ describe('services/building:buildTranspiler', () => {
     };
     const targets = {
       findTargetForFile: jest.fn(() => target),
-      utils: {
-        ensureExtension: jest.fn((filepath) => toJS(filepath)),
-      },
+    };
+    const utils = {
+      ensureExtension: jest.fn((filepath) => toJS(filepath)),
     };
     let sut = null;
     let result = null;
@@ -939,7 +955,8 @@ describe('services/building:buildTranspiler', () => {
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     result = sut.transpileFileSync(file, 'development', {}, false);
     // Then
@@ -947,8 +964,8 @@ describe('services/building:buildTranspiler', () => {
       filepath: file,
       code,
     });
-    expect(targets.utils.ensureExtension).toHaveBeenCalledTimes(1);
-    expect(targets.utils.ensureExtension).toHaveBeenCalledWith(file);
+    expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
+    expect(utils.ensureExtension).toHaveBeenCalledWith(file);
     expect(babel.transformFileSync).toHaveBeenCalledTimes(1);
     expect(babel.transformFileSync).toHaveBeenCalledWith(file, {});
     expect(fs.writeFileSync).toHaveBeenCalledTimes(0);
@@ -971,13 +988,15 @@ describe('services/building:buildTranspiler', () => {
     const targets = {
       findTargetForFile: jest.fn(() => target),
     };
+    const utils = 'utils';
     let sut = null;
     let result = null;
     // When
     sut = new BuildTranspiler(
       babelConfiguration,
       appLogger,
-      targets
+      targets,
+      utils
     );
     result = sut.getTargetConfigurationForFile(file);
     // Then
@@ -1010,5 +1029,6 @@ describe('services/building:buildTranspiler', () => {
     expect(sut.babelConfiguration).toBe('babelConfiguration');
     expect(sut.appLogger).toBe('appLogger');
     expect(sut.targets).toBe('targets');
+    expect(sut.utils).toBe('utils');
   });
 });

--- a/tests/services/common/dotEnvUtils.test.js
+++ b/tests/services/common/dotEnvUtils.test.js
@@ -1,0 +1,373 @@
+const JimpleMock = require('/tests/mocks/jimple.mock');
+
+jest.mock('jimple', () => JimpleMock);
+jest.mock('fs-extra');
+jest.mock('dotenv');
+jest.mock('dotenv-expand');
+jest.unmock('/src/services/common/dotEnvUtils');
+
+require('jasmine-expect');
+const fs = require('fs-extra');
+const dotenv = require('dotenv');
+const dotenvExpand = require('dotenv-expand');
+const ObjectUtils = require('wootils/shared/objectUtils');
+
+const {
+  DotEnvUtils,
+  dotEnvUtils,
+} = require('/src/services/common/dotEnvUtils');
+
+describe('services/common:dotEnvUtils', () => {
+  it('should be instantiated', () => {
+    // Given
+    const environmentUtils = 'environmentUtils';
+    const appLogger = 'appLogger';
+    const pathUtils = 'pathUtils';
+    let sut = null;
+    // When
+    sut = new DotEnvUtils(environmentUtils, appLogger, pathUtils);
+    // Then
+    expect(sut).toBeInstanceOf(DotEnvUtils);
+  });
+
+  it('should include a provider for the DIC', () => {
+    // Given
+    const container = {
+      set: jest.fn(),
+      get: jest.fn(),
+    };
+    let serviceName = null;
+    let serviceFn = null;
+    const expectedGets = [
+      'environmentUtils',
+      'appLogger',
+      'pathUtils',
+    ];
+    // When
+    dotEnvUtils(container);
+    [[serviceName, serviceFn]] = container.set.mock.calls;
+    // Then
+    expect(serviceName).toBe('dotEnvUtils');
+    expect(serviceFn).toBeFunction();
+    expect(serviceFn()).toBeInstanceOf(DotEnvUtils);
+    expect(container.get).toHaveBeenCalledTimes(expectedGets.length);
+    expectedGets.forEach((expectedGet) => {
+      expect(container.get).toHaveBeenCalledWith(expectedGet);
+    });
+  });
+
+  describe('load', () => {
+    beforeEach(() => {
+      fs.pathExistsSync.mockReset();
+      fs.readFileSync.mockReset();
+      dotenv.parse.mockReset();
+      dotenvExpand.mockReset();
+    });
+
+    it('shouldn\'t load anything if no files are provided', () => {
+      // Given
+      const environmentUtils = 'environmentUtils';
+      const appLogger = 'appLogger';
+      const pathUtils = 'pathUtils';
+      let sut = null;
+      let result = null;
+      // When
+      sut = new DotEnvUtils(environmentUtils, appLogger, pathUtils);
+      result = sut.load([]);
+      // Then
+      expect(result).toEqual({
+        loaded: false,
+        variables: {},
+      });
+    });
+
+    it('shouldn\'t load anything if the file doesn\'t exist', () => {
+      // Given
+      fs.pathExistsSync.mockReturnValueOnce(false);
+      const environmentUtils = 'environmentUtils';
+      const appLogger = 'appLogger';
+      const pathUtils = {
+        join: jest.fn((filepath) => filepath),
+      };
+      const file = '.env';
+      let sut = null;
+      let result = null;
+      // When
+      sut = new DotEnvUtils(environmentUtils, appLogger, pathUtils);
+      result = sut.load([file]);
+      // Then
+      expect(result).toEqual({
+        loaded: false,
+        variables: {},
+      });
+      expect(pathUtils.join).toHaveBeenCalledTimes(1);
+      expect(pathUtils.join).toHaveBeenCalledWith(file);
+      expect(fs.pathExistsSync).toHaveBeenCalledTimes(1);
+      expect(fs.pathExistsSync).toHaveBeenCalledWith(file);
+    });
+
+    it('should fail to load the variables from an .env file', () => {
+      // Given
+      fs.pathExistsSync.mockReturnValueOnce(true);
+      const error = new Error('Unexpected Error');
+      fs.readFileSync.mockImplementationOnce(() => {
+        throw error;
+      });
+      const environmentUtils = 'environmentUtils';
+      const appLogger = {
+        success: jest.fn(),
+        error: jest.fn(),
+      };
+      const pathUtils = {
+        join: jest.fn((filepath) => filepath),
+      };
+      const file = '.env';
+      let sut = null;
+      // When/Then
+      sut = new DotEnvUtils(environmentUtils, appLogger, pathUtils);
+      expect(() => sut.load([file])).toThrow(error.message);
+      expect(appLogger.error).toHaveBeenCalledTimes(1);
+      expect(appLogger.error).toHaveBeenCalledWith(
+        `Error: The environment file couldn't be read: ${file}`
+      );
+      expect(pathUtils.join).toHaveBeenCalledTimes(1);
+      expect(pathUtils.join).toHaveBeenCalledWith(file);
+      expect(fs.pathExistsSync).toHaveBeenCalledTimes(1);
+      expect(fs.pathExistsSync).toHaveBeenCalledWith(file);
+      expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+      expect(fs.readFileSync).toHaveBeenCalledWith(file);
+      expect(dotenv.parse).toHaveBeenCalledTimes(0);
+      expect(dotenvExpand).toHaveBeenCalledTimes(0);
+      expect(appLogger.success).toHaveBeenCalledTimes(0);
+    });
+
+    it('should load the variables from an .env file', () => {
+      // Given
+      fs.pathExistsSync.mockReturnValueOnce(true);
+      const fileContents = {
+        ROSARIO: 'Charito',
+        PILAR: 'Pili',
+      };
+      fs.readFileSync.mockReturnValueOnce(fileContents);
+      dotenv.parse.mockImplementationOnce((variables) => variables);
+      dotenvExpand.mockImplementationOnce((config) => config);
+      const environmentUtils = 'environmentUtils';
+      const appLogger = {
+        success: jest.fn(),
+      };
+      const pathUtils = {
+        join: jest.fn((filepath) => filepath),
+      };
+      const file = '.env';
+      let sut = null;
+      let result = null;
+      // When
+      sut = new DotEnvUtils(environmentUtils, appLogger, pathUtils);
+      result = sut.load([file]);
+      // Then
+      expect(result).toEqual({
+        loaded: true,
+        variables: fileContents,
+      });
+      expect(pathUtils.join).toHaveBeenCalledTimes(1);
+      expect(pathUtils.join).toHaveBeenCalledWith(file);
+      expect(fs.pathExistsSync).toHaveBeenCalledTimes(1);
+      expect(fs.pathExistsSync).toHaveBeenCalledWith(file);
+      expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+      expect(fs.readFileSync).toHaveBeenCalledWith(file);
+      expect(dotenv.parse).toHaveBeenCalledTimes(1);
+      expect(dotenv.parse).toHaveBeenCalledWith(fileContents);
+      expect(dotenvExpand).toHaveBeenCalledTimes(1);
+      expect(dotenvExpand).toHaveBeenCalledWith({
+        parsed: fileContents,
+      });
+      expect(appLogger.success).toHaveBeenCalledTimes(1);
+      expect(appLogger.success).toHaveBeenCalledWith(
+        `Environment file successfully loaded: ${file}`
+      );
+    });
+
+    it('should load and merge the variables from multiple .env files', () => {
+      // Given
+      fs.pathExistsSync.mockReturnValueOnce(true);
+      fs.pathExistsSync.mockReturnValueOnce(true);
+      const firstFile = '.envOne';
+      const firstFileContents = {
+        ROSARIO: 'Charito',
+        PILAR: 'Pili',
+      };
+      const secondFile = '.envTwo';
+      const secondFileContents = {
+        PILAR: 'Pili!',
+        MONSTRO: 'UAAA',
+      };
+      fs.readFileSync.mockReturnValueOnce(firstFileContents);
+      fs.readFileSync.mockReturnValueOnce(secondFileContents);
+      dotenv.parse.mockImplementationOnce((variables) => variables);
+      dotenv.parse.mockImplementationOnce((variables) => variables);
+      dotenvExpand.mockImplementationOnce((config) => config);
+      const environmentUtils = 'environmentUtils';
+      const appLogger = {
+        success: jest.fn(),
+      };
+      const pathUtils = {
+        join: jest.fn((filepath) => filepath),
+      };
+      const files = [firstFile, secondFile];
+      let sut = null;
+      let result = null;
+      const expectedMerge = ObjectUtils.merge(firstFileContents, secondFileContents);
+      // When
+      sut = new DotEnvUtils(environmentUtils, appLogger, pathUtils);
+      result = sut.load(files);
+      // Then
+      expect(result).toEqual({
+        loaded: true,
+        variables: expectedMerge,
+      });
+      expect(pathUtils.join).toHaveBeenCalledTimes(files.length);
+      expect(pathUtils.join).toHaveBeenCalledWith(firstFile);
+      expect(pathUtils.join).toHaveBeenCalledWith(secondFile);
+      expect(fs.pathExistsSync).toHaveBeenCalledTimes(files.length);
+      expect(fs.pathExistsSync).toHaveBeenCalledWith(firstFile);
+      expect(fs.pathExistsSync).toHaveBeenCalledWith(secondFile);
+      expect(fs.readFileSync).toHaveBeenCalledTimes(files.length);
+      expect(fs.readFileSync).toHaveBeenCalledWith(firstFile);
+      expect(fs.readFileSync).toHaveBeenCalledWith(secondFile);
+      expect(dotenv.parse).toHaveBeenCalledTimes(files.length);
+      expect(dotenv.parse).toHaveBeenCalledWith(firstFileContents);
+      expect(dotenv.parse).toHaveBeenCalledWith(secondFileContents);
+      expect(appLogger.success).toHaveBeenCalledTimes(files.length);
+      expect(appLogger.success).toHaveBeenCalledWith(
+        `Environment file successfully loaded: ${firstFile}`
+      );
+      expect(appLogger.success).toHaveBeenCalledWith(
+        `Environment file successfully loaded: ${secondFile}`
+      );
+      expect(dotenvExpand).toHaveBeenCalledTimes(1);
+      expect(dotenvExpand).toHaveBeenCalledWith({
+        parsed: expectedMerge,
+      });
+    });
+
+    it('should load the variables from the first .env file it finds', () => {
+      // Given
+      fs.pathExistsSync.mockReturnValueOnce(true);
+      fs.pathExistsSync.mockReturnValueOnce(true);
+      const firstFile = '.envOne';
+      const firstFileContents = {
+        ROSARIO: 'Charito',
+        PILAR: 'Pili',
+      };
+      const secondFile = '.envTwo';
+      fs.readFileSync.mockReturnValueOnce(firstFileContents);
+      dotenv.parse.mockImplementationOnce((variables) => variables);
+      dotenvExpand.mockImplementationOnce((config) => config);
+      const environmentUtils = 'environmentUtils';
+      const appLogger = {
+        success: jest.fn(),
+      };
+      const pathUtils = {
+        join: jest.fn((filepath) => filepath),
+      };
+      const files = [firstFile, secondFile];
+      let sut = null;
+      let result = null;
+      // When
+      sut = new DotEnvUtils(environmentUtils, appLogger, pathUtils);
+      result = sut.load(files, false);
+      // Then
+      expect(result).toEqual({
+        loaded: true,
+        variables: firstFileContents,
+      });
+      expect(pathUtils.join).toHaveBeenCalledTimes(files.length);
+      expect(pathUtils.join).toHaveBeenCalledWith(firstFile);
+      expect(pathUtils.join).toHaveBeenCalledWith(secondFile);
+      expect(fs.pathExistsSync).toHaveBeenCalledTimes(files.length);
+      expect(fs.pathExistsSync).toHaveBeenCalledWith(firstFile);
+      expect(fs.pathExistsSync).toHaveBeenCalledWith(secondFile);
+      expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+      expect(fs.readFileSync).toHaveBeenCalledWith(firstFile);
+      expect(dotenv.parse).toHaveBeenCalledTimes(1);
+      expect(dotenv.parse).toHaveBeenCalledWith(firstFileContents);
+      expect(appLogger.success).toHaveBeenCalledTimes(1);
+      expect(appLogger.success).toHaveBeenCalledWith(
+        `Environment file successfully loaded: ${firstFile}`
+      );
+      expect(dotenvExpand).toHaveBeenCalledTimes(1);
+      expect(dotenvExpand).toHaveBeenCalledWith({
+        parsed: firstFileContents,
+      });
+    });
+  });
+
+  describe('inject', () => {
+    it('should inject variables into the environment', () => {
+      // Given
+      const environmentUtils = {
+        set: jest.fn(),
+      };
+      const appLogger = 'appLogger';
+      const pathUtils = 'pathUtils';
+      const firstVariableName = 'ROSARIO';
+      const firstVariableValue = 'Charito';
+      const secondVariableName = 'PILAR';
+      const secondVariableValue = 'Pili';
+      let sut = null;
+      // When
+      sut = new DotEnvUtils(environmentUtils, appLogger, pathUtils);
+      sut.inject({
+        [firstVariableName]: firstVariableValue,
+        [secondVariableName]: secondVariableValue,
+      });
+      // Then
+      expect(environmentUtils.set).toHaveBeenCalledTimes(2);
+      expect(environmentUtils.set).toHaveBeenCalledWith(
+        firstVariableName,
+        firstVariableValue,
+        true
+      );
+      expect(environmentUtils.set).toHaveBeenCalledWith(
+        secondVariableName,
+        secondVariableValue,
+        true
+      );
+    });
+
+    it('should inject variables into the environment without overwriting existing ones', () => {
+      // Given
+      const environmentUtils = {
+        set: jest.fn(),
+      };
+      const appLogger = 'appLogger';
+      const pathUtils = 'pathUtils';
+      const firstVariableName = 'ROSARIO';
+      const firstVariableValue = 'Charito';
+      const secondVariableName = 'PILAR';
+      const secondVariableValue = 'Pili';
+      let sut = null;
+      // When
+      sut = new DotEnvUtils(environmentUtils, appLogger, pathUtils);
+      sut.inject(
+        {
+          [firstVariableName]: firstVariableValue,
+          [secondVariableName]: secondVariableValue,
+        },
+        false
+      );
+      // Then
+      expect(environmentUtils.set).toHaveBeenCalledTimes(2);
+      expect(environmentUtils.set).toHaveBeenCalledWith(
+        firstVariableName,
+        firstVariableValue,
+        false
+      );
+      expect(environmentUtils.set).toHaveBeenCalledWith(
+        secondVariableName,
+        secondVariableValue,
+        false
+      );
+    });
+  });
+});

--- a/tests/services/targets/targets.test.js
+++ b/tests/services/targets/targets.test.js
@@ -28,6 +28,7 @@ describe('services/targets:targets', () => {
 
   it('should be instantiated with all its dependencies', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = 'events';
     const environmentUtils = 'environmentUtils';
     const packageInfo = 'packageInfo';
@@ -45,6 +46,7 @@ describe('services/targets:targets', () => {
     let sut = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -66,6 +68,7 @@ describe('services/targets:targets', () => {
 
   it('should load the project targets', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -290,6 +293,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -314,6 +318,7 @@ describe('services/targets:targets', () => {
     // Given
     const hash = '2509';
     Date.now = () => hash;
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -707,6 +712,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -736,6 +742,7 @@ describe('services/targets:targets', () => {
 
   it('should load the project targets and resolve the browser targets `html` setting', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -922,6 +929,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -944,6 +952,7 @@ describe('services/targets:targets', () => {
 
   it('should get a target by its name', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -999,6 +1008,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1014,6 +1024,7 @@ describe('services/targets:targets', () => {
 
   it('should get a target with the project\'s name as the default target', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1082,6 +1093,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1097,6 +1109,7 @@ describe('services/targets:targets', () => {
 
   it('should get the first target (by alphabetical order) as the default target', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1165,6 +1178,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1180,6 +1194,7 @@ describe('services/targets:targets', () => {
 
   it('should get a target with an specific type as the default target', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1250,6 +1265,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1265,6 +1281,7 @@ describe('services/targets:targets', () => {
 
   it('should throw an error while trying to get the default target without having targets', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1284,6 +1301,7 @@ describe('services/targets:targets', () => {
     let sut = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1298,6 +1316,7 @@ describe('services/targets:targets', () => {
 
   it('should throw an error while trying to get the default target with an specific type', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1332,6 +1351,7 @@ describe('services/targets:targets', () => {
     let sut = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1347,6 +1367,7 @@ describe('services/targets:targets', () => {
 
   it('should throw an error while trying to get the default target with an invalid type', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1366,6 +1387,7 @@ describe('services/targets:targets', () => {
     let sut = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1381,6 +1403,7 @@ describe('services/targets:targets', () => {
 
   it('should throw an error while trying to load a target with an invalid type', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1407,6 +1430,7 @@ describe('services/targets:targets', () => {
     const utils = 'utils';
     // When/Then
     expect(() => new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1420,6 +1444,7 @@ describe('services/targets:targets', () => {
 
   it('should throw an error for a node target with bundling but no build engine', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1448,6 +1473,7 @@ describe('services/targets:targets', () => {
     const utils = 'utils';
     // When/Then
     expect(() => new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1461,6 +1487,7 @@ describe('services/targets:targets', () => {
 
   it('should throw an error for a browser target with no build engine', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1489,6 +1516,7 @@ describe('services/targets:targets', () => {
     const utils = 'utils';
     // When/Then
     expect(() => new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1502,6 +1530,7 @@ describe('services/targets:targets', () => {
 
   it('should validate that a target exists', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1538,6 +1567,7 @@ describe('services/targets:targets', () => {
     let invalidResult = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1555,6 +1585,7 @@ describe('services/targets:targets', () => {
 
   it('should throw an error when trying to get a target that doesn\'t exist', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1574,6 +1605,7 @@ describe('services/targets:targets', () => {
     let sut = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1593,6 +1625,7 @@ describe('services/targets:targets', () => {
     const folder = 'target-three';
     const file = `some-path/${source}/${folder}/file.js`;
     const targetName = 'targetThree';
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((name, target) => target),
     };
@@ -1626,6 +1659,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1642,6 +1676,7 @@ describe('services/targets:targets', () => {
 
   it('should throw an error if it can\'t find a target by a filepath', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = 'events';
     const environmentUtils = 'environmentUtils';
     const packageInfo = 'packageInfo';
@@ -1659,6 +1694,7 @@ describe('services/targets:targets', () => {
     let sut = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1674,6 +1710,7 @@ describe('services/targets:targets', () => {
 
   it('should throw an error when trying to generate a configuration for a Node target', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = 'events';
     const environmentUtils = 'environmentUtils';
     const packageInfo = 'packageInfo';
@@ -1696,6 +1733,7 @@ describe('services/targets:targets', () => {
     let sut = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1711,6 +1749,7 @@ describe('services/targets:targets', () => {
 
   it('shouldn\'t generate any configuration if the feature flag is disabled', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = 'events';
     const environmentUtils = 'environmentUtils';
     const packageInfo = 'packageInfo';
@@ -1738,6 +1777,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1753,6 +1793,7 @@ describe('services/targets:targets', () => {
 
   it('should generate a browser target config by loading from an external file', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = 'events';
     const environmentUtils = 'environmentUtils';
     const packageInfo = 'packageInfo';
@@ -1791,6 +1832,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1822,6 +1864,7 @@ describe('services/targets:targets', () => {
 
   it('should look for a browser target default config inside a folder with its name', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = 'events';
     const environmentUtils = 'environmentUtils';
     const packageInfo = 'packageInfo';
@@ -1860,6 +1903,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1889,8 +1933,9 @@ describe('services/targets:targets', () => {
     expect(WootilsAppConfigurationMock.mocks.loadFromEnvironment).toHaveBeenCalledTimes(1);
   });
 
-  it('should receive the default browser target configuration as a option property', () => {
+  it('should receive the default browser target configuration as an option property', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = 'events';
     const environmentUtils = 'environmentUtils';
     const packageInfo = 'packageInfo';
@@ -1929,6 +1974,7 @@ describe('services/targets:targets', () => {
     let result = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1956,8 +2002,257 @@ describe('services/targets:targets', () => {
     expect(WootilsAppConfigurationMock.mocks.loadFromEnvironment).toHaveBeenCalledTimes(0);
   });
 
+  it('shouldn\'t inject any environment variables if the feature flag is disabled', () => {
+    // Given
+    const dotEnvUtils = {
+      load: jest.fn(),
+    };
+    const events = 'events';
+    const environmentUtils = 'environmentUtils';
+    const packageInfo = 'packageInfo';
+    const pathUtils = 'pathUtils';
+    const projectConfiguration = {
+      targets: {},
+      targetsTemplates: {},
+      paths: {
+        source: '',
+        build: '',
+      },
+    };
+    const rootRequire = 'rootRequire';
+    const utils = 'utils';
+    const target = {
+      name: 'my-target',
+      is: {
+        node: false,
+      },
+      dotEnv: {
+        enabled: false,
+      },
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new Targets(
+      dotEnvUtils,
+      events,
+      environmentUtils,
+      packageInfo,
+      pathUtils,
+      projectConfiguration,
+      rootRequire,
+      utils
+    );
+    result = sut.loadTargetDotEnvFile(target);
+    // Then
+    expect(result).toEqual({});
+    expect(dotEnvUtils.load).toHaveBeenCalledTimes(0);
+  });
+
+  it('shouldn\'t inject any environment variables if no files are loaded', () => {
+    // Given
+    const dotEnvUtils = {
+      load: jest.fn(() => ({
+        loaded: false,
+      })),
+      inject: jest.fn(),
+    };
+    const events = 'events';
+    const environmentUtils = 'environmentUtils';
+    const packageInfo = 'packageInfo';
+    const pathUtils = 'pathUtils';
+    const projectConfiguration = {
+      targets: {},
+      targetsTemplates: {},
+      paths: {
+        source: '',
+        build: '',
+      },
+    };
+    const rootRequire = 'rootRequire';
+    const utils = 'utils';
+    const dotEnvFile = '.env.[target-name].[build-type]';
+    const target = {
+      name: 'my-target',
+      is: {
+        node: false,
+      },
+      dotEnv: {
+        enabled: true,
+        extend: true,
+        files: [dotEnvFile],
+      },
+    };
+    const expectedDotEnvFile = `.env.${target.name}.development`;
+    let sut = null;
+    let result = null;
+    // When
+    sut = new Targets(
+      dotEnvUtils,
+      events,
+      environmentUtils,
+      packageInfo,
+      pathUtils,
+      projectConfiguration,
+      rootRequire,
+      utils
+    );
+    result = sut.loadTargetDotEnvFile(target);
+    // Then
+    expect(result).toEqual({});
+    expect(dotEnvUtils.load).toHaveBeenCalledTimes(1);
+    expect(dotEnvUtils.load).toHaveBeenCalledWith([expectedDotEnvFile], target.dotEnv.extend);
+    expect(dotEnvUtils.inject).toHaveBeenCalledTimes(0);
+  });
+
+  it('should reduce and inject environment variables for a target', () => {
+    // Given
+    const loadedVariables = {
+      ROSARIO: 'Charito',
+      PILAR: 'Pili',
+    };
+    const dotEnvUtils = {
+      load: jest.fn(() => ({
+        loaded: true,
+        variables: loadedVariables,
+      })),
+      inject: jest.fn(),
+    };
+    const events = {
+      reduce: jest.fn((name, variables) => variables),
+    };
+    const environmentUtils = 'environmentUtils';
+    const packageInfo = 'packageInfo';
+    const pathUtils = 'pathUtils';
+    const projectConfiguration = {
+      targets: {},
+      targetsTemplates: {},
+      paths: {
+        source: '',
+        build: '',
+      },
+    };
+    const rootRequire = 'rootRequire';
+    const utils = 'utils';
+    const dotEnvFile = '.env.[target-name].[build-type]';
+    const target = {
+      name: 'my-target',
+      is: {
+        node: false,
+      },
+      dotEnv: {
+        enabled: true,
+        extend: true,
+        overwrite: true,
+        files: [dotEnvFile],
+      },
+    };
+    const buildType = 'production';
+    const expectedDotEnvFile = `.env.${target.name}.${buildType}`;
+    let sut = null;
+    let result = null;
+    // When
+    sut = new Targets(
+      dotEnvUtils,
+      events,
+      environmentUtils,
+      packageInfo,
+      pathUtils,
+      projectConfiguration,
+      rootRequire,
+      utils
+    );
+    result = sut.loadTargetDotEnvFile(target, buildType);
+    // Then
+    expect(result).toEqual(loadedVariables);
+    expect(dotEnvUtils.load).toHaveBeenCalledTimes(1);
+    expect(dotEnvUtils.load).toHaveBeenCalledWith([expectedDotEnvFile], target.dotEnv.extend);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(
+      'target-environment-variables',
+      loadedVariables,
+      target,
+      buildType
+    );
+    expect(dotEnvUtils.inject).toHaveBeenCalledTimes(1);
+    expect(dotEnvUtils.inject).toHaveBeenCalledWith(loadedVariables, target.dotEnv.overwrite);
+  });
+
+  it('should reduce but not inject environment variables for a target', () => {
+    // Given
+    const loadedVariables = {
+      ROSARIO: 'Charito',
+      PILAR: 'Pili',
+    };
+    const dotEnvUtils = {
+      load: jest.fn(() => ({
+        loaded: true,
+        variables: loadedVariables,
+      })),
+      inject: jest.fn(),
+    };
+    const events = {
+      reduce: jest.fn((name, variables) => variables),
+    };
+    const environmentUtils = 'environmentUtils';
+    const packageInfo = 'packageInfo';
+    const pathUtils = 'pathUtils';
+    const projectConfiguration = {
+      targets: {},
+      targetsTemplates: {},
+      paths: {
+        source: '',
+        build: '',
+      },
+    };
+    const rootRequire = 'rootRequire';
+    const utils = 'utils';
+    const dotEnvFile = '.env.[target-name].[build-type]';
+    const target = {
+      name: 'my-target',
+      is: {
+        node: false,
+      },
+      dotEnv: {
+        enabled: true,
+        extend: true,
+        overwrite: true,
+        files: [dotEnvFile],
+      },
+    };
+    const buildType = 'production';
+    const expectedDotEnvFile = `.env.${target.name}.${buildType}`;
+    let sut = null;
+    let result = null;
+    // When
+    sut = new Targets(
+      dotEnvUtils,
+      events,
+      environmentUtils,
+      packageInfo,
+      pathUtils,
+      projectConfiguration,
+      rootRequire,
+      utils
+    );
+    result = sut.loadTargetDotEnvFile(target, buildType, false);
+    // Then
+    expect(result).toEqual(loadedVariables);
+    expect(dotEnvUtils.load).toHaveBeenCalledTimes(1);
+    expect(dotEnvUtils.load).toHaveBeenCalledWith([expectedDotEnvFile], target.dotEnv.extend);
+    expect(events.reduce).toHaveBeenCalledTimes(1);
+    expect(events.reduce).toHaveBeenCalledWith(
+      'target-environment-variables',
+      loadedVariables,
+      target,
+      buildType
+    );
+    expect(dotEnvUtils.inject).toHaveBeenCalledTimes(0);
+  });
+
   it('should throw an error when requesting the files to copy of a target without bundling', () => {
     // Given
+    const dotEnvUtils = 'dotEnvUtils';
     const events = 'events';
     const environmentUtils = 'environmentUtils';
     const packageInfo = 'packageInfo';
@@ -1982,6 +2277,7 @@ describe('services/targets:targets', () => {
     let sut = null;
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -1998,6 +2294,7 @@ describe('services/targets:targets', () => {
   it('should throw an error when generating a list of files with one that doesn\'t exist', () => {
     // Given
     fs.pathExistsSync.mockImplementationOnce(() => false);
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((eventName, list) => list),
     };
@@ -2039,6 +2336,7 @@ describe('services/targets:targets', () => {
     const expectedErrorPath = expectedItem.from.replace('.', '\\.');
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -2063,6 +2361,7 @@ describe('services/targets:targets', () => {
     // Given
     fs.pathExistsSync.mockImplementationOnce(() => true);
     fs.pathExistsSync.mockImplementationOnce(() => true);
+    const dotEnvUtils = 'dotEnvUtils';
     const events = {
       reduce: jest.fn((eventName, list) => list),
     };
@@ -2116,6 +2415,7 @@ describe('services/targets:targets', () => {
     ];
     // When
     sut = new Targets(
+      dotEnvUtils,
       events,
       environmentUtils,
       packageInfo,
@@ -2167,6 +2467,7 @@ describe('services/targets:targets', () => {
     expect(serviceName).toBe('targets');
     expect(serviceFn).toBeFunction();
     expect(sut).toBeInstanceOf(Targets);
+    expect(sut.dotEnvUtils).toBe('dotEnvUtils');
     expect(sut.events).toBe('events');
     expect(sut.environmentUtils).toBe('environmentUtils');
     expect(sut.packageInfo).toBe('packageInfo');

--- a/tests/services/targets/targets.test.js
+++ b/tests/services/targets/targets.test.js
@@ -95,6 +95,11 @@ describe('services/targets:targets', () => {
         targetFour: {
           type: 'browser',
           hasFolder: false,
+          dotEnv: {
+            files: [
+              '.env.browser',
+            ],
+          },
         },
         targetFive: {
           folder: 'target-five',
@@ -108,10 +113,22 @@ describe('services/targets:targets', () => {
           defaultTargetName: 'node',
           hasFolder: true,
           engine: 'webpack',
+          dotEnv: {
+            enabled: true,
+            files: [
+              '.env',
+            ],
+          },
         },
         browser: {
           defaultTargetName: 'browser',
           engine: 'webpack',
+          dotEnv: {
+            enabled: true,
+            files: [
+              '.env',
+            ],
+          },
         },
       },
       paths: {
@@ -143,6 +160,12 @@ describe('services/targets:targets', () => {
           browser: false,
         },
         engine: 'webpack',
+        dotEnv: {
+          enabled: true,
+          files: [
+            '.env',
+          ],
+        },
       },
       targetTwo: {
         defaultTargetName: 'node',
@@ -168,6 +191,12 @@ describe('services/targets:targets', () => {
           browser: false,
         },
         engine: 'webpack',
+        dotEnv: {
+          enabled: true,
+          files: [
+            '.env',
+          ],
+        },
       },
       targetThree: {
         defaultTargetName: 'node',
@@ -194,6 +223,12 @@ describe('services/targets:targets', () => {
           browser: false,
         },
         engine: 'webpack',
+        dotEnv: {
+          enabled: true,
+          files: [
+            '.env',
+          ],
+        },
       },
       targetFour: {
         defaultTargetName: 'browser',
@@ -210,6 +245,12 @@ describe('services/targets:targets', () => {
           browser: true,
         },
         engine: 'webpack',
+        dotEnv: {
+          enabled: true,
+          files: [
+            '.env.browser',
+          ],
+        },
       },
       targetFive: {
         defaultTargetName: 'node',
@@ -236,6 +277,12 @@ describe('services/targets:targets', () => {
           browser: false,
         },
         engine: 'webpack',
+        dotEnv: {
+          enabled: true,
+          files: [
+            '.env',
+          ],
+        },
       },
     };
     const expectedTargetsNames = Object.keys(expectedTargets);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,6 +2330,11 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.0.0.tgz#ed310c165b4e8a97bb745b0a9d99c31bda566440"
+  integrity sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,6 +2330,11 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv-expand@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
+  integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
+
 dotenv@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.0.0.tgz#ed310c165b4e8a97bb745b0a9d99c31bda566440"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,7 +1908,7 @@ colors@1.0.x:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@1.3.3, colors@^1.1.2:
+colors@^1.1.2, colors@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
   integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
@@ -3009,7 +3009,7 @@ fs-extra@5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@8.1.0, fs-extra@^8.1.0:
+fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -4229,7 +4229,7 @@ jest-worker@^24.6.0:
     merge-stream "^1.0.1"
     supports-color "^6.1.0"
 
-jimple@1.5.0, jimple@^1.5.0:
+jimple@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/jimple/-/jimple-1.5.0.tgz#a964bf4862bb2b488ce3830266a4dd8e8ef1213b"
   integrity sha512-lV8T+LMLvq4qYomJvXtIoL+rwT3tQ2fjq6Bv+vgO0zEtfIw6oXlOmSbHusq5TgR5IKP2avouqWVpGFjbsWlR2Q==
@@ -6243,7 +6243,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-statuses@1.5.0:
+statuses@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
@@ -6673,7 +6673,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urijs@1.19.1:
+urijs@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.1.tgz#5b0ff530c0cbde8386f6342235ba5ca6e995d25a"
   integrity sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==
@@ -6851,17 +6851,17 @@ winston@2.1.x:
     pkginfo "0.3.x"
     stack-trace "0.0.x"
 
-wootils@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/wootils/-/wootils-2.4.1.tgz#37349b2d5b9e832dc4d654714fe6f267827d698d"
-  integrity sha512-uSXKxCX1Ydt6qaQ+1PBEpZZXKNmk5ZCT1G+KUCXH+m2QkyoqDIdAqFyWvGJcck08SK38WD4fEOQYIB0RhAOMTQ==
+wootils@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/wootils/-/wootils-2.5.0.tgz#597813ce496e4afe3a335f182002fd6581cbc674"
+  integrity sha512-lV8U2jXe2V73zpDvOEjqdLbvrym3USGh49oy2flVQAVREmLwotbLlMNX10IgIoICwJfs8+r2REo5uupN4safww==
   dependencies:
-    colors "1.3.3"
+    colors "^1.3.3"
     extend "^3.0.2"
-    fs-extra "8.1.0"
-    jimple "1.5.0"
-    statuses "1.5.0"
-    urijs "1.19.1"
+    fs-extra "^8.1.0"
+    jimple "^1.5.0"
+    statuses "^1.5.0"
+    urijs "^1.19.1"
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
### What does this PR do?

> If you don't know what an `.env` file is, please read about [`dotenv`](https://yarnpkg.com/en/package/dotenv).

It adds support for `.env` files that can be scoped to your targets. The files can load environment variables that projext will send to the Node runner and the browser targets configuration and the "definitions" build engines replace on the bundles.

You can read more about the feature on the updated `projectConfiguration.md`.

#### why is this PR breaking?

First, `BuildNodeRunner` and `BuildTraspiler` now require `Utils`: until now, they were using it from inside the `Targets` injection, with a `@todo` saying that I would eventually change it... well, I did it.

And `Targets` now requires `dotEnvUtils`, which is a new service that takes care of loading and parsing the `.env` files.

### How should it be tested manually?

As for now, this can only be tested on Node targets that don't require bundling nor transpilation; The build engines will later add the rest of the support.

Now, create a file called `.env.[target-name]` and declare some variable, then, on your target code, log that variable.

When you run your target, you should have access to the variable as it was declared on the `.env` file.

And of course...

```bash
yarn test
# or
npm test
```