### PR TITLE
fix(services/targets/targetsHTML): add support for targets with names with scopes

### DIFF
--- a/src/abstracts/cliCommand.js
+++ b/src/abstracts/cliCommand.js
@@ -268,7 +268,7 @@ class CLICommand {
    * @abstract
    */
   handle() {
-    throw new Error('This method must to be overwritten');
+    throw new Error('This method must be overwritten');
   }
   /**
    * A simple wrapper for a `console.log`. Outputs a variable to the CLI interface.

--- a/src/services/common/dotEnvUtils.js
+++ b/src/services/common/dotEnvUtils.js
@@ -128,7 +128,6 @@ class DotEnvUtils {
     try {
       const contents = fs.readFileSync(fileInfo.path);
       result = dotenv.parse(contents);
-      this._appLogger.success(`Environment file successfully loaded: ${fileInfo.name}`);
     } catch (error) {
       this._appLogger.error(`Error: The environment file couldn't be read: ${fileInfo.name}`);
       throw error;

--- a/src/services/targets/targetsHTML.js
+++ b/src/services/targets/targetsHTML.js
@@ -47,13 +47,16 @@ class TargetsHTML {
    * Given a target, this method will validate if the target has an HTML template file and return
    * its absolute path; if the file doesn't exists, it will generate a new one, save it on the
    * temp directory and return its path.
-   * @param {Target}  target        The target information.
-   * @param {boolean} [force=false] Optional. If this is `true`, the file will be created anyways.
+   * @param {Target}  target                   The target information.
+   * @param {boolean} [force=false]            Optional. If this is `true`, the file will be
+   *                                           created anyways.
+   * @param {string}  [buildType='production'] Optional. If the HTML is for an specific type of
+   *                                           build. This may be useful for plugins.
    * @return {string}
    */
-  getFilepath(target, force = false) {
+  getFilepath(target, force = false, buildType = 'production') {
     const validation = this.validate(target);
-    return validation.exists && !force ? validation.path : this._generateHTML(target);
+    return validation.exists && !force ? validation.path : this._generateHTML(target, buildType);
   }
   /**
    * This method generates a default HTML file template for a target, saves it on the temp
@@ -63,13 +66,14 @@ class TargetsHTML {
    *  information and it expects another {@link TargetDefaultHTMLSettings} in return.
    * - `target-default-html`: It receives the HTML code for the file, the target information and
    *  it expects a new HTML code in return.
-   * @param {Target} target The target information.
+   * @param {Target} target    The target information.
+   * @param {string} buildType The type of build for which the HTML is for.
    * @return {string}
    * @throws {Error} If the file couldn't be saved on the temp directory.
    * @ignore
    * @access protected
    */
-  _generateHTML(target) {
+  _generateHTML(target, buildType) {
     // Reduce the settings for the template.
     const info = this.events.reduce(
       'target-default-html-settings',
@@ -78,7 +82,8 @@ class TargetsHTML {
         bodyAttributes: '',
         bodyContents: '<div id="app"></div>',
       },
-      target
+      target,
+      buildType
     );
     // Normalize the body attributes to avoid unnecessary spaces on the tag.
     const bodyAttrs = info.bodyAttributes ? ` ${info.bodyAttributes}` : '';

--- a/src/services/targets/targetsHTML.js
+++ b/src/services/targets/targetsHTML.js
@@ -99,8 +99,10 @@ class TargetsHTML {
     ].join('\n');
     // Reduce the HTML code.
     const html = this.events.reduce('target-default-html', htmlTpl, target);
+    // Normalize the target name to avoid issues with packages with scope.
+    const filename = target.name.replace(/\//g, '-');
     // Write the file on the temp directory.
-    return this.tempFiles.writeSync(`${target.name}.index.html`, html);
+    return this.tempFiles.writeSync(`${filename}.index.html`, html);
   }
 }
 /**

--- a/tests/abstracts/cliCommand.test.js
+++ b/tests/abstracts/cliCommand.test.js
@@ -572,7 +572,7 @@ describe('abstracts:CLICommand', () => {
     let sut = null;
     // When/Then
     sut = new Sut();
-    expect(() => sut.handle()).toThrow(/This method must to be overwritten/i);
+    expect(() => sut.handle()).toThrow(/This method must be overwritten/i);
   });
 
   it('should handle a command an send all the options to the `handle` method', () => {

--- a/tests/services/common/dotEnvUtils.test.js
+++ b/tests/services/common/dotEnvUtils.test.js
@@ -115,7 +115,6 @@ describe('services/common:dotEnvUtils', () => {
       });
       const environmentUtils = 'environmentUtils';
       const appLogger = {
-        success: jest.fn(),
         error: jest.fn(),
       };
       const pathUtils = {
@@ -138,7 +137,6 @@ describe('services/common:dotEnvUtils', () => {
       expect(fs.readFileSync).toHaveBeenCalledWith(file);
       expect(dotenv.parse).toHaveBeenCalledTimes(0);
       expect(dotenvExpand).toHaveBeenCalledTimes(0);
-      expect(appLogger.success).toHaveBeenCalledTimes(0);
     });
 
     it('should load the variables from an .env file', () => {
@@ -152,9 +150,7 @@ describe('services/common:dotEnvUtils', () => {
       dotenv.parse.mockImplementationOnce((variables) => variables);
       dotenvExpand.mockImplementationOnce((config) => config);
       const environmentUtils = 'environmentUtils';
-      const appLogger = {
-        success: jest.fn(),
-      };
+      const appLogger = 'appLogger';
       const pathUtils = {
         join: jest.fn((filepath) => filepath),
       };
@@ -182,10 +178,6 @@ describe('services/common:dotEnvUtils', () => {
         parsed: fileContents,
         ignoreProcessEnv: true,
       });
-      expect(appLogger.success).toHaveBeenCalledTimes(1);
-      expect(appLogger.success).toHaveBeenCalledWith(
-        `Environment file successfully loaded: ${file}`
-      );
     });
 
     it('should load and merge the variables from multiple .env files', () => {
@@ -208,9 +200,7 @@ describe('services/common:dotEnvUtils', () => {
       dotenv.parse.mockImplementationOnce((variables) => variables);
       dotenvExpand.mockImplementationOnce((config) => config);
       const environmentUtils = 'environmentUtils';
-      const appLogger = {
-        success: jest.fn(),
-      };
+      const appLogger = 'appLogger';
       const pathUtils = {
         join: jest.fn((filepath) => filepath),
       };
@@ -238,13 +228,6 @@ describe('services/common:dotEnvUtils', () => {
       expect(dotenv.parse).toHaveBeenCalledTimes(files.length);
       expect(dotenv.parse).toHaveBeenCalledWith(firstFileContents);
       expect(dotenv.parse).toHaveBeenCalledWith(secondFileContents);
-      expect(appLogger.success).toHaveBeenCalledTimes(files.length);
-      expect(appLogger.success).toHaveBeenCalledWith(
-        `Environment file successfully loaded: ${firstFile}`
-      );
-      expect(appLogger.success).toHaveBeenCalledWith(
-        `Environment file successfully loaded: ${secondFile}`
-      );
       expect(dotenvExpand).toHaveBeenCalledTimes(1);
       expect(dotenvExpand).toHaveBeenCalledWith({
         parsed: expectedMerge,
@@ -266,9 +249,7 @@ describe('services/common:dotEnvUtils', () => {
       dotenv.parse.mockImplementationOnce((variables) => variables);
       dotenvExpand.mockImplementationOnce((config) => config);
       const environmentUtils = 'environmentUtils';
-      const appLogger = {
-        success: jest.fn(),
-      };
+      const appLogger = 'appLogger';
       const pathUtils = {
         join: jest.fn((filepath) => filepath),
       };
@@ -293,10 +274,6 @@ describe('services/common:dotEnvUtils', () => {
       expect(fs.readFileSync).toHaveBeenCalledWith(firstFile);
       expect(dotenv.parse).toHaveBeenCalledTimes(1);
       expect(dotenv.parse).toHaveBeenCalledWith(firstFileContents);
-      expect(appLogger.success).toHaveBeenCalledTimes(1);
-      expect(appLogger.success).toHaveBeenCalledWith(
-        `Environment file successfully loaded: ${firstFile}`
-      );
       expect(dotenvExpand).toHaveBeenCalledTimes(1);
       expect(dotenvExpand).toHaveBeenCalledWith({
         parsed: firstFileContents,

--- a/tests/services/targets/targetsHTML.test.js
+++ b/tests/services/targets/targetsHTML.test.js
@@ -100,6 +100,7 @@ describe('services/targets:targetsHTML', () => {
           bodyContents: '<div id="app"></div>',
         },
         target,
+        'production',
       ],
       'target-default-html': [
         expectedHTML,
@@ -113,7 +114,78 @@ describe('services/targets:targetsHTML', () => {
     // Then
     expect(result).toBe(expectedFilepath);
     expect(fs.pathExistsSync).toHaveBeenCalledTimes(1);
-    expect(fs.pathExistsSync).toHaveBeenCalledWith(`${target.paths.source}/${target.html.template}`);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(
+      `${target.paths.source}/${target.html.template}`
+    );
+    expect(events.reduce).toHaveBeenCalledTimes(expectedEventNames.length);
+    expectedEventNames.forEach((eventName) => {
+      expect(events.reduce).toHaveBeenCalledWith(eventName, ...expectedEvents[eventName]);
+    });
+    expect(tempFiles.writeSync).toHaveBeenCalledTimes(1);
+    expect(tempFiles.writeSync).toHaveBeenCalledWith(expectedFilepath, expectedHTML);
+  });
+
+  it('should generate a default HTML file for the target for a development build type', () => {
+    // Given
+    fs.pathExistsSync.mockReturnValueOnce(false);
+    const events = {
+      reduce: jest.fn((eventName, variableToReduce) => variableToReduce),
+    };
+    const tempFiles = {
+      writeSync: jest.fn((filepath) => filepath),
+    };
+    const target = {
+      name: 'charito',
+      paths: {
+        source: 'src',
+      },
+      html: {
+        template: 'index.html',
+      },
+    };
+    const buildType = 'development';
+    let sut = null;
+    let result = null;
+    const expectedFilepath = `${target.name}.index.html`;
+    const expectedHTML = [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      ' <meta charset="utf-8" />',
+      ' <meta http-equiv="x-ua-compatible" content="ie=edge" />',
+      ' <meta name="viewport" content="width=device-width, initial-scale=1" />',
+      ` <title>${target.name}</title>`,
+      '</head>',
+      '<body>',
+      ' <div id="app"></div>',
+      '</body>',
+      '</html>',
+    ].join('\n');
+    const expectedEvents = {
+      'target-default-html-settings': [
+        {
+          title: target.name,
+          bodyAttributes: '',
+          bodyContents: '<div id="app"></div>',
+        },
+        target,
+        buildType,
+      ],
+      'target-default-html': [
+        expectedHTML,
+        target,
+      ],
+    };
+    const expectedEventNames = Object.keys(expectedEvents);
+    // When
+    sut = new TargetsHTML(events, tempFiles);
+    result = sut.getFilepath(target, false, buildType);
+    // Then
+    expect(result).toBe(expectedFilepath);
+    expect(fs.pathExistsSync).toHaveBeenCalledTimes(1);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(
+      `${target.paths.source}/${target.html.template}`
+    );
     expect(events.reduce).toHaveBeenCalledTimes(expectedEventNames.length);
     expectedEventNames.forEach((eventName) => {
       expect(events.reduce).toHaveBeenCalledWith(eventName, ...expectedEvents[eventName]);
@@ -168,6 +240,7 @@ describe('services/targets:targetsHTML', () => {
           bodyContents: '<div id="app"></div>',
         },
         target,
+        'production',
       ],
       'target-default-html': [
         expectedHTML,
@@ -181,7 +254,9 @@ describe('services/targets:targetsHTML', () => {
     // Then
     expect(result).toBe(expectedFilepath);
     expect(fs.pathExistsSync).toHaveBeenCalledTimes(1);
-    expect(fs.pathExistsSync).toHaveBeenCalledWith(`${target.paths.source}/${target.html.template}`);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(
+      `${target.paths.source}/${target.html.template}`
+    );
     expect(events.reduce).toHaveBeenCalledTimes(expectedEventNames.length);
     expectedEventNames.forEach((eventName) => {
       expect(events.reduce).toHaveBeenCalledWith(eventName, ...expectedEvents[eventName]);
@@ -233,6 +308,7 @@ describe('services/targets:targetsHTML', () => {
           bodyContents: '<div id="app"></div>',
         },
         target,
+        'production',
       ],
       'target-default-html': [
         expectedHTML,
@@ -246,7 +322,9 @@ describe('services/targets:targetsHTML', () => {
     // Then
     expect(result).toBe(expectedFilepath);
     expect(fs.pathExistsSync).toHaveBeenCalledTimes(1);
-    expect(fs.pathExistsSync).toHaveBeenCalledWith(`${target.paths.source}/${target.html.template}`);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(
+      `${target.paths.source}/${target.html.template}`
+    );
     expect(events.reduce).toHaveBeenCalledTimes(expectedEventNames.length);
     expectedEventNames.forEach((eventName) => {
       expect(events.reduce).toHaveBeenCalledWith(eventName, ...expectedEvents[eventName]);
@@ -308,6 +386,7 @@ describe('services/targets:targetsHTML', () => {
           bodyContents: '<div id="app"></div>',
         },
         target,
+        'production',
       ],
       'target-default-html': [
         expectedHTML,
@@ -321,7 +400,9 @@ describe('services/targets:targetsHTML', () => {
     // Then
     expect(result).toBe(expectedFilepath);
     expect(fs.pathExistsSync).toHaveBeenCalledTimes(1);
-    expect(fs.pathExistsSync).toHaveBeenCalledWith(`${target.paths.source}/${target.html.template}`);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(
+      `${target.paths.source}/${target.html.template}`
+    );
     expect(events.reduce).toHaveBeenCalledTimes(expectedEventNames.length);
     expectedEventNames.forEach((eventName) => {
       expect(events.reduce).toHaveBeenCalledWith(eventName, ...expectedEvents[eventName]);

--- a/tests/services/targets/targetsHTML.test.js
+++ b/tests/services/targets/targetsHTML.test.js
@@ -122,6 +122,74 @@ describe('services/targets:targetsHTML', () => {
     expect(tempFiles.writeSync).toHaveBeenCalledWith(expectedFilepath, expectedHTML);
   });
 
+  it('should generate a default HTML file for the target with a name with a scope', () => {
+    // Given
+    fs.pathExistsSync.mockReturnValueOnce(false);
+    const events = {
+      reduce: jest.fn((eventName, variableToReduce) => variableToReduce),
+    };
+    const tempFiles = {
+      writeSync: jest.fn((filepath) => filepath),
+    };
+    const targetNameScope = '@homer0';
+    const targetNamePackage = 'charito';
+    const target = {
+      name: `${targetNameScope}/${targetNamePackage}`,
+      paths: {
+        source: 'src',
+      },
+      html: {
+        template: 'index.html',
+      },
+    };
+    let sut = null;
+    let result = null;
+    const expectedTargetFileName = `${targetNameScope}-${targetNamePackage}`;
+    const expectedFilepath = `${expectedTargetFileName}.index.html`;
+    const expectedHTML = [
+      '<!doctype html>',
+      '<html lang="en">',
+      '<head>',
+      ' <meta charset="utf-8" />',
+      ' <meta http-equiv="x-ua-compatible" content="ie=edge" />',
+      ' <meta name="viewport" content="width=device-width, initial-scale=1" />',
+      ` <title>${target.name}</title>`,
+      '</head>',
+      '<body>',
+      ' <div id="app"></div>',
+      '</body>',
+      '</html>',
+    ].join('\n');
+    const expectedEvents = {
+      'target-default-html-settings': [
+        {
+          title: target.name,
+          bodyAttributes: '',
+          bodyContents: '<div id="app"></div>',
+        },
+        target,
+      ],
+      'target-default-html': [
+        expectedHTML,
+        target,
+      ],
+    };
+    const expectedEventNames = Object.keys(expectedEvents);
+    // When
+    sut = new TargetsHTML(events, tempFiles);
+    result = sut.getFilepath(target);
+    // Then
+    expect(result).toBe(expectedFilepath);
+    expect(fs.pathExistsSync).toHaveBeenCalledTimes(1);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(`${target.paths.source}/${target.html.template}`);
+    expect(events.reduce).toHaveBeenCalledTimes(expectedEventNames.length);
+    expectedEventNames.forEach((eventName) => {
+      expect(events.reduce).toHaveBeenCalledWith(eventName, ...expectedEvents[eventName]);
+    });
+    expect(tempFiles.writeSync).toHaveBeenCalledTimes(1);
+    expect(tempFiles.writeSync).toHaveBeenCalledWith(expectedFilepath, expectedHTML);
+  });
+
   it('should generate a default HTML file for the target even if the target has a one', () => {
     // Given
     fs.pathExistsSync.mockReturnValueOnce(true);


### PR DESCRIPTION
### What does this PR do?

While the main objective of this PR was to fix the issue on the title, I took also did a few other small changes:

**fix(services/targets/targetsHTML): add support for targets with names with scopes**

When trying to generate the HTML for a target with a name like `@scope/name`, the `targetsHTML` service was failing because of the backslash, so the fix was to replace them with a simple dash.

**refactor(services/common/dotEnvUtils): remove the message for when a file is loaded**

Every service that wants to access a target env file was causing projext to output that the file was loaded, so at the end of the day, the message stop being useful and started looking like spam.

**feat(services/targets/targetsHTML): allow the method that generates the HTML to receive a build type**

While working on other plugins, I realized that when projext generates the default HTML during build time, the `targetsHTML` service is not aware of the type of build it's being generated, and having that information could be useful, so I just added it with a default value of `production`.

### How should it be tested manually?

1. Create a new with a name with scope; it should work fine.
2. Build a target with an env file; you shouldn't see the "the file was successfully loaded" message.
3. You would need to build a plugin to test this out, so just run the tests :P.

```bash
yarn test
# or
npm test
```
