### PR TITLE
v8.0.3: fix: avoid using flags as fallbacks for missing CLI args

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "projext",
   "description": "Bundle and run your javascript project without configuring an specific module bundler.",
   "homepage": "https://projextjs.com",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "repository": "homer0/projext",
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",


### PR DESCRIPTION
### What does this PR do?

Follow up for #103 and #104- There's a new surprise on Commander's new version: If a command has a required parameter (`hello [message]`), support unknown options and it gets invoked without the parameter but with unknown options, instead of sending `message` as `undefined`, it will take the options to fill the missing parameters:

```bash
hello --something else
```

Will end up as:

- `message`: `--something`.
- unknown options: `['else']`.

Now, how does it affects projext? If you call `projext run` without any target name, projext would find the default target name and use it; but if `run` gets called from `projext-plugin-runner`, the instruction becomes `projext run --plugin projext-plugin-runner`... yes, projext will try to find the target `--plugin`.

The fix is to check arguments list to make sure there are no flags before a real parameter or the command object. This fix only works on commands with a single parameter, which are all the commands with parameters on projext, but not to worry, I'll probably replace Commander soon, it's slow and it's giving too many issues after the latest release.

### How should it be tested manually?

Try to use `projext-plugin-runner` without specifying the target and you'll see what happens :P.