### PR TITLE
v7.1.1: fix(services/configuration/project): add 'excludeModules' to the browser target template

### DIFF
--- a/documents/projectConfiguration.md
+++ b/documents/projectConfiguration.md
@@ -446,6 +446,7 @@ If `extend` is set to `false`, projext will use the first file it can find.
   html: { ... },
   css: { ... },
   includeModules: [],
+  excludeModules: [],
   includeTargets: [],
   uglifyOnProduction: true,
   runOnDevelopment: false,
@@ -598,6 +599,11 @@ This setting can be used to specify a list of node modules you want to process o
 For example, let's say you are using a library that exports a native `Class` that you are `extend`ing, but you are transpiling for a browser that doesn't support native `Class`es; you can add the name of the module on this setting and projext will include it on its bundling process and transpile it if needed.
 
 > At the end of the process, those names are converted to regular expressions, so you can also make the name a expression, while escaping especial characters of course.
+
+#### `excludeModules`
+> Default value: `[]`
+
+This setting can be used to specify a list of modules that should never be bundled.
 
 #### `includeTargets`
 > Default value: `[]`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "projext",
     "description": "Bundle and run your javascript project without configuring an specific module bundler.",
     "homepage": "https://homer0.github.io/projext/",
-    "version": "7.1.0",
+    "version": "7.1.1",
     "repository": "homer0/projext",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",

--- a/src/services/configurations/projectConfiguration.js
+++ b/src/services/configurations/projectConfiguration.js
@@ -177,6 +177,7 @@ class ProjectConfiguration extends ConfigurationFile {
             inject: false,
           },
           includeModules: [],
+          excludeModules: [],
           includeTargets: [],
           uglifyOnProduction: true,
           runOnDevelopment: false,


### PR DESCRIPTION
### What does this PR do?

While both type of targets can make use of `excludeModules`, it was only being set by default on the Node target template.

In this PR I added its default value and also included it on the documentation.

### How should it be tested manually?

1. Create a browser target.
2. Create a `projext.plugin.js` and listen for `target-load`, the target should have `excludeModules` set as an empty array:

```js
module.exports = (app) => {
  app.get('events').on('target-load', (target) => {
    console.log(target.excludeModules); // it should log `[]`
    return target;
  });
};
```
