### PR TITLE
feat(services/targets/targets): delete the require.cache entry for browser configurations

### DIFF
--- a/src/bin/projext
+++ b/src/bin/projext
@@ -61,7 +61,7 @@ else
       fi
       projextCLIStartTaskLog "Validating the command"
       eval "projext-cli sh-validate-$*"
-      projextCLICompleteTaskLog "Command validated"
+      projextCLISuccessLog "Command validated"
       # Capture the commands that need to run
       if [ "$showSHCommand" = true ]; then
         echo "> projext-cli sh-$*"

--- a/src/services/targets/targets.js
+++ b/src/services/targets/targets.js
@@ -351,12 +351,14 @@ class Targets {
       /**
        * The idea of `files` and this small wrapper around `rootRequire` is for the method to be
        * able to identify all the external files that were involved on the configuration creation.
-       * Then the method can return the list so the build engine can also watch for those files
+       * Then the method can return the list, so the build engine can also watch for those files
        * and reload the target not only when the source changes, but when the config changes too.
        */
       const files = [];
       const rootRequireAndSave = (filepath) => {
         files.push(filepath);
+        // Delete the file cache entry so it can be rebuilt in case env vars were updated.
+        delete require.cache[filepath];
         return this.rootRequire(filepath);
       };
 

--- a/src/services/targets/targets.js
+++ b/src/services/targets/targets.js
@@ -358,7 +358,7 @@ class Targets {
       const rootRequireAndSave = (filepath) => {
         files.push(filepath);
         // Delete the file cache entry so it can be rebuilt in case env vars were updated.
-        delete require.cache[filepath];
+        delete require.cache[this.pathUtils.join(filepath)];
         return this.rootRequire(filepath);
       };
 

--- a/tests/services/targets/targets.test.js
+++ b/tests/services/targets/targets.test.js
@@ -1800,7 +1800,9 @@ describe('services/targets:targets', () => {
     const events = 'events';
     const environmentUtils = 'environmentUtils';
     const packageInfo = 'packageInfo';
-    const pathUtils = 'pathUtils';
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
     const projectConfiguration = {
       targets: {},
       targetsTemplates: {},
@@ -1851,6 +1853,8 @@ describe('services/targets:targets', () => {
       configuration: defaultConfig,
       files: [expectedConfigFile],
     });
+    expect(pathUtils.join).toHaveBeenCalledTimes(1);
+    expect(pathUtils.join).toHaveBeenCalledWith(expectedConfigFile);
     expect(rootRequire).toHaveBeenCalledTimes(1);
     expect(rootRequire).toHaveBeenCalledWith(expectedConfigFile);
     expect(WootilsAppConfigurationMock.mocks.constructor).toHaveBeenCalledTimes(1);
@@ -1874,7 +1878,9 @@ describe('services/targets:targets', () => {
     const events = 'events';
     const environmentUtils = 'environmentUtils';
     const packageInfo = 'packageInfo';
-    const pathUtils = 'pathUtils';
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
     const projectConfiguration = {
       targets: {},
       targetsTemplates: {},
@@ -1926,6 +1932,8 @@ describe('services/targets:targets', () => {
       configuration: defaultConfig,
       files: [expectedConfigFile],
     });
+    expect(pathUtils.join).toHaveBeenCalledTimes(1);
+    expect(pathUtils.join).toHaveBeenCalledWith(expectedConfigFile);
     expect(rootRequire).toHaveBeenCalledTimes(1);
     expect(rootRequire).toHaveBeenCalledWith(expectedConfigFile);
     expect(WootilsAppConfigurationMock.mocks.constructor).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### What does this PR do?

This is a followup for #80.

If a "browser target configuration file" uses a variable from an `.env` file, even if the configuration is reloaded, the variable(s) won't be updated, because the configuration file is cached by Node. This PR just removes the configuration file from the Node cache before requiring it.

Also, there was a small problem with the logs on the binary: When I added the new log messages, I forgot that the "validate command" could emit "validation messages", like when a browser target doesn't have an HTML file. The problem was that the "success message" after the "validate command" was overwriting any emitted message.

The fix was to make the "success message" a regular log (without overwrite).

### How should it be tested manually?

The change for the Node cache can't be tested without the build engines, but the fix for binary is easy:

Try running/building a browser target without and HTML file, you should see the warning from projext on the console.

And of course...

```bash
yarn test
# or
npm test
```