### PR TITLE
feat(project): reload .env files when a Node app is restarted

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -401,7 +401,6 @@ This is different from the main `copy` feature as this is specific to targets an
 >     '.env',
 >   ],
 >   extend: true,
->   overwrite: false,
 > }
 > ```
 
@@ -431,10 +430,6 @@ Take for example the following list of files:
 If `extend` is set to `true` and both files exist, projext will load `.env.[target-name]` as the first file and then merge the values from `.env.[target-name].[build-type]` on top of it.
 
 If `extend` is set to `false`, projext will use the first file it can find.
-
-**`dotEnv.overwrite`**
-
-When projext injects a target variables in the environment, having this setting in `false`, prevents it from overwriting already declared variables.
 
 ### `browser`
 
@@ -756,7 +751,6 @@ This is different from the main `copy` feature as this is specific to targets an
 >     '.env',
 >   ],
 >   extend: true,
->   overwrite: false,
 > }
 > ```
 
@@ -786,10 +780,6 @@ Take for example the following list of files:
 If `extend` is set to `true` and both files exist, projext will load `.env.[target-name]` as the first file and then merge the values from `.env.[target-name].[build-type]` on top of it.
 
 If `extend` is set to `false`, projext will use the first file it can find.
-
-**`dotEnv.overwrite`**
-
-When projext injects a target variables in the environment, having this setting in `false`, prevents it from overwriting already declared variables.
 
 #### `devServer`
 > Default value:

--- a/src/services/building/buildNodeRunner.js
+++ b/src/services/building/buildNodeRunner.js
@@ -108,7 +108,9 @@ class BuildNodeRunner {
       inspectOptions,
       transpilationPaths,
       copyPaths,
-      this.targets.loadTargetDotEnvFile(target, 'development', false)
+      {},
+      ['*.test.js'],
+      () => this.targets.loadTargetDotEnvFile(target, 'development')
     );
   }
   /**
@@ -147,7 +149,9 @@ class BuildNodeRunner {
       inspectOptions,
       [],
       [],
-      this.targets.loadTargetDotEnvFile(target, 'development', false)
+      {},
+      ['*.test.js'],
+      () => this.targets.loadTargetDotEnvFile(target, 'development')
     );
   }
 }

--- a/src/services/common/dotEnvUtils.js
+++ b/src/services/common/dotEnvUtils.js
@@ -113,7 +113,7 @@ class DotEnvUtils {
       {}
     );
 
-    return dotenvExpand({ parsed }).parsed;
+    return dotenvExpand({ parsed, ignoreProcessEnv: true }).parsed;
   }
   /**
    * Loads and parses a single environment file.

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -135,7 +135,6 @@ class ProjectConfiguration extends ConfigurationFile {
               '.env',
             ],
             extend: true,
-            overwrite: false,
           },
         },
         browser: {
@@ -216,7 +215,6 @@ class ProjectConfiguration extends ConfigurationFile {
               '.env',
             ],
             extend: true,
-            overwrite: false,
           },
           devServer: {
             port: 2509,

--- a/src/services/targets/targets.js
+++ b/src/services/targets/targets.js
@@ -428,7 +428,7 @@ class Targets {
         );
 
         if (inject) {
-          this.dotEnvUtils.inject(result, target.dotEnv.overwrite);
+          this.dotEnvUtils.inject(result);
         }
       }
     }

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -229,6 +229,32 @@
  */
 
 /**
+ * @typdef {Object} ProjectConfigurationTargetTemplateDotEnvSettings
+ * @property {boolean} [enabled=true]
+ * Whether or not the feature is enabled.
+ * @property {Array} [files]
+ * The list of files projext will try to find in order to load the variables. Based on the value
+ * of `extend`, the way projext will process them may change.
+ *
+ * The available placeholders are:
+ * - `[target-name]`: The name of the target.
+ * - `[build-type]`: The type of bundle/build projext is creating (`development` or `production`).
+ *
+ * The default value is, for both `node` and `browser` targets:
+ *
+ * ```
+ * [
+ *   '.env.[target-name].[build-type]',
+ *   '.env.[target-name]',
+ *   '.env.[build-type]',
+ *   '.env',
+ * ]
+ * ```
+ * @property {boolean} [extend=true]
+ * Whether or not projext should merge all the variables from all the files it can find.
+ */
+
+/**
  * ================================================================================================
  * Project configuration > Targets templates > Sub properties > Node
  * ================================================================================================
@@ -469,6 +495,9 @@
  * A list of files to copy during the bundling process. It can be a list of file paths relative to
  * the target source directory, in which case they'll be copied to the target distribution
  * directory root; or a list of {@link ProjectConfigurationTargetTemplateCopyItem}.
+ * @property {ProjectConfigurationTargetTemplateDotEnvSettings} [dotEnv]
+ * These options are used by both projext and the build engine in order to load "environment
+ * files".
  */
 
 /**
@@ -552,6 +581,9 @@
  * @property {TargetFolders} folders
  * The target relative paths to both the source directory folder and the distribution directory
  * folder.
+ * @property {ProjectConfigurationTargetTemplateDotEnvSettings} dotEnv
+ * These options are used by both projext and the build engine in order to load "environment
+ * files".
  */
 
 /**
@@ -620,6 +652,9 @@
  * A list of files to copy during the bundling process. It can be a list of file paths relative to
  * the target source directory, in which case they'll be copied to the target distribution
  * directory root; or a list of {@link ProjectConfigurationTargetTemplateCopyItem}.
+ * @property {ProjectConfigurationTargetTemplateDotEnvSettings} [dotEnv]
+ * These options are used by both projext and the build engine in order to load "environment
+ * files".
  * @property {ProjectConfigurationBrowserTargetTemplateDevServerSettings} [devServer]
  * These are the options for the `http` server projext will use when running the target on a
  * development environment.
@@ -690,6 +725,9 @@
  * A list of files to copy during the bundling process. It can be a list of file paths relative to
  * the target source directory, in which case they'll be copied to the target distribution
  * directory root; or a list of {@link ProjectConfigurationTargetTemplateCopyItem}.
+ * @property {ProjectConfigurationTargetTemplateDotEnvSettings} dotEnv
+ * These options are used by both projext and the build engine in order to load "environment
+ * files".
  * @property {ProjectConfigurationBrowserTargetTemplateDevServerSettings} devServer
  * These are the options for the `http` server projext will use when running the target on a
  * development environment.

--- a/tests/services/building/buildNodeRunner.test.js
+++ b/tests/services/building/buildNodeRunner.test.js
@@ -165,6 +165,8 @@ describe('services/building:buildNodeRunner', () => {
         includeTargets: [],
       };
       let sut = null;
+      let setupFn = null;
+      let setupFnResult = null;
       // When
       sut = new BuildNodeRunner(
         buildNodeRunnerProcess,
@@ -173,6 +175,8 @@ describe('services/building:buildNodeRunner', () => {
         utils
       );
       sut.runTarget(target);
+      [[,,,,,,, setupFn]] = buildNodeRunnerProcess.run.mock.calls;
+      setupFnResult = setupFn();
       // Then
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledTimes(1);
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledWith(
@@ -181,13 +185,15 @@ describe('services/building:buildNodeRunner', () => {
         target.inspect,
         [],
         [],
-        environmentVariables
+        {},
+        ['*.test.js'],
+        expect.any(Function)
       );
+      expect(setupFnResult).toEqual(environmentVariables);
       expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
       expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
         target,
-        'development',
-        false
+        'development'
       );
     });
 
@@ -203,13 +209,7 @@ describe('services/building:buildNodeRunner', () => {
           },
         },
       };
-      const environmentVariables = {
-        ROSARIO: 'Charito!',
-        PILAR: 'Pili!',
-      };
-      const targets = {
-        loadTargetDotEnvFile: jest.fn(() => environmentVariables),
-      };
+      const targets = 'targets';
       const utils = 'utils';
       const target = {
         bundle: false,
@@ -244,13 +244,9 @@ describe('services/building:buildNodeRunner', () => {
         Object.assign({}, target.inspect, { enabled: true }),
         [],
         [],
-        environmentVariables
-      );
-      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
-      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
-        target,
-        'development',
-        false
+        {},
+        ['*.test.js'],
+        expect.any(Function)
       );
     });
 
@@ -272,13 +268,8 @@ describe('services/building:buildNodeRunner', () => {
           source: 'included-target-source-path',
         },
       };
-      const environmentVariables = {
-        ROSARIO: 'Charito!',
-        PILAR: 'Pili!',
-      };
       const targets = {
         getTarget: jest.fn(() => includedTarget),
-        loadTargetDotEnvFile: jest.fn(() => environmentVariables),
       };
       const utils = 'utils';
       const target = {
@@ -317,13 +308,9 @@ describe('services/building:buildNodeRunner', () => {
         target.inspect,
         [],
         [],
-        environmentVariables
-      );
-      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
-      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
-        target,
-        'development',
-        false
+        {},
+        ['*.test.js'],
+        expect.any(Function)
       );
     });
 
@@ -463,6 +450,8 @@ describe('services/building:buildNodeRunner', () => {
         includeTargets: [],
       };
       let sut = null;
+      let setupFn = null;
+      let setupFnResult = null;
       // When
       sut = new BuildNodeRunner(
         buildNodeRunnerProcess,
@@ -471,6 +460,8 @@ describe('services/building:buildNodeRunner', () => {
         utils
       );
       sut.runTarget(target);
+      [[,,,,,,, setupFn]] = buildNodeRunnerProcess.run.mock.calls;
+      setupFnResult = setupFn();
       // Then
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledTimes(1);
       expect(buildNodeRunnerProcess.run).toHaveBeenCalledWith(
@@ -482,13 +473,15 @@ describe('services/building:buildNodeRunner', () => {
           to: target.paths.build,
         }],
         [],
-        environmentVariables
+        {},
+        ['*.test.js'],
+        expect.any(Function)
       );
+      expect(setupFnResult).toEqual(environmentVariables);
       expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
       expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
         target,
-        'development',
-        false
+        'development'
       );
       expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
       expect(utils.ensureExtension).toHaveBeenCalledWith(
@@ -516,13 +509,8 @@ describe('services/building:buildNodeRunner', () => {
           build: 'included-target-build-path',
         },
       };
-      const environmentVariables = {
-        ROSARIO: 'Charito!',
-        PILAR: 'Pili!',
-      };
       const targets = {
         getTarget: jest.fn(() => includedTarget),
-        loadTargetDotEnvFile: jest.fn(() => environmentVariables),
       };
       const utils = {
         ensureExtension: jest.fn((filepath) => filepath),
@@ -573,13 +561,9 @@ describe('services/building:buildNodeRunner', () => {
           },
         ],
         [],
-        environmentVariables
-      );
-      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
-      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
-        target,
-        'development',
-        false
+        {},
+        ['*.test.js'],
+        expect.any(Function)
       );
       expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
       expect(utils.ensureExtension).toHaveBeenCalledWith(
@@ -607,13 +591,8 @@ describe('services/building:buildNodeRunner', () => {
           build: 'included-target-build-path',
         },
       };
-      const environmentVariables = {
-        ROSARIO: 'Charito!',
-        PILAR: 'Pili!',
-      };
       const targets = {
         getTarget: jest.fn(() => includedTarget),
-        loadTargetDotEnvFile: jest.fn(() => environmentVariables),
       };
       const utils = {
         ensureExtension: jest.fn((filepath) => filepath),
@@ -661,13 +640,9 @@ describe('services/building:buildNodeRunner', () => {
           from: includedTarget.paths.source,
           to: includedTarget.paths.build,
         }],
-        environmentVariables
-      );
-      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
-      expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(
-        target,
-        'development',
-        false
+        {},
+        ['*.test.js'],
+        expect.any(Function)
       );
       expect(utils.ensureExtension).toHaveBeenCalledTimes(1);
       expect(utils.ensureExtension).toHaveBeenCalledWith(

--- a/tests/services/common/dotEnvUtils.test.js
+++ b/tests/services/common/dotEnvUtils.test.js
@@ -180,6 +180,7 @@ describe('services/common:dotEnvUtils', () => {
       expect(dotenvExpand).toHaveBeenCalledTimes(1);
       expect(dotenvExpand).toHaveBeenCalledWith({
         parsed: fileContents,
+        ignoreProcessEnv: true,
       });
       expect(appLogger.success).toHaveBeenCalledTimes(1);
       expect(appLogger.success).toHaveBeenCalledWith(
@@ -247,6 +248,7 @@ describe('services/common:dotEnvUtils', () => {
       expect(dotenvExpand).toHaveBeenCalledTimes(1);
       expect(dotenvExpand).toHaveBeenCalledWith({
         parsed: expectedMerge,
+        ignoreProcessEnv: true,
       });
     });
 
@@ -298,6 +300,7 @@ describe('services/common:dotEnvUtils', () => {
       expect(dotenvExpand).toHaveBeenCalledTimes(1);
       expect(dotenvExpand).toHaveBeenCalledWith({
         parsed: firstFileContents,
+        ignoreProcessEnv: true,
       });
     });
   });

--- a/tests/services/targets/targets.test.js
+++ b/tests/services/targets/targets.test.js
@@ -2156,7 +2156,6 @@ describe('services/targets:targets', () => {
       dotEnv: {
         enabled: true,
         extend: true,
-        overwrite: true,
         files: [dotEnvFile],
       },
     };
@@ -2188,7 +2187,7 @@ describe('services/targets:targets', () => {
       buildType
     );
     expect(dotEnvUtils.inject).toHaveBeenCalledTimes(1);
-    expect(dotEnvUtils.inject).toHaveBeenCalledWith(loadedVariables, target.dotEnv.overwrite);
+    expect(dotEnvUtils.inject).toHaveBeenCalledWith(loadedVariables);
   });
 
   it('should reduce but not inject environment variables for a target', () => {
@@ -2229,7 +2228,6 @@ describe('services/targets:targets', () => {
       dotEnv: {
         enabled: true,
         extend: true,
-        overwrite: true,
         files: [dotEnvFile],
       },
     };


### PR DESCRIPTION
### What does this PR do?

This is a followup for #80  .

After some debugging, I noticed a big issue with the feature: If you were to restart a Node target, the `.env` file wasn't being reloaded.

First, I updated `BuildNodeRunnerProcess#run` and added a new parameter: `setupFn`. A function that would be called every time the Nodemon process were started.

> I had to "hack" Nodemon a little bit because there wasn't a way to add this function before the start using its "public API". You can read more about it on the description for `_injectSetupFnOnNodemon(fn)`.

Then, on the `BuildNodeRunner`, instead of sending the variables from the `.env` file(s) as env vars, I use `setupFn` to send a function that calls `Targets.loadTargetDotEnvFile` for the target, ensuring the variables will be reload when Nodemon starts.

Another thing I had to do is to remove the targets `dotEnv.overwrite` setting. The idea of the setting was to prevent projext from overwriting an already declared variable, but... if the `.env` file was loaded for a second time, it wouldn't update the variables... so, yes, now the variables are always overwritten if they already exist.

> You can argue that I could keep track of the variables... but that was too much of an overkill FOR NOW.

### How should it be tested manually?

As for now, this can only be tested on Node targets that don't require bundling nor transpilation; The build engines will later add the rest of the support.

First, create a file called `.env.[target-name]` and declare some variable, then, on your target code, log that variable.

When you run your target, you should have access to the variable as it was declared on the `.env` file.

Now, update the variable value on the `.env` file and restart the target (using `rs`), the logged value should be updated.

And of course...

```bash
yarn test
# or
npm test
```