### PR TITLE
fix(bin/projext): fix the order of the messages to avoid deleting the ones for debug

### DIFF
--- a/src/bin/projext
+++ b/src/bin/projext
@@ -53,13 +53,13 @@ else
   # If the task is a shell task that needs commands...
   if [ "$isSHTask" = true ] && [ "$disableSHTasks" = false ]; then
       # ... let the user know the CLI started working
-      projextCLISuccessLog "CLI started"
+      projextCLIInfoLog "> $*"
       # execute a validation command to avoid any error being thrown on the
       # command that returns the list.
-      projextCLIStartTaskLog "Validating the command"
       if [ "$showSHCommand" = true ]; then
         echo "> projext-cli sh-validate-$*"
       fi
+      projextCLIStartTaskLog "Validating the command"
       eval "projext-cli sh-validate-$*"
       projextCLICompleteTaskLog "Command validated"
       # Capture the commands that need to run


### PR DESCRIPTION
### What does this PR do?

This is a followup for # .

Instead of showing `CLI started` it now shows the actual command recevied by projext. I believe this is better "feedback" than the generic message.

### How should it be tested manually?

Try running/building a target, it will now show you the actual command istead of `CLI started`.